### PR TITLE
fix: startup panic if solana endpoint is not valid

### DIFF
--- a/ops/go.sum
+++ b/ops/go.sum
@@ -1185,6 +1185,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/smartcontractkit/chainlink-relay/ops v0.0.0-20220126171549-56e2a1dd6034 h1:LxSa+5rlio3GkawyWfL5fllSLK6KABYBBC4eo5cetls=
+github.com/smartcontractkit/chainlink-relay/ops v0.0.0-20220126171549-56e2a1dd6034/go.mod h1:DmGN1H1YWnYUahkZSBM49O0LCD6eU240geaMjlq6iX8=
 github.com/smartcontractkit/helmenv v1.0.25 h1:FxVzDyMa5GjIHAsK9puHbraoSM1Z7IThN6oqEz8cukU=
 github.com/smartcontractkit/helmenv v1.0.25/go.mod h1:ef0doolSZf8ckqaWMIK2M+EPXdIKYVzttd6EXaCgCK4=
 github.com/smartcontractkit/integrations-framework v1.0.36-0.20220124220015-0efc5b13cfc6 h1:sVSSPugf6hkGGjLaYZmsBcs3tyRVRC+orGJG7bbNosI=

--- a/pkg/solana/contract.go
+++ b/pkg/solana/contract.go
@@ -80,8 +80,6 @@ func NewTracker(spec OCR2Spec, client *Client, transmitter TransmissionSigner, l
 		lggr:            lggr,
 		stateLock:       &sync.RWMutex{},
 		ansLock:         &sync.RWMutex{},
-		stateTime:       time.Time{},
-		ansTime:         time.Time{},
 		staleTimeout:    staleTimeout,
 	}
 }

--- a/pkg/solana/contract.go
+++ b/pkg/solana/contract.go
@@ -80,8 +80,8 @@ func NewTracker(spec OCR2Spec, client *Client, transmitter TransmissionSigner, l
 		lggr:            lggr,
 		stateLock:       &sync.RWMutex{},
 		ansLock:         &sync.RWMutex{},
-		stateTime:       time.Now(),
-		ansTime:         time.Now(),
+		stateTime:       time.Time{},
+		ansTime:         time.Time{},
 		staleTimeout:    staleTimeout,
 	}
 }


### PR DESCRIPTION
Problem: node on startup will panic if endpoint is not valid and there are existing jobs

Cause:
* times are not initialized to zero: https://github.com/smartcontractkit/chainlink-solana/blob/5b4d7cdb0ba245654894036369a35898f8284751/pkg/solana/contract.go#L88
* which allows the state + answer to be read because the time comparison will pass (even though the state has not been updated) https://github.com/smartcontractkit/chainlink-solana/blob/5b4d7cdb0ba245654894036369a35898f8284751/pkg/solana/contract.go#L172
* then causes a panic when libocr tries using the data returned from LatestTransmission

Fix:
* initialize time to 0 which will throw an error for an uninitialized state (and will keep throwing an error to indicate an issue with polling and the endpoint)

Testing: ✅ 
* tested locally: start up network + nodes + feed => shut down a node => stop local network => start up the stopped node
  * previously would panic at this step
  * now shows error logs related to polling and failed to fetch state/data
  * => start up local network again => all nodes join again ✅ 