### PR TITLE
Update run-test actions and .tool-versions requirements for those actions

### DIFF
--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -1,6 +1,6 @@
 name: e2e_tests_custom_cl
 on:
-  push:
+  pull_request:
   workflow_dispatch:
     inputs:
       cl_branch_ref:
@@ -8,8 +8,11 @@ on:
         required: true
         default: develop
         type: string
-jobs:
+concurrency:
+  group: e2e-solana-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   e2e_custom_build_artifacts:
     name: E2E Custom Build Artifacts
     environment: integration
@@ -36,7 +39,7 @@ jobs:
       contents: read
     steps:
       - name: Build Image
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@010068ddc7dd55cd4439159a485390aa651fdd39 # v2.0.3
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@de292d573eea2debf31c058a0a7c003fa5880af5 # v2.0.6
         with:
           cl_repo: smartcontractkit/chainlink
           # by default we are integrating with develop
@@ -61,7 +64,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb # v2.4.1
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@010068ddc7dd55cd4439159a485390aa651fdd39 # v2.0.3
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@de292d573eea2debf31c058a0a7c003fa5880af5 # v2.0.6
         with:
           test_command_to_run: make test_smoke
           cl_repo: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -8,6 +8,8 @@ on:
         required: true
         default: develop
         type: string
+
+# Only run 1 of this workflow at a time per PR
 concurrency:
   group: e2e-solana-${{ github.ref }}
   cancel-in-progress: true
@@ -30,6 +32,7 @@ jobs:
         uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb # v2.4.1
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
+
   e2e_custom_build_custom_chainlink_image:
     name: E2E Custom Build Custom CL Image
     runs-on: ubuntu-latest
@@ -45,8 +48,8 @@ jobs:
           # by default we are integrating with develop
           cl_ref: ${{ github.event.inputs.cl_branch_ref }}
           # commit of the caller branch
-          dep_solana_sha: ${{ github.sha }}
-          push_tag: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:custom.${{ github.sha }}
+          dep_solana_sha: ${{ github.event.pull_request.head.sha }}
+          push_tag: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:custom.${{ github.event.pull_request.head.sha }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
 
@@ -68,7 +71,7 @@ jobs:
         with:
           test_command_to_run: make test_smoke
           cl_repo: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
-          cl_image_tag: custom.${{ github.sha }}
+          cl_image_tag: custom.${{ github.event.pull_request.head.sha }}
           download_contract_artifacts_path: contracts/target/deploy
           artifacts_location: /home/runner/work/chainlink-solana/chainlink-solana/tests/e2e/logs
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -9,6 +9,11 @@ on:
         default: develop
         type: string
 
+# Only run 1 of this workflow at a time per PR
+concurrency:
+  group: integration-tests-solana-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e_custom_build_artifacts:
     name: E2E Custom Build Artifacts
@@ -37,7 +42,7 @@ jobs:
       contents: read
     steps:
       - name: Build Image
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@de292d573eea2debf31c058a0a7c003fa5880af5 # v2.0.6
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@f828fdf6b929c762f1f5ed4e6ecd52be52a2f379 # v2.0.8
         with:
           cl_repo: smartcontractkit/chainlink
           # by default we are integrating with develop
@@ -48,7 +53,7 @@ jobs:
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
 
-  e2e_custom_run_smoke_testss:
+  e2e_custom_run_smoke_tests:
     name: E2E Custom Run Smoke Tests
     environment: integration
     permissions:
@@ -58,11 +63,16 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     needs: [e2e_custom_build_artifacts, e2e_custom_build_custom_chainlink_image]
+    env:
+      CHAINLINK_COMMIT_SHA: ${{ github.sha }}
+      CHAINLINK_ENV_USER: ${{ github.actor }}
+      TEST_TRIGGERED_BY: solana-CI
+      TEST_LOG_LEVEL: debug
     steps:
       - name: Checkout the repo
         uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb # v2.4.1
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@de292d573eea2debf31c058a0a7c003fa5880af5 # v2.0.6
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@f828fdf6b929c762f1f5ed4e6ecd52be52a2f379 # v2.0.8
         with:
           test_command_to_run: make test_smoke
           cl_repo: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
@@ -70,6 +80,12 @@ jobs:
           download_contract_artifacts_path: contracts/target/deploy
           artifacts_location: /home/runner/work/chainlink-solana/chainlink-solana/tests/e2e/logs
           token: ${{ secrets.GITHUB_TOKEN }}
+          triggered_by: ${{ env.TEST_TRIGGERED_BY }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
+      - name: cleanup
+        if: always()
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@f828fdf6b929c762f1f5ed4e6ecd52be52a2f379 # v2.0.8
+        with:
+          triggered_by: ${{ env.TEST_TRIGGERED_BY }}

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -9,11 +9,6 @@ on:
         default: develop
         type: string
 
-# Only run 1 of this workflow at a time per PR
-concurrency:
-  group: e2e-solana-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   e2e_custom_build_artifacts:
     name: E2E Custom Build Artifacts

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     steps:
       - name: Build Image
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@010068ddc7dd55cd4439159a485390aa651fdd39 # v2.0.3
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@de292d573eea2debf31c058a0a7c003fa5880af5 # v2.0.6
         with:
           cl_repo: smartcontractkit/chainlink
           # by default we are integrating with develop
@@ -62,7 +62,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb # v2.4.1
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@010068ddc7dd55cd4439159a485390aa651fdd39 # v2.0.3
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@de292d573eea2debf31c058a0a7c003fa5880af5 # v2.0.6
         with:
           test_command_to_run: make test_ocr_soak
           cl_repo: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     steps:
       - name: Build Image
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@de292d573eea2debf31c058a0a7c003fa5880af5 # v2.0.6
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@f828fdf6b929c762f1f5ed4e6ecd52be52a2f379 # v2.0.8
         with:
           cl_repo: smartcontractkit/chainlink
           # by default we are integrating with develop
@@ -58,11 +58,15 @@ jobs:
     needs: [soak_testing_build_contracts, soak_testing_build_custom_chainlink_image]
     env:
       CGO_ENABLED: 1
+      CHAINLINK_COMMIT_SHA: ${{ github.sha }}
+      CHAINLINK_ENV_USER: ${{ github.actor }}
+      TEST_TRIGGERED_BY: solana-soak
+      TEST_LOG_LEVEL: debug
     steps:
       - name: Checkout the repo
         uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb # v2.4.1
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@de292d573eea2debf31c058a0a7c003fa5880af5 # v2.0.6
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@f828fdf6b929c762f1f5ed4e6ecd52be52a2f379 # v2.0.8
         with:
           test_command_to_run: make test_ocr_soak
           cl_repo: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
@@ -72,6 +76,7 @@ jobs:
           publish_report_paths: ./tests-soak-report.xml
           publish_check_name: Chaos Test Results
           token: ${{ secrets.GITHUB_TOKEN }}
+          triggered_by: ${{ env.TEST_TRIGGERED_BY }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -6,3 +6,4 @@ pulumi 3.25.1
 ginkgo 2.1.4
 actionlint 1.6.15
 shellcheck 0.8.0
+helm 3.9.2


### PR DESCRIPTION
Updates to latest runner for e2e, includes cleanup on cancelling of a job for both a normal user cancel and when a new pr commit is made.