### PR TITLE
Fixed mockery usage

### DIFF
--- a/pkg/monitoring/prometheus_exporter_test.go
+++ b/pkg/monitoring/prometheus_exporter_test.go
@@ -11,16 +11,17 @@ import (
 )
 
 func TestPrometheusExporter(t *testing.T) {
+	t.Parallel()
+
 	t.Run("it should export balance updates then clean up", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
-		metrics := new(mocks.Metrics)
-		metrics.Test(t)
+		metrics := mocks.NewMetrics(t)
 		factory := NewPrometheusExporterFactory(newNullLogger(), metrics)
 
 		chainConfig := generateChainConfig()
 		feedConfig := generateFeedConfig()
-		exporter, err := factory.NewExporter(relayMonitoring.ExporterParams{chainConfig, feedConfig, []relayMonitoring.NodeConfig{}})
+		exporter, err := factory.NewExporter(relayMonitoring.ExporterParams{ChainConfig: chainConfig, FeedConfig: feedConfig, Nodes: []relayMonitoring.NodeConfig{}})
 		require.NoError(t, err)
 
 		balances := generateBalances()

--- a/pkg/monitoring/source_envelope_test.go
+++ b/pkg/monitoring/source_envelope_test.go
@@ -121,8 +121,7 @@ func TestEnvelopeSource(t *testing.T) {
 	feedConfig.ContractAddress = solana.MustPublicKeyFromBase58(feedConfig.ContractAddressBase58)
 
 	// Setup mocks
-	chainReader := new(mocks.ChainReader)
-	chainReader.Test(t)
+	chainReader := mocks.NewChainReader(t)
 	chainReader.On("GetState",
 		mock.Anything, // ctx
 		feedConfig.StateAccount,
@@ -222,6 +221,8 @@ func TestEnvelopeSource(t *testing.T) {
 }
 
 func TestGetLinkAvailableForPayment(t *testing.T) {
+	t.Parallel()
+
 	t.Run("should panic for a nil link balance", func(t *testing.T) {
 		require.Panics(t, func() {
 			_, _ = getLinkAvailableForPayment(fakeState, nil)


### PR DESCRIPTION
Part of https://app.shortcut.com/chainlinklabs/story/44670/spike-mockery-usage-overhaul