### PR TITLE
fix: use correct path for contract location

### DIFF
--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           files: | 
             contracts/artifacts.tar.gz
-            target/deploy/*.so
+            contracts/target/deploy/*.so


### PR DESCRIPTION
The archive job created the archive within the `contracts` dir, so the path of the contracts also needs to include the `contracts` parent dir in the path. Running `ls contracts/target/deploy/*.so` from the repo root returns the correct contract code

<img width="612" alt="Screen Shot 2022-02-01 at 7 56 56 AM" src="https://user-images.githubusercontent.com/25337829/151992313-edb054e5-e112-4eba-b6f4-9103d8df8a98.png">
