### PR TITLE
Drop requirement for exact version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ no-entrypoint = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.8.1"
-solana-program = "=1.7.4"
+solana-program = "~1.7.4"
 thiserror = "1.0"
 num-derive = "0.3"
 num-traits = "0.2"
@@ -20,8 +20,8 @@ uint = "0.9"
 bytemuck = "1.7"
 
 [dev-dependencies]
-solana-program-test = "=1.7.4"
-solana-sdk = "=1.7.4"
+solana-program-test = "~1.7.4"
+solana-sdk = "~1.7.4"
 serde = "1"
 bincode = "1.3"
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -14,12 +14,12 @@ no-entrypoint = []
 [dependencies]
 borsh = "0.9.1"
 borsh-derive = "0.9.1"
-solana-program = "=1.7.4"
+solana-program = "~1.7.4"
 chainlink = { git = "https://github.com/smartcontractkit/chainlink-solana", package = "chainlink-solana" }
 
 [dev-dependencies]
-solana-program-test = "=1.7.4"
-solana-sdk = "=1.7.4"
+solana-program-test = "~1.7.4"
+solana-sdk = "~1.7.4"
 
 [lib]
 name = "helloworld"


### PR DESCRIPTION
This was conflicting with other rust package requirements and doesn't appear to need to be this restrictive.