### PR TITLE
Fix Gauntlet bundle 

### DIFF
--- a/gauntlet/package.json
+++ b/gauntlet/package.json
@@ -34,7 +34,8 @@
       "linux",
       "macos"
     ],
-    "outputPath": "bin"
+    "outputPath": "bin",
+    "assets": "node_modules/usb/prebuilds"
   },
   "devDependencies": {
     "@changesets/cli": "^2.17.0",


### PR DESCRIPTION
USB Library needs its prebuilds that only exist in `node_modules`, adding them to `assets` solves it. 

Fixes #180 