### PR TITLE
QA-79 Use projectserum version from makefile in github workflows

### DIFF
--- a/.github/actions/projectserum_version/action.yml
+++ b/.github/actions/projectserum_version/action.yml
@@ -1,0 +1,16 @@
+name: Get ProjectSerum Image Version
+description: Gets the projectserum version in the makefile
+outputs:
+  projectserum_version:
+    description: The projectserum image version
+    value: ${{ steps.psversion.outputs.PSVERSION }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get the projectserum version
+      id: psversion
+      shell: bash
+      run: |
+        PSVERSION=$(make projectserum_version)
+        echo "PSVERSION=${PSVERSION}" >>$GITHUB_OUTPUT

--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -9,11 +9,23 @@ defaults:
   run:
     working-directory: ./contracts
 jobs:
+  get_projectserum_version:
+    name: Get ProjectSerum Version
+    runs-on: ubuntu-latest
+    outputs:
+      projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb # v2.4.1
+      - name: Get ProjectSerum Version
+        id: psversion
+        uses: ./.github/actions/projectserum_version
   release-artifacts:
     name: Release Artifacts
     runs-on: ubuntu-latest
+    needs: [get_projectserum_version]
     container:
-      image: projectserum/build:v0.25.0
+      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
       env:
         RUSTUP_HOME: "/root/.rustup"
     steps:

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -15,6 +15,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get_projectserum_version:
+    name: Get ProjectSerum Version
+    environment: integration
+    runs-on: ubuntu-latest
+    outputs:
+      projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb # v2.4.1
+      - name: Get ProjectSerum Version
+        id: psversion
+        uses: ./.github/actions/projectserum_version
   e2e_custom_build_artifacts:
     name: E2E Custom Build Artifacts
     environment: integration
@@ -22,8 +34,9 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
+    needs: [get_projectserum_version]
     container:
-      image: projectserum/build:v0.25.0
+      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
       env:
         RUSTUP_HOME: "/root/.rustup"
         FORCE_COLOR: 1
@@ -32,7 +45,6 @@ jobs:
         uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb # v2.4.1
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
-
   e2e_custom_build_custom_chainlink_image:
     name: E2E Custom Build Custom CL Image
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,11 +7,24 @@ defaults:
     working-directory: contracts
 
 jobs:
+  get_projectserum_version:
+    name: Get ProjectSerum Version
+    runs-on: ubuntu-latest
+    outputs:
+      projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb # v2.4.1
+      - name: Get ProjectSerum Version
+        id: psversion
+        uses: ./.github/actions/projectserum_version
+
   rust_run_anchor_tests:
     name: Rust Run Anchor Tests
     runs-on: ubuntu-latest
+    needs: [get_projectserum_version]
     container:
-      image: projectserum/build:v0.25.0
+      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
       env:
         RUSTUP_HOME: "/root/.rustup"
         FORCE_COLOR: 1
@@ -52,8 +65,9 @@ jobs:
   rust_lint:
     name: Rust Lint
     runs-on: ubuntu-latest
+    needs: [get_projectserum_version]
     container:
-      image: projectserum/build:v0.25.0
+      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
       env:
         RUSTUP_HOME: "/root/.rustup"
         FORCE_COLOR: 1

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -10,6 +10,18 @@ on:
         default: develop
         type: string
 jobs:
+  get_projectserum_version:
+    name: Get ProjectSerum Version
+    environment: integration
+    runs-on: ubuntu-latest
+    outputs:
+      projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb # v2.4.1
+      - name: Get ProjectSerum Version
+        id: psversion
+        uses: ./.github/actions/projectserum_version
   soak_testing_build_contracts:
     name: Soak Testing Build Contracts
     environment: integration
@@ -17,8 +29,9 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
+    needs: [get_projectserum_version]
     container:
-      image: projectserum/build:v0.25.0
+      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
       env:
         RUSTUP_HOME: "/root/.rustup"
         FORCE_COLOR: 1

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 BIN_DIR = bin
 export GOPATH ?= $(shell go env GOPATH)
 export GO111MODULE ?= on
-export PROJECT_SERUM_IMAGE ?= projectserum/build:v0.25.0
+export PROJECT_SERUM_VERSION ?=v0.25.0
+export PROJECT_SERUM_IMAGE ?= projectserum/build:$(PROJECT_SERUM_VERSION)
 
 LINUX=LINUX
 OSX=OSX
@@ -45,6 +46,10 @@ ifneq ($(CI),true)
 endif
 	go install github.com/onsi/ginkgo/v2/ginkgo@v$(shell cat ./.tool-versions | grep ginkgo | sed -En "s/ginkgo.(.*)/\1/p")
 endif
+
+.PHONY: projectserum_version
+projectserum_version:
+	@echo "${PROJECT_SERUM_VERSION}"
 
 anchor_shell:
 	docker run --rm -it -v $(shell pwd):/workdir --entrypoint bash ${PROJECT_SERUM_IMAGE}


### PR DESCRIPTION
Reduces the number of places the projectserum image version is needed to be updated.
The action can be used in the chainlink repo to keep its version in sync with this repo.