### PR TITLE
fixes + test case for running simultaneous solana-test-validator

### DIFF
--- a/pkg/solana/client/test_helpers.go
+++ b/pkg/solana/client/test_helpers.go
@@ -17,13 +17,17 @@ import (
 // SetupLocalSolNode sets up a local solana node via solana cli, and returns the url
 func SetupLocalSolNode(t *testing.T) string {
 	port := utils.MustRandomPort(t)
+	faucetPort := utils.MustRandomPort(t)
 	url := "http://127.0.0.1:" + port
 	cmd := exec.Command("solana-test-validator",
 		"--reset",
 		"--rpc-port", port,
+		"--faucet-port", faucetPort,
 	)
 	var stdErr bytes.Buffer
 	cmd.Stderr = &stdErr
+	var stdOut bytes.Buffer
+	cmd.Stdout = &stdOut
 	require.NoError(t, cmd.Start())
 	t.Cleanup(func() {
 		assert.NoError(t, cmd.Process.Kill())
@@ -46,6 +50,9 @@ func SetupLocalSolNode(t *testing.T) string {
 		}
 		ready = true
 		break
+	}
+	if !ready {
+		t.Logf("Cmd output: %s\nCmd error: %s\n", stdOut.String(), stdErr.String())
 	}
 	require.True(t, ready)
 	return url

--- a/pkg/solana/client/test_helpers_test.go
+++ b/pkg/solana/client/test_helpers_test.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupLocalSolNode_SimultaneousNetworks(t *testing.T) {
+	// run two networks
+	network0 := SetupLocalSolNode(t)
+	network1 := SetupLocalSolNode(t)
+
+	account := solana.NewWallet()
+	pubkey := account.PublicKey()
+
+	// client configs
+	requestTimeout := 5 * time.Second
+	lggr := logger.Test(t)
+	cfg := config.NewConfig(db.ChainCfg{}, lggr)
+
+	// check & fund address
+	checkFunded := func(t *testing.T, url string) {
+		// create client
+		c, err := NewClient(url, cfg, requestTimeout, lggr)
+		require.NoError(t, err)
+
+		// check init balance
+		bal, err := c.Balance(pubkey)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0), bal)
+
+		FundTestAccounts(t, []solana.PublicKey{pubkey}, url)
+
+		// check end balance
+		bal, err = c.Balance(pubkey)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(100_000_000_000), bal) // once funds get sent to the system program it should be unrecoverable (so this number should remain > 0)
+	}
+
+	checkFunded(t, network0)
+	checkFunded(t, network1)
+}


### PR DESCRIPTION
improvements to local node test set up
- additional logging of outputs when failed to start
- setting faucet port to random to prevent overlap
- test case to validate multiple local nodes running at the same time