### PR TITLE
fix: need unique contractID in job spec

### DIFF
--- a/examples/spec/ocr2-bootstrap.spec.toml
+++ b/examples/spec/ocr2-bootstrap.spec.toml
@@ -6,7 +6,7 @@ contractConfigTrackerPollInterval      = "1m"
 contractConfigTrackerSubscribeInterval = "2m"
 name                                   = "<insert job name here>"
 relay                                  = "solana"
-contractID                             = "<insert solana ocr2 program ID>"
+contractID                             = "<insert solana ocr2 state account>"
 p2pBootstrapPeers                      = []
 isBootstrapPeer                        = true
 p2pPeerID                              = "<insert p2p id>"
@@ -17,6 +17,6 @@ transmitterID                          = "<insert solana transmitter key id>"
 [relayConfig]
 nodeEndpointHTTP   = "http:..."
 nodeEndpointWS     = "ws:..."
-stateID            = "<insert ocr2 state account>"
+ocr2ProgramID      = "<insert ocr2 program id>"
 transmissionsID    = "<insert ocr2 transmissions account>"
 validatorProgramID = "<insert validator program id>"

--- a/examples/spec/ocr2-oracle.spec.toml
+++ b/examples/spec/ocr2-oracle.spec.toml
@@ -6,7 +6,7 @@ contractConfigTrackerPollInterval      = "1m"
 contractConfigTrackerSubscribeInterval = "2m"
 name                                   = "<insert job name here>"
 relay                                  = "solana"
-contractID                             = "<insert solana ocr2 program ID>"
+contractID                             = "<insert solana ocr2 state account>"
 p2pBootstrapPeers                      = ["somep2pkey@localhost-tcp:port"]
 isBootstrapPeer                        = false
 p2pPeerID                              = "<insert p2p id>"
@@ -38,6 +38,6 @@ juelsPerFeeCoinSource                  = """
 [relayConfig]
 nodeEndpointHTTP   = "http:..."
 nodeEndpointWS     = "ws:..."
-stateID            = "<insert ocr2 state account>"
+ocr2ProgramID      = "<insert ocr2 program id>"
 transmissionsID    = "<insert ocr2 transmissions account>"
 validatorProgramID = "<insert validator program id>"

--- a/ops/main.go
+++ b/ops/main.go
@@ -29,7 +29,7 @@ func RelayConfig(ctx *pulumi.Context, addresses map[int]string) (map[string]stri
 	return map[string]string{
 		"nodeEndpointHTTP": config.Require(ctx, "CL-RELAY_HTTP"),
 		"nodeEndpointWS":   config.Require(ctx, "CL-RELAY_WS"),
-		"stateID":          addresses[solana.OCRFeed],
+		"ocr2ProgramID":    addresses[solana.OCR2],
 		"transmissionsID":  addresses[solana.OCRTransmissions],
 		"storeProgramID":   addresses[solana.Store],
 	}, nil

--- a/ops/solana/solana.go
+++ b/ops/solana/solana.go
@@ -523,7 +523,7 @@ func (d Deployer) Fund(addresses []string) error {
 }
 
 func (d Deployer) OCR2Address() string {
-	return d.Account[OCR2]
+	return d.Account[OCRFeed]
 }
 
 func (d Deployer) Addresses() map[int]string {

--- a/pkg/solana/types.go
+++ b/pkg/solana/types.go
@@ -139,8 +139,9 @@ type RelayConfig struct {
 	NodeEndpointHTTP string `json:"nodeEndpointHTTP"`
 	NodeEndpointWS   string `json:"nodeEndpointWS"`
 
-	// on-chain program + 2x state accounts (state + transmissions) + validator programID
-	StateID         string `json:"stateID"`
+	// state account passed as the ContractID in main job spec
+	// on-chain program + transmissions account + store programID
+	OCR2ProgramID   string `json:"ocr2ProgramID"`
 	TransmissionsID string `json:"transmissionsID"`
 	StoreProgramID  string `json:"storeProgramID"`
 }


### PR DESCRIPTION
The `contractID` used in the job spec must be unique for each feed.

Originally the OCR2 program ID was used, but this is not unique to each feed.
Fix: use the state account as the unique `contractID` parameter

corresponding PR in core: https://github.com/smartcontractkit/chainlink/pull/5754
* needs this PR to merged to have final commit hash to use in core