### PR TITLE
Small relay fixes + improvements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@
 ## Reference Docs
 
 - **[Multisig](./multisig/)**: How to setup and use the multisig program.
+-- **[Relay](./relay/)**: Details on the configuration options within a job spec.

--- a/docs/relay/README.md
+++ b/docs/relay/README.md
@@ -1,0 +1,28 @@
+# Relay Configuration Parameters
+
+The relay can be configured with various specific parameters. This document discusses the optional parameters and their impact.
+
+```toml
+[relayConfig]
+nodeEndpointHTTP   = "http:..."
+ocr2ProgramID      = "<insert solana ocr2 program ID>"
+transmissionsID    = "<insert solana ocr2 transmissions account>"
+storeProgramID     = "<insert solana ocr2 store account>"
+usePreflight       = false       # optional, defaults to false
+commitment         = "confirmed" # optional, defaults to "confirmed"
+txTimeout          = "1m"        # optional, defaults to "1m"
+pollingInterval    = "1s"        # optional, defaults to "1s"
+pollingCtxTimeout  = "2s"        # optional, defaults to `2x ${pollingInterval}`
+staleTimeout       = "1m"        # optional, defaults to "1m"
+```
+
+### Parameters
+
+| Parameter           | Description                                                                                                                                                  | Default                      | Options                               |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------------------------- |
+| `usePreflight`      | Controls if simulating transactions are enabled when transmitting (disabled for speed)                                                                       | `false`                      | `false`, `true`                       |
+| `commitment`        | Confirmation level for solana state and transactions. ([documentation](https://docs.solana.com/developing/clients/jsonrpc-api#configuring-state-commitment)) | `confirmed`                  | `processed`, `confirmed`, `finalized` |
+| `txTimeout`         | Timeout for sending a transaction                                                                                                                            | `"1m"`                       |                                       |
+| `pollingInterval`   | State polling interval                                                                                                                                       | `"1s"`                       |                                       |
+| `pollingCtxTimeout` | Request timeout during state polling                                                                                                                         | `2 x pollingInterval = "2s"` |                                       |
+| `staleTimeout`      | Used when polling is unsuccessful to indicate that consumed data is stale, and will cause errors to throw                                                    | `"1m"`                       |                                       |

--- a/examples/spec/ocr2-bootstrap.spec.toml
+++ b/examples/spec/ocr2-bootstrap.spec.toml
@@ -14,6 +14,7 @@ ocr2ProgramID      = "<insert solana ocr2 program ID>"
 transmissionsID    = "<insert solana ocr2 transmissions account>"
 storeProgramID     = "<insert solana ocr2 store account>"
 commitment         = "confirmed" # optional, defaults to "confirmed"
+txTimeout          = "1m"        # optional, defaults to "1m"
 pollingInterval    = "1s"        # optional, defaults to "1s"
 pollingCtxTimeout  = "2s"        # optional, defaults to `2x ${pollingInterval}`
 staleTimeout       = "1m"        # optional, defaults to "1m"

--- a/examples/spec/ocr2-oracle-simple.spec.toml
+++ b/examples/spec/ocr2-oracle-simple.spec.toml
@@ -41,6 +41,7 @@ transmissionsID    = "<insert solana ocr2 transmissions account>"
 storeProgramID     = "<insert solana ocr2 store account>"
 usePreflight       = false       # optional, defaults to false
 commitment         = "confirmed" # optional, defaults to "confirmed"
+txTimeout          = "1m"        # optional, defaults to "1m"
 pollingInterval    = "1s"        # optional, defaults to "1s"
 pollingCtxTimeout  = "2s"        # optional, defaults to `2x ${pollingInterval}`
 staleTimeout       = "1m"        # optional, defaults to "1m"

--- a/examples/spec/ocr2-oracle.spec.toml
+++ b/examples/spec/ocr2-oracle.spec.toml
@@ -75,6 +75,7 @@ transmissionsID    = "<insert solana ocr2 transmissions account>"
 storeProgramID     = "<insert solana ocr2 store account>"
 usePreflight       = false       # optional, defaults to false
 commitment         = "confirmed" # optional, defaults to "confirmed"
+txTimeout          = "1m"        # optional, defaults to "1m"
 pollingInterval    = "1s"        # optional, defaults to "1s"
 pollingCtxTimeout  = "2s"        # optional, defaults to `2x ${pollingInterval}`
 staleTimeout       = "1m"        # optional, defaults to "1m"

--- a/pkg/solana/client.go
+++ b/pkg/solana/client.go
@@ -49,7 +49,7 @@ func NewClient(spec OCR2Spec, logger Logger) *Client {
 	// parse context lenght, if errors, use 2x poll interval
 	ctxInterval, err := time.ParseDuration(spec.PollingCtxTimeout)
 	if err != nil {
-		logger.Warnf("could not parse polling context duration ('%s') using default 2x polling interval (%s)", spec.PollingCtxTimeout, 2 * pollInterval)
+		logger.Warnf("could not parse polling context duration ('%s') using default 2x polling interval (%s)", spec.PollingCtxTimeout, 2*pollInterval)
 		ctxInterval = 2 * pollInterval
 	}
 

--- a/pkg/solana/client.go
+++ b/pkg/solana/client.go
@@ -13,7 +13,7 @@ type Client struct {
 	rpc             *rpc.Client
 	skipPreflight   bool // to enable or disable preflight checks
 	commitment      rpc.CommitmentType
-	txDuration       time.Duration
+	txTimeout       time.Duration
 	pollingInterval time.Duration
 	contextDuration time.Duration
 
@@ -54,15 +54,15 @@ func NewClient(spec OCR2Spec, logger Logger) *Client {
 	}
 
 	// parse tx context, if errors use defaultStaleTimeout
-	txCtxDuration, err := time.ParseDuration(spec.TxTimeout)
+	txTimeout, err := time.ParseDuration(spec.TxTimeout)
 	if err != nil {
 		logger.Warnf("could not parse tx context duration using default 1m")
-		txCtxDuration = defaultStaleTimeout
+		txTimeout = defaultStaleTimeout
 	}
 
 	client.pollingInterval = pollInterval
 	client.contextDuration = ctxInterval
-	client.txDuration = txCtxDuration
+	client.txTimeout = txTimeout
 
 	// log client configuration
 	logger.Debugf("NewClient configuration: %+v", client)

--- a/pkg/solana/client.go
+++ b/pkg/solana/client.go
@@ -42,21 +42,21 @@ func NewClient(spec OCR2Spec, logger Logger) *Client {
 	// parse poll interval, if errors: use 1 second default
 	pollInterval, err := time.ParseDuration(spec.PollingInterval)
 	if err != nil {
-		logger.Warnf("could not parse polling interval using default 1s")
-		pollInterval = 1 * time.Second
+		logger.Warnf("could not parse polling interval ('%s') using default (%s)", spec.PollingInterval, defaultPollInterval)
+		pollInterval = defaultPollInterval
 	}
 
 	// parse context lenght, if errors, use 2x poll interval
 	ctxInterval, err := time.ParseDuration(spec.PollingCtxTimeout)
 	if err != nil {
-		logger.Warnf("could not parse polling context duration using default 2x polling interval")
+		logger.Warnf("could not parse polling context duration ('%s') using default 2x polling interval (%s)", spec.PollingCtxTimeout, 2 * pollInterval)
 		ctxInterval = 2 * pollInterval
 	}
 
 	// parse tx context, if errors use defaultStaleTimeout
 	txTimeout, err := time.ParseDuration(spec.TxTimeout)
 	if err != nil {
-		logger.Warnf("could not parse tx context duration using default 1m")
+		logger.Warnf("could not parse tx context duration ('%s') using default (%s)", spec.TxTimeout, defaultStaleTimeout)
 		txTimeout = defaultStaleTimeout
 	}
 

--- a/pkg/solana/client.go
+++ b/pkg/solana/client.go
@@ -13,6 +13,7 @@ type Client struct {
 	rpc             *rpc.Client
 	skipPreflight   bool // to enable or disable preflight checks
 	commitment      rpc.CommitmentType
+	txDuration       time.Duration
 	pollingInterval time.Duration
 	contextDuration time.Duration
 
@@ -52,8 +53,16 @@ func NewClient(spec OCR2Spec, logger Logger) *Client {
 		ctxInterval = 2 * pollInterval
 	}
 
+	// parse tx context, if errors use defaultStaleTimeout
+	txCtxDuration, err := time.ParseDuration(spec.TxTimeout)
+	if err != nil {
+		logger.Warnf("could not parse tx context duration using default 1m")
+		txCtxDuration = defaultStaleTimeout
+	}
+
 	client.pollingInterval = pollInterval
 	client.contextDuration = ctxInterval
+	client.txDuration = txCtxDuration
 
 	// log client configuration
 	logger.Debugf("NewClient configuration: %+v", client)

--- a/pkg/solana/config_digester.go
+++ b/pkg/solana/config_digester.go
@@ -11,9 +11,6 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 )
 
-// TODO: move this in with the Terra constant
-const ConfigDigestPrefixSolana types.ConfigDigestPrefix = 3
-
 var _ types.OffchainConfigDigester = (*OffchainConfigDigester)(nil)
 
 type OffchainConfigDigester struct {
@@ -84,13 +81,12 @@ func (d OffchainConfigDigester) ConfigDigest(cfg types.ContractConfig) (types.Co
 		return digest, fmt.Errorf("incorrect hash size %d, expected %d", n, len(digest))
 	}
 
-	digest[0] = 0x00
-	digest[1] = uint8(d.ConfigDigestPrefix())
+	binary.BigEndian.PutUint16(digest[0:2], uint16(d.ConfigDigestPrefix()))
 
 	return digest, nil
 }
 
 // This should return the same constant value on every invocation
 func (_ OffchainConfigDigester) ConfigDigestPrefix() types.ConfigDigestPrefix {
-	return ConfigDigestPrefixSolana
+	return types.ConfigDigestPrefixSolana
 }

--- a/pkg/solana/contract.go
+++ b/pkg/solana/contract.go
@@ -20,6 +20,7 @@ import (
 var (
 	configVersion       uint8 = 1
 	defaultStaleTimeout       = 1 * time.Minute
+	defaultPollInterval       = 1 * time.Second
 
 	// error declarations
 	errCursorLength       = errors.New("incorrect cursor length")

--- a/pkg/solana/relay.go
+++ b/pkg/solana/relay.go
@@ -43,6 +43,7 @@ type OCR2Spec struct {
 	// transaction + state parameters [optional]
 	UsePreflight bool
 	Commitment   string
+	TxTimeout    string
 
 	// polling configuration [optional]
 	PollingInterval   string

--- a/pkg/solana/transmitter.go
+++ b/pkg/solana/transmitter.go
@@ -83,7 +83,7 @@ func (c *ContractTracker) Transmit(
 
 	// Send transaction, and wait for confirmation:
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), c.client.txDuration)
+		ctx, cancel := context.WithTimeout(context.Background(), c.client.txTimeout)
 		defer cancel()
 		txSig, err := c.client.rpc.SendTransactionWithOpts(
 			ctx, // does not use libocr transmit context

--- a/pkg/solana/transmitter.go
+++ b/pkg/solana/transmitter.go
@@ -94,6 +94,7 @@ func (c *ContractTracker) Transmit(
 
 		if err != nil {
 			c.lggr.Errorf("error on Transmit.SendAndConfirmTransaction: %s", err.Error())
+			return
 		}
 		// TODO: poll rpc for tx confirmation (WS connection unreliable)
 		c.lggr.Debugf("tx signature from Transmit.SendAndConfirmTransaction: %s", txSig.String())

--- a/pkg/solana/transmitter.go
+++ b/pkg/solana/transmitter.go
@@ -83,8 +83,10 @@ func (c *ContractTracker) Transmit(
 
 	// Send transaction, and wait for confirmation:
 	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), c.client.txDuration)
+		defer cancel()
 		txSig, err := c.client.rpc.SendTransactionWithOpts(
-			context.Background(), // does not use libocr transmit context
+			ctx, // does not use libocr transmit context
 			tx,
 			c.client.skipPreflight,
 			c.client.commitment,

--- a/pkg/solana/types.go
+++ b/pkg/solana/types.go
@@ -146,6 +146,7 @@ type RelayConfig struct {
 	// transaction + state parameters [OPTIONAL]
 	UsePreflight bool   `json:"usePreflight"`
 	Commitment   string `json:"commitment"`
+	TxTimeout    string `json:"txTimeout"`
 
 	// polling parameters [OPTIONAL]
 	PollingInterval   string `json:"pollingInterval"`


### PR DESCRIPTION
- [x] use libocr for digest prefix #170 
- [x] use PutUint16 for digest prefix #170 
- [x] implement timeout for transmit context #169 
- [x] document relayConfig variables in a md file (see comment below)

To be addressed in separate PR:
- add golangci-lint parameters from core #173 
- fix potential nil pointer risk #174 