### PR TITLE
updated  provider syntax to match 0.24.2

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -27,7 +27,7 @@
     "format": "prettier --write ./src"
   },
   "dependencies": {
-    "@project-serum/anchor": "^0.23.0",
+    "@project-serum/anchor": "^0.24.2",
     "@solana/web3.js": "1.31.0"
   },
   "devDependencies": {

--- a/ts/src/index.test.ts
+++ b/ts/src/index.test.ts
@@ -89,7 +89,7 @@ describe("OCR2Feed", () => {
       // Listen to feed
       let cl = await OCR2Feed.load(
         CHAINLINK_AGGREGATOR_PROGRAM_ID,
-        anchor.Provider.env()
+        anchor.AnchorProvider.env()
       );
       let resolve;
       let promise = new Promise<Round>((r) => (resolve = r));

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -23,7 +23,7 @@ export class OCR2Feed {
 
   constructor(
     readonly aggregatorProgram: anchor.Program,
-    readonly provider: anchor.Provider
+    readonly provider: anchor.AnchorProvider
   ) {
     this._parser = new anchor.EventParser(
       aggregatorProgram.programId,
@@ -33,7 +33,7 @@ export class OCR2Feed {
 
   static async load(
     programID: PublicKey = CHAINLINK_AGGREGATOR_PROGRAM_ID,
-    provider: anchor.Provider = anchor.getProvider()
+    provider: anchor.AnchorProvider = anchor.AnchorProvider.env()
   ): Promise<OCR2Feed> {
     const aggregatorProgram = await anchor.Program.at(programID, provider);
     return new OCR2Feed(aggregatorProgram, provider);


### PR DESCRIPTION
Updating Anchor JS version in the NPM library to latest stable version 0.24.2, including updating the provider syntax to match