### PR TITLE
Fix Token transfer amount

### DIFF
--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/token/transfer.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/token/transfer.ts
@@ -48,7 +48,14 @@ export default class TransferToken extends SolanaCommand {
     logger.info(
       `Preparing instruction to send ${amount.toString()} (${this.flags.amount}) Tokens to ${destination.toString()}`,
     )
-    const ix = Token.createTransferInstruction(TOKEN_PROGRAM_ID, from, destination, signer, [], amount.toNumber())
+    const ix = Token.createTransferInstruction(
+      TOKEN_PROGRAM_ID,
+      from,
+      destination,
+      signer,
+      [],
+      amount.toString() as any,
+    )
 
     return [
       {


### PR DESCRIPTION
Number type hits the JS max safe integer limit. Converting to string. Solana web3 uses BN conversion underneath