### PR TITLE
Fix: slot height instead of block height

### DIFF
--- a/pkg/solana/client.go
+++ b/pkg/solana/client.go
@@ -66,8 +66,8 @@ func (cc Connections) Close() error {
 // GetBlockHeight returns the height of the most recent processed block in the chain, coalescing requests.
 func (c Client) GetBlockHeight(ctx context.Context, commitment rpc.CommitmentType) (blockHeight uint64, err error) {
 	// do single flight request
-	v, err, _ := c.requestGroup.Do("GetBlockHeight", func() (interface{}, error) {
-		return c.rpc.GetBlockHeight(ctx, commitment)
+	v, err, _ := c.requestGroup.Do("GetSlotHeight", func() (interface{}, error) {
+		return c.rpc.GetSlot(ctx, commitment)
 	})
 
 	if err != nil {


### PR DESCRIPTION
Tested locally? ✅ 

Program uses slot number: https://github.com/smartcontractkit/chainlink-solana/blob/aec3cd3068683c945141e9e5477c93285be07187/contracts/programs/ocr2/src/lib.rs#L150