### PR TITLE
Performance upgrades for polling

### DIFF
--- a/pkg/solana/contract.go
+++ b/pkg/solana/contract.go
@@ -55,8 +55,8 @@ type ContractTracker struct {
 	lggr   Logger
 
 	// polling
-	done chan struct{}
-	ctx context.Context
+	done   chan struct{}
+	ctx    context.Context
 	cancel context.CancelFunc
 
 	utils.StartStopOnce

--- a/pkg/solana/contract.go
+++ b/pkg/solana/contract.go
@@ -132,14 +132,9 @@ func (c *ContractTracker) PollState() {
 				}
 			}()
 			wg.Wait()
-			runTime := time.Now().Sub(start)
 
-			// reset ticker with new jitter
-			newTick := utils.WithJitter(c.client.pollingInterval) - runTime
-			if newTick < 0 {
-				newTick = 0
-			}
-			tick = time.After(newTick)
+			// Note negative duration will be immediately ready
+			tick = time.After(utils.WithJitter(c.client.pollingInterval) - time.Since(start))
 		}
 	}
 }

--- a/pkg/solana/contract_test.go
+++ b/pkg/solana/contract_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"golang.org/x/sync/singleflight"
 )
 
 var mockTransmission = []byte{
@@ -189,7 +188,6 @@ func TestStatePolling(t *testing.T) {
 		TransmissionsID: solana.MustPublicKeyFromBase58("11111111111111111111111111111112"),
 		client:          NewClient(OCR2Spec{NodeEndpointHTTP: mockServer.URL}, logger.TestLogger(t)),
 		lggr:            logger.TestLogger(t),
-		requestGroup:    &singleflight.Group{},
 		stateLock:       &sync.RWMutex{},
 		ansLock:         &sync.RWMutex{},
 		staleTimeout:    defaultStaleTimeout,

--- a/pkg/solana/contract_test.go
+++ b/pkg/solana/contract_test.go
@@ -196,9 +196,9 @@ func TestStatePolling(t *testing.T) {
 	require.Error(t, tracker.Start()) // test startOnce
 	time.Sleep(wait)
 	require.NoError(t, tracker.Close())
-	require.Error(t, tracker.Close())                                             // test StopOnce
-	mockServer.Close()                                                            // close server once tracker is stopped
-	assert.GreaterOrEqual(t, callsPerSecond*int(wait.Seconds()-1), int(i.Load())) // expect minimum number of calls
+	require.Error(t, tracker.Close())                                           // test StopOnce
+	mockServer.Close()                                                          // close server once tracker is stopped
+	assert.GreaterOrEqual(t, callsPerSecond*int(wait.Seconds()), int(i.Load())) // expect minimum number of calls
 
 	answer, err := tracker.ReadAnswer()
 	assert.NoError(t, err)


### PR DESCRIPTION
* replace singleflight with waitgroup (calls will always return latest data)
* fix shutdown performance issue with channel (replaced with context)
* start polling immediately