### PR TITLE
ts: add slot to Round

### DIFF
--- a/ts/src/index.test.ts
+++ b/ts/src/index.test.ts
@@ -12,7 +12,7 @@ import * as path from "path";
 
 describe("OCR2Feed", () => {
   it("parseLog", () => {
-    let got = OCR2Feed.parseLog("testfeed", {
+    let got = OCR2Feed.parseLog({
       data: {
         roundId: 1688241,
         configDigest: [
@@ -29,24 +29,22 @@ describe("OCR2Feed", () => {
       },
     });
     expect(got).toEqual({
-      feed: "testfeed",
       answer: new BN("328053000000"),
       roundId: 1688241,
       observationsTS: new Date("2022-03-31T23:11:30.000Z"),
     });
   });
   it("parseLog null log", () => {
-    let got = OCR2Feed.parseLog("testfeed", null);
+    let got = OCR2Feed.parseLog(null);
     expect(got).toBeNull();
   });
   it("parseLog null data", () => {
-    let got = OCR2Feed.parseLog("testfeed", {});
+    let got = OCR2Feed.parseLog({});
     expect(got).toBeNull();
   });
   it("parseLog empty data", () => {
-    let got = OCR2Feed.parseLog("testfeed", { data: {} });
+    let got = OCR2Feed.parseLog({ data: {} });
     expect(got).toBeDefined();
-    expect(got.feed).toEqual("testfeed");
     expect(got.answer).toBeUndefined();
     expect(got.roundId).toBeUndefined();
     expect(got.observationsTS).toBeUndefined();
@@ -106,6 +104,7 @@ describe("OCR2Feed", () => {
       expect(got.answer).toBeDefined();
       expect(got.roundId).toBeDefined();
       expect(got.observationsTS).toBeDefined();
+      expect(got.slot).toBeDefined();
     },
     20_000
   );

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -14,6 +14,8 @@ export interface Round {
   answer: BN;
   roundId: number;
   observationsTS: Date;
+
+  slot: number;
 }
 
 export class OCR2Feed {
@@ -43,7 +45,10 @@ export class OCR2Feed {
         if (log.name != "NewTransmission") {
           return;
         }
-        callback(OCR2Feed.parseLog(feed, log));
+        let parsed = OCR2Feed.parseLog(log);
+        parsed.feed = feed;
+        parsed.slot = ctx.slot;
+        callback(parsed);
       });
     });
   }
@@ -52,7 +57,7 @@ export class OCR2Feed {
     return this.provider.connection.removeOnLogsListener(listener);
   }
 
-  public static parseLog(feed, log): Round {
+  public static parseLog(log): Round {
     if (!log || !log.data) return null;
     let answer: BN;
     if (log.data.answer)
@@ -65,10 +70,9 @@ export class OCR2Feed {
         (log.data.observationsTimestamp as number) * 1000
       );
     return {
-      feed: feed,
       answer: answer,
       roundId: roundId,
       observationsTS: observationsTS,
-    };
+    } as Round;
   }
 }


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/36233/terra-sdk-solana-sdk-add-chain-timestamp-to-round

On-chain timestamp was requested, but that doesn't seem to be available on the logs callback. We do have 'slot' though.