### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ no-entrypoint = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.8.1"
-solana-program = "=1.7.4"
+solana-program = "~1.7.5"
 thiserror = "1.0"
 num-derive = "0.3"
 num-traits = "0.2"
@@ -20,8 +20,8 @@ uint = "0.9"
 bytemuck = "1.7"
 
 [dev-dependencies]
-solana-program-test = "=1.7.4"
-solana-sdk = "=1.7.4"
+solana-program-test = "~1.7.5"
+solana-sdk = "~1.7.5"
 serde = "1"
 bincode = "1.3"
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -14,12 +14,12 @@ no-entrypoint = []
 [dependencies]
 borsh = "0.9.1"
 borsh-derive = "0.9.1"
-solana-program = "=1.7.4"
-chainlink = { git = "https://github.com/smartcontractkit/chainlink-solana", package = "chainlink-solana" }
+solana-program = "~1.7.5"
+chainlink = { git = "https://github.com/smartcontractkit/chainlink-solana", package = "chainlink-solana", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "=1.7.4"
-solana-sdk = "=1.7.4"
+solana-program-test = "~1.7.5"
+solana-sdk = "~1.7.5"
 
 [lib]
 name = "helloworld"


### PR DESCRIPTION
- Update the Solana packages to "~1.7.5": crypto-mac 0.7.0 is deprecated and unavailable for builds: https://docs.rs/crate/crypto-mac/0.7.0  The solana-sdk 1.7.5 updates a chain of dependencies to point to crypto-mac 0.8.0, which allows builds to proceed.
- Add `features = ["no-entrypoint"]`, which resolves the following build error: ~/.cargo/registry/src/github.com-1ecc6299db9ec823/solana-program-1.7.10/src/entrypoint.rs:46: multiple definition of `entrypoint'; ~/chainlink-solana/example/target/debug/deps/helloworld.1lm1j40j0atahysb.rcgu.o