### PR TITLE
Gauntlet inspection commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ pkg/bin
 v1/target
 contracts/target
 contracts/programs/*/target
-v1/target
 contracts/.anchor
 # keypair used by anchor/anchor test
 contracts/id.json

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/index.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/index.ts
@@ -13,6 +13,7 @@ import SetupFlow from './setup.dev.flow'
 import SetupRDDFlow from './setup.dev.rdd.flow'
 import SetValidatorConfig from './setValidatorConfig'
 import Transmit from './transmit.dev'
+import Inspection from './inspection'
 
 export default [
   Initialize,
@@ -27,6 +28,8 @@ export default [
   BeginOffchainConfig,
   WriteOffchainConfig,
   CommitOffchainConfig,
+  // Inspection
+  ...Inspection,
   // ONLY DEV
   Transmit,
   SetupFlow,

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/inspection/index.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/inspection/index.ts
@@ -1,0 +1,3 @@
+import Inspect from './inspect'
+
+export default [Inspect]

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/inspection/inspect.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/inspection/inspect.ts
@@ -1,0 +1,103 @@
+import { Result } from '@chainlink/gauntlet-core'
+import { SolanaCommand, TransactionResponse } from '@chainlink/gauntlet-solana'
+import { PublicKey } from '@solana/web3.js'
+import { CONTRACT_LIST, getContract } from '../../../../lib/contracts'
+import { getRDD } from '../../../../lib/rdd'
+import {
+  inspect,
+  Inspection,
+  makeInspection,
+  toComparableNumber,
+  toComparablePubKey,
+} from '../../../../core/inspection'
+
+type Input = {
+  description: string
+  decimals: string | number
+  minAnswer: string | number
+  maxAnswer: string | number
+  transmitters: string[]
+  billingAccessController: string
+  requesterAccessController: string
+  link: string
+}
+
+export default class OCR2Inspect extends SolanaCommand {
+  static id = 'ocr2:inspect'
+  static category = CONTRACT_LIST.OCR_2
+
+  makeInput = (userInput): Input => {
+    if (userInput) return userInput as Input
+    const rdd = getRDD(this.flags.rdd)
+    const info = rdd.contracts[this.flags.state]
+    const aggregatorOperators: string[] = info.oracles.map((o) => o.operator)
+    const transmitters = aggregatorOperators.map((operator) => rdd.operators[operator].nodeAddress[0])
+    const billingAccessController =
+      this.flags.billingAccessController || process.env.BILLING_ADMIN_ACCESS_CONTROLLER_ADDRESS
+    const requesterAccessController =
+      this.flags.requesterAccessController || process.env.REQUESTER_ADMIN_ACCESS_CONTROLLER_ADDRESS
+    const link = this.flags.link || process.env.LINK_ADDRESS
+    return {
+      description: info.name,
+      decimals: info.decimals,
+      minAnswer: info.minSubmissionValue,
+      maxAnswer: info.maxSubmissionValue,
+      transmitters,
+      billingAccessController,
+      requesterAccessController,
+      link,
+    }
+  }
+
+  constructor(flags, args) {
+    super(flags, args)
+    this.require(!!this.flags.state, 'Please provide flags with "state""')
+  }
+
+  execute = async () => {
+    const ocr2 = getContract(CONTRACT_LIST.OCR_2, '')
+    const program = this.loadProgram(ocr2.idl, ocr2.programId.publicKey.toString())
+
+    const state = new PublicKey(this.flags.state)
+    const input = this.makeInput(this.flags.input)
+    const data = await program.account.state.fetch(state)
+
+    const inspections: Inspection[] = [
+      makeInspection(toComparableNumber(data.config.minAnswer), toComparableNumber(input.minAnswer), 'Min Answer'),
+      makeInspection(toComparableNumber(data.config.maxAnswer), toComparableNumber(input.maxAnswer), 'Max Answer'),
+      makeInspection(toComparableNumber(data.config.decimals), toComparableNumber(input.decimals), 'Decimals'),
+      makeInspection(
+        // Description comes with some empty bytes
+        Buffer.from(data.config.description.filter((v) => v !== 0)).toString(),
+        input.description,
+        'Description',
+      ),
+      makeInspection(
+        toComparablePubKey(data.config.requesterAccessController),
+        toComparablePubKey(input.requesterAccessController),
+        'Requester access controller',
+      ),
+      makeInspection(
+        toComparablePubKey(data.config.billingAccessController),
+        toComparablePubKey(input.billingAccessController),
+        'Requester access controller',
+      ),
+      makeInspection(
+        data.oracles.xs.slice(0, data.oracles.len).map(({ transmitter }) => toComparablePubKey(transmitter)),
+        input.transmitters.map(toComparablePubKey),
+        'Transmitters',
+      ),
+    ]
+
+    const isSuccessfulInspection = inspect(inspections)
+
+    return {
+      responses: [
+        {
+          tx: this.wrapInspectResponse(isSuccessfulInspection, state.toString()),
+          contract: state.toString(),
+        },
+      ],
+    } as Result<TransactionResponse>
+  }
+}

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/inspection/inspect.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/inspection/inspect.ts
@@ -9,7 +9,12 @@ import {
   makeInspection,
   toComparableNumber,
   toComparablePubKey,
+  toComparableLongNumber,
 } from '../../../../core/inspection'
+import WriteOffchainConfig, { Input as OffchainConfigInput } from '../offchainConfig/write'
+import BN from 'bn.js'
+import { Protobuf } from '../../../../core/proto'
+import { descriptor as OCR2Descriptor } from '../../../../core/proto/ocr2Proto'
 
 type Input = {
   description: string
@@ -20,6 +25,7 @@ type Input = {
   billingAccessController: string
   requesterAccessController: string
   link: string
+  offchainConfig: OffchainConfigInput
 }
 
 export default class OCR2Inspect extends SolanaCommand {
@@ -37,6 +43,7 @@ export default class OCR2Inspect extends SolanaCommand {
     const requesterAccessController =
       this.flags.requesterAccessController || process.env.REQUESTER_ADMIN_ACCESS_CONTROLLER_ADDRESS
     const link = this.flags.link || process.env.LINK_ADDRESS
+    const offchainConfig = WriteOffchainConfig.makeInputFromRDD(rdd, this.flags.state)
     return {
       description: info.name,
       decimals: info.decimals,
@@ -46,6 +53,7 @@ export default class OCR2Inspect extends SolanaCommand {
       billingAccessController,
       requesterAccessController,
       link,
+      offchainConfig,
     }
   }
 
@@ -54,38 +62,117 @@ export default class OCR2Inspect extends SolanaCommand {
     this.require(!!this.flags.state, 'Please provide flags with "state""')
   }
 
+  deserializeConfig = (buffer: Buffer): any => {
+    const proto = new Protobuf({ descriptor: OCR2Descriptor })
+    const offchain = proto.decode('offchainreporting2_config.OffchainConfigProto', buffer)
+    const reportingPluginConfig = proto.decode(
+      'offchainreporting2_config.ReportingPluginConfig',
+      offchain.reportingPluginConfig,
+    )
+    return { ...offchain, reportingPluginConfig }
+  }
+
   execute = async () => {
     const ocr2 = getContract(CONTRACT_LIST.OCR_2, '')
     const program = this.loadProgram(ocr2.idl, ocr2.programId.publicKey.toString())
 
     const state = new PublicKey(this.flags.state)
     const input = this.makeInput(this.flags.input)
-    const data = await program.account.state.fetch(state)
+    const onChainState = await program.account.state.fetch(state)
+
+    const bufferedConfig = Buffer.from(onChainState.config.offchainConfig.xs).slice(
+      0,
+      new BN(onChainState.config.offchainConfig.len).toNumber(),
+    )
+
+    const onChainOCRConfig = this.deserializeConfig(bufferedConfig)
+    const longNumberInspections = [
+      'deltaProgressNanoseconds',
+      'deltaResendNanoseconds',
+      'deltaRoundNanoseconds',
+      'deltaGraceNanoseconds',
+      'deltaStageNanoseconds',
+      'maxDurationQueryNanoseconds',
+      'maxDurationObservationNanoseconds',
+      'maxDurationReportNanoseconds',
+      'maxDurationShouldAcceptFinalizedReportNanoseconds',
+      'maxDurationShouldTransmitAcceptedReportNanoseconds',
+    ].map((prop) =>
+      makeInspection(
+        toComparableLongNumber(onChainOCRConfig[prop]),
+        toComparableNumber(input.offchainConfig[prop]),
+        `Offchain Config "${prop}"`,
+      ),
+    )
 
     const inspections: Inspection[] = [
-      makeInspection(toComparableNumber(data.config.minAnswer), toComparableNumber(input.minAnswer), 'Min Answer'),
-      makeInspection(toComparableNumber(data.config.maxAnswer), toComparableNumber(input.maxAnswer), 'Max Answer'),
-      makeInspection(toComparableNumber(data.config.decimals), toComparableNumber(input.decimals), 'Decimals'),
+      makeInspection(
+        toComparableNumber(onChainState.config.minAnswer),
+        toComparableNumber(input.minAnswer),
+        'Min Answer',
+      ),
+      makeInspection(
+        toComparableNumber(onChainState.config.maxAnswer),
+        toComparableNumber(input.maxAnswer),
+        'Max Answer',
+      ),
+      makeInspection(toComparableNumber(onChainState.config.decimals), toComparableNumber(input.decimals), 'Decimals'),
       makeInspection(
         // Description comes with some empty bytes
-        Buffer.from(data.config.description.filter((v) => v !== 0)).toString(),
+        Buffer.from(onChainState.config.description.filter((v) => v !== 0)).toString(),
         input.description,
         'Description',
       ),
       makeInspection(
-        toComparablePubKey(data.config.requesterAccessController),
+        toComparablePubKey(onChainState.config.requesterAccessController),
         toComparablePubKey(input.requesterAccessController),
         'Requester access controller',
       ),
       makeInspection(
-        toComparablePubKey(data.config.billingAccessController),
+        toComparablePubKey(onChainState.config.billingAccessController),
         toComparablePubKey(input.billingAccessController),
         'Requester access controller',
       ),
       makeInspection(
-        data.oracles.xs.slice(0, data.oracles.len).map(({ transmitter }) => toComparablePubKey(transmitter)),
+        onChainState.oracles.xs
+          .slice(0, onChainState.oracles.len)
+          .map(({ transmitter }) => toComparablePubKey(transmitter)),
         input.transmitters.map(toComparablePubKey),
         'Transmitters',
+      ),
+      // Offchain config inspection
+      makeInspection(onChainOCRConfig.s, input.offchainConfig.s, 'Offchain Config "s"'),
+      makeInspection(onChainOCRConfig.peerIds, input.offchainConfig.peerIds, 'Offchain Config "peerIds"'),
+      makeInspection(
+        toComparableNumber(onChainOCRConfig.rMax),
+        toComparableNumber(input.offchainConfig.rMax),
+        'Offchain Config "rMax"',
+      ),
+      ...longNumberInspections,
+      makeInspection(
+        onChainOCRConfig.reportingPluginConfig.alphaReportInfinite,
+        input.offchainConfig.reportingPluginConfig.alphaReportInfinite,
+        'Offchain Config "reportingPluginConfig.alphaReportInfinite"',
+      ),
+      makeInspection(
+        onChainOCRConfig.reportingPluginConfig.alphaAcceptInfinite,
+        input.offchainConfig.reportingPluginConfig.alphaAcceptInfinite,
+        'Offchain Config "reportingPluginConfig.alphaAcceptInfinite"',
+      ),
+      makeInspection(
+        toComparableLongNumber(onChainOCRConfig.reportingPluginConfig.alphaReportPpb),
+        toComparableNumber(input.offchainConfig.reportingPluginConfig.alphaReportPpb),
+        `Offchain Config "reportingPluginConfig.alphaReportPpb"`,
+      ),
+      makeInspection(
+        toComparableLongNumber(onChainOCRConfig.reportingPluginConfig.alphaAcceptPpb),
+        toComparableNumber(input.offchainConfig.reportingPluginConfig.alphaAcceptPpb),
+        `Offchain Config "reportingPluginConfig.alphaAcceptPpb"`,
+      ),
+      makeInspection(
+        toComparableLongNumber(onChainOCRConfig.reportingPluginConfig.deltaCNanoseconds),
+        toComparableNumber(input.offchainConfig.reportingPluginConfig.deltaCNanoseconds),
+        `Offchain Config "reportingPluginConfig.deltaCNanoseconds"`,
       ),
     ]
 

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/inspection/inspectResponses.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/inspection/inspectResponses.ts
@@ -1,0 +1,46 @@
+import { Result } from '@chainlink/gauntlet-core'
+import { SolanaCommand, TransactionResponse } from '@chainlink/gauntlet-solana'
+import { PublicKey } from '@solana/web3.js'
+import { CONTRACT_LIST, getContract } from '../../../../lib/contracts'
+import { inspect, Inspection } from '../../../../core/inspection'
+
+type Input = {}
+
+export default class OCR2InspectResponses extends SolanaCommand {
+  static id = 'ocr2:inspect:responses'
+  static category = CONTRACT_LIST.OCR_2
+
+  makeInput = (userInput): Input => {
+    if (userInput) return userInput as Input
+
+    return {}
+  }
+
+  constructor(flags, args) {
+    super(flags, args)
+
+    this.require(!!this.flags.state, 'Please provide flags with "state""')
+  }
+
+  execute = async () => {
+    const ocr2 = getContract(CONTRACT_LIST.OCR_2, '')
+    const program = this.loadProgram(ocr2.idl, ocr2.programId.publicKey.toString())
+
+    const state = new PublicKey(this.flags.state)
+    const input = this.makeInput(this.flags.input)
+    const data = await program.account.state.fetch(state)
+
+    const inspections: Inspection[] = []
+
+    const successfulInspection = inspect(inspections)
+
+    return {
+      responses: [
+        {
+          tx: this.wrapInspectResponse(successfulInspection, state.toString()),
+          contract: state.toString(),
+        },
+      ],
+    } as Result<TransactionResponse>
+  }
+}

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/offchainConfig/write.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/offchainConfig/write.ts
@@ -11,7 +11,7 @@ import { makeSharedSecretEncryptions, SharedSecretEncryptions } from '../../../.
 import { durationToNanoseconds } from '../../../../core/time'
 import { divideIntoChunks } from '../../../../core/utils'
 
-type Input = {
+export type Input = {
   deltaProgressNanoseconds: number
   deltaResendNanoseconds: number
   deltaRoundNanoseconds: number
@@ -54,11 +54,8 @@ export default class WriteOffchainConfig extends SolanaCommand {
     )
   }
 
-  makeInput = (userInput: any): Input => {
-    // TODO: Some format validation for user input
-    if (userInput) return userInput as Input
-    const rdd = getRDD(this.flags.rdd)
-    const aggregator = rdd.contracts[this.flags.state]
+  static makeInputFromRDD = (rdd: any, stateAddress: string): Input => {
+    const aggregator = rdd.contracts[stateAddress]
     const config = aggregator.config
     const aggregatorOperators: string[] = aggregator.oracles.map((o) => o.operator)
     const operatorsPublicKeys = aggregatorOperators.map((o) => rdd.operators[o].ocrOffchainPublicKey[0])
@@ -94,6 +91,13 @@ export default class WriteOffchainConfig extends SolanaCommand {
       configPublicKeys: operatorConfigPublicKeys,
     }
     return input
+  }
+
+  makeInput = (userInput: any): Input => {
+    // TODO: Some format validation for user input
+    if (userInput) return userInput as Input
+    const rdd = getRDD(this.flags.rdd)
+    return WriteOffchainConfig.makeInputFromRDD(rdd, this.flags.state)
   }
 
   serializeOffchainConfig = async (input: Input): Promise<Buffer> => {

--- a/gauntlet/packages/gauntlet-solana-contracts/src/core/assert.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/core/assert.ts
@@ -1,0 +1,18 @@
+export function assert(value: any, expected: any): boolean {
+  if (Array.isArray(expected) && Array.isArray(value)) return isEqualArrays(expected, value)
+  return isEqual(value, expected)
+}
+
+export const isEqual = (a, b) => new String(a).toString() === new String(b).toString()
+
+export function isEqualArrays(a, b) {
+  a = a.map((x) => JSON.stringify(x))
+  b = b.map((y) => JSON.stringify(y))
+
+  const intersection = a.filter((x) => b.includes(x))
+  const difference = arrayDifference(a, b)
+  return a.length === b.length && intersection.length === a.length && difference.length === 0
+}
+
+export const arrayDifference = (a: any[], b: any[]) =>
+  a.filter((x) => !b.includes(x)).concat(b.filter((x) => !a.includes(x)))

--- a/gauntlet/packages/gauntlet-solana-contracts/src/core/inspection.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/core/inspection.ts
@@ -1,0 +1,35 @@
+import { logger } from '@chainlink/gauntlet-core/dist/utils'
+import { PublicKey } from '@solana/web3.js'
+import BN from 'bn.js'
+import { assert } from './assert'
+
+export type Inspection = {
+  value: any
+  expected: any
+  name: string
+}
+
+export const makeInspection = (value, expected, name) => ({ value, expected, name })
+
+export const inspect = (inspections: Inspection[]): boolean => {
+  let success = true
+  inspections.forEach(({ value, expected, name }) => {
+    if (!assert(value, expected)) {
+      success = false
+      logger.warn(`${name} invalid: expected ${expected} but actually ${value}`)
+    } else {
+      logger.success(`${name} matches: ${expected}`)
+    }
+  })
+  return success
+}
+
+export const toComparableNumber = (v: string | number) => new BN(v).toString()
+export const toComparablePubKey = (v: string) => {
+  try {
+    return new PublicKey(v).toString()
+  } catch (e) {
+    logger.error(`Error generating public key from ${v}`)
+    return ''
+  }
+}

--- a/gauntlet/packages/gauntlet-solana-contracts/src/core/inspection.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/core/inspection.ts
@@ -2,6 +2,7 @@ import { logger } from '@chainlink/gauntlet-core/dist/utils'
 import { PublicKey } from '@solana/web3.js'
 import BN from 'bn.js'
 import { assert } from './assert'
+import { Protobuf } from './proto'
 
 export type Inspection = {
   value: any
@@ -25,6 +26,8 @@ export const inspect = (inspections: Inspection[]): boolean => {
 }
 
 export const toComparableNumber = (v: string | number) => new BN(v).toString()
+export const toComparableLongNumber = (v: Long) => new BN(Protobuf.longToString(v)).toString()
+
 export const toComparablePubKey = (v: string) => {
   try {
     return new PublicKey(v).toString()

--- a/gauntlet/packages/gauntlet-solana/src/commands/internal/solana.ts
+++ b/gauntlet/packages/gauntlet-solana/src/commands/internal/solana.ts
@@ -31,6 +31,13 @@ export default abstract class SolanaCommand extends WriteCommand<TransactionResp
     },
   })
 
+  wrapInspectResponse = (success: boolean, address: string, states?: Record<string, string>): TransactionResponse => ({
+    hash: '',
+    address,
+    states,
+    wait: async () => ({ success }),
+  })
+
   deploy = async (bytecode: Buffer | Uint8Array | Array<number>, programId: Keypair): Promise<TransactionResponse> => {
     const success = await BpfLoader.load(
       this.provider.connection,


### PR DESCRIPTION
Added inspect aggregator command. 
Inspect responses is indicated only. We should come back when we have a contract example with valid responses