### PR TITLE
Fix: transmission decoding

### DIFF
--- a/gauntlet/packages/gauntlet-solana-contracts/artifacts/schemas/ocr2.json
+++ b/gauntlet/packages/gauntlet-solana-contracts/artifacts/schemas/ocr2.json
@@ -337,11 +337,11 @@
       ],
       "args": [
         {
-          "name": "observationPayment",
+          "name": "observationPaymentGjuels",
           "type": "u32"
         },
         {
-          "name": "transmissionPayment",
+          "name": "transmissionPaymentGjuels",
           "type": "u32"
         }
       ]
@@ -761,11 +761,11 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "observationPayment",
+            "name": "observationPaymentGjuels",
             "type": "u32"
           },
           {
-            "name": "transmissionPayment",
+            "name": "transmissionPaymentGjuels",
             "type": "u32"
           }
         ]
@@ -1163,31 +1163,36 @@
     },
     {
       "code": 6009,
+      "name": "DuplicateTransmitter",
+      "msg": "Duplicate transmitter"
+    },
+    {
+      "code": 6010,
       "name": "PayeeAlreadySet",
       "msg": "Payee already set"
     },
     {
-      "code": 6010,
+      "code": 6011,
       "name": "PaymentsRemaining",
       "msg": "Leftover payments remaining, please call payRemaining first"
     },
     {
-      "code": 6011,
+      "code": 6012,
       "name": "PayeeOracleMismatch",
       "msg": "Payee and Oracle lenght mismatch"
     },
     {
-      "code": 6012,
+      "code": 6013,
       "name": "InvalidTokenAccount",
       "msg": "Invalid Token Account"
     },
     {
-      "code": 6013,
+      "code": 6014,
       "name": "UnauthorizedSigner",
       "msg": "Oracle signer key not found"
     },
     {
-      "code": 6014,
+      "code": 6015,
       "name": "UnauthorizedTransmitter",
       "msg": "Oracle transmitter key not found"
     }

--- a/pkg/solana/contract.go
+++ b/pkg/solana/contract.go
@@ -159,7 +159,7 @@ func getLatestTransmission(ctx context.Context, client *rpc.Client, account sola
 	}
 
 	return Answer{
-		Data:      big.NewInt(0).SetBytes(t[4:]),
-		Timestamp: binary.BigEndian.Uint32(t[:4]),
+		Data:      big.NewInt(0).SetBytes(t[TimestampLen:]),
+		Timestamp: binary.BigEndian.Uint64(t[:TimestampLen]),
 	}, nil
 }

--- a/pkg/solana/contract_test.go
+++ b/pkg/solana/contract_test.go
@@ -19,15 +19,29 @@ import (
 )
 
 var mockTransmission = []byte{
-	96, 179, 69, 66, 128, 129, 73, 117, 1, 0, 0, 0,
-	1, 0, 0, 0, 210, 2, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 83, 43, 91, 97,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0,
+	96, 179, 69, 66, 128, 129, 73, 117, // account discriminator 8 byte
+	8, 0, 0, 0, // latest round id u32, 4 byte
+	8, 0, 0, 0, // cursor u32, 4 byte
+	0, 255, 122, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // answer i128, 16 byte
+	240, 181, 184, 97, 0, 0, 0, 0, // timestamp u64, 8 bytes
+	192, 197, 168, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	255, 184, 184, 97, 0, 0, 0, 0,
+	192, 197, 168, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	18, 185, 184, 97, 0, 0, 0, 0,
+	64, 92, 65, 109, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	67, 187, 184, 97, 0, 0, 0, 0,
+	192, 206, 229, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	19, 189, 184, 97, 0, 0, 0, 0,
+	128, 149, 19, 109, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	193, 189, 184, 97, 0, 0, 0, 0,
+	64, 56, 77, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	30, 191, 184, 97, 0, 0, 0, 0,
+	64, 20, 89, 107, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	35, 192, 184, 97, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,
 }
 
 type mockRequest struct {
@@ -37,7 +51,7 @@ type mockRequest struct {
 	JSONRPC string
 }
 
-func TestgetLatestTransmissionRaw(t *testing.T) {
+func TestGetLatestTransmissionRaw(t *testing.T) {
 	// each getLatestTransmission submits two API requests
 	// 0 + 0: everything passes
 	// 1 + 0: return too short cursor (fail on first API request)
@@ -69,8 +83,8 @@ func TestgetLatestTransmissionRaw(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	expectedTime := binary.BigEndian.Uint32([]byte{97, 91, 43, 83})
-	expectedAns := big.NewInt(0).SetBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 210}).String()
+	expectedTime := binary.BigEndian.Uint64([]byte{0, 0, 0, 0, 97, 184, 192, 35})
+	expectedAns := big.NewInt(0).SetBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 107, 89, 20, 64}).String()
 
 	a, err := getLatestTransmission(context.TODO(), rpc.New(mockServer.URL), solana.PublicKey{})
 	assert.NoError(t, err)

--- a/pkg/solana/transmitter.go
+++ b/pkg/solana/transmitter.go
@@ -93,14 +93,14 @@ func (c *ContractTracker) Transmit(
 	// Send transaction, and wait for confirmation:
 	go func() {
 		_, err := confirm.SendAndConfirmTransactionWithOpts(
-			ctx,
+			context.Background(), // does not use libocr transmit context
 			c.client.rpc,
 			c.client.ws,
 			tx,
 			true, // skip preflight
 			rpc.CommitmentConfirmed,
 		)
-		c.lggr.Errorf("error on Transmit.SendAndConfirmTransaction: %w", err)
+		c.lggr.Errorf("error on Transmit.SendAndConfirmTransaction: %s", err.Error())
 	}()
 
 	return nil

--- a/pkg/solana/transmitter.go
+++ b/pkg/solana/transmitter.go
@@ -92,15 +92,16 @@ func (c *ContractTracker) Transmit(
 
 	// Send transaction, and wait for confirmation:
 	go func() {
-		_, err := confirm.SendAndConfirmTransactionWithOpts(
+		if _, err := confirm.SendAndConfirmTransactionWithOpts(
 			context.Background(), // does not use libocr transmit context
 			c.client.rpc,
 			c.client.ws,
 			tx,
 			true, // skip preflight
 			rpc.CommitmentConfirmed,
-		)
-		c.lggr.Errorf("error on Transmit.SendAndConfirmTransaction: %s", err.Error())
+		); err != nil {
+			c.lggr.Errorf("error on Transmit.SendAndConfirmTransaction: %s", err.Error())
+		}
 	}()
 
 	return nil

--- a/pkg/solana/types.go
+++ b/pkg/solana/types.go
@@ -12,7 +12,8 @@ const (
 	TransmissionsSize uint32 = 8096
 
 	// answer (int128, 16 bytes), timestamp (uint32, 4 bytes)
-	TransmissionLen uint64 = 16 + 4
+	TimestampLen    uint64 = 8
+	TransmissionLen uint64 = 16 + TimestampLen
 
 	// AccountDiscriminator (8 bytes), RoundID (uint32, 4 bytes), Cursor (uint32, 4 bytes)
 	CursorOffset uint64 = 8 + 4
@@ -124,7 +125,7 @@ type Billing struct {
 // Answer contains the current price answer
 type Answer struct {
 	Data      *big.Int
-	Timestamp uint32
+	Timestamp uint64
 }
 
 // Access controller state


### PR DESCRIPTION
Previously, timestamp was a u32, but the latest program uses a u64. This PR fixes the offchain side for proper answer + timestamp parsing

Bonus:
* updated ocr2 schema for gauntlet related to upstream contract updates
* fix transmitter context + error logging
  * go func context should be separate from `transmit` context. otherwise the end of the function cancels the go func call

Currently testing... ✅ works!