### PR TITLE
fix: Use correct observer count in the report

### DIFF
--- a/pkg/solana/report.go
+++ b/pkg/solana/report.go
@@ -57,7 +57,7 @@ func (c ReportCodec) BuildReport(oo []median.ParsedAttributedObservation) (types
 	binary.BigEndian.PutUint32(time, timestamp)
 	report = append(report, time[:]...)
 
-	observersCount := uint8(len(observers))
+	observersCount := uint8(n)
 	report = append(report, observersCount)
 
 	report = append(report, observers[:]...)

--- a/pkg/solana/report_test.go
+++ b/pkg/solana/report_test.go
@@ -44,7 +44,7 @@ func TestBuildReport(t *testing.T) {
 	assert.Equal(t, oo[0].Timestamp, binary.BigEndian.Uint32(report[0:4]), "validate timestamp")
 
 	// validate observer count
-	assert.Equal(t, uint8(len(observers)), report[4], "validate observer count")
+	assert.Equal(t, uint8(n), report[4], "validate observer count")
 
 	// validate observers
 	index := 4 + 1


### PR DESCRIPTION
len(observers) was always 32, but we want to know the actual number
of observers, not the array size.