### PR TITLE
bump solana validator version

### DIFF
--- a/tests/e2e/common/test_common.go
+++ b/tests/e2e/common/test_common.go
@@ -134,28 +134,7 @@ func (m *OCRv2TestState) DeployEnv(nodes int, stateful bool, contractsDir string
 	}).
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
-		AddHelm(sol.New(&sol.Props{ // copied because config is not merged
-			NetworkName: "sol",
-			Values: map[string]interface{}{
-				"replicas": "1",
-				"sol": map[string]interface{}{
-					"image": map[string]interface{}{
-						"image":   "solanalabs/solana",
-						"version": "v1.13.3",
-					},
-					"resources": map[string]interface{}{
-						"requests": map[string]interface{}{
-							"cpu":    "2000m",
-							"memory": "4000Mi",
-						},
-						"limits": map[string]interface{}{
-							"cpu":    "2000m",
-							"memory": "4000Mi",
-						},
-					},
-				},
-			},
-		})).
+		AddHelm(sol.New(nil)).
 		AddHelm(chainlink.New(0, map[string]interface{}{
 			"replicas": nodes,
 			"env": map[string]interface{}{

--- a/tests/e2e/common/test_common.go
+++ b/tests/e2e/common/test_common.go
@@ -134,7 +134,28 @@ func (m *OCRv2TestState) DeployEnv(nodes int, stateful bool, contractsDir string
 	}).
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
-		AddHelm(sol.New(nil)).
+		AddHelm(sol.New(&sol.Props{ // copied because config is not merged
+			NetworkName: "sol",
+			Values: map[string]interface{}{
+				"replicas": "1",
+				"sol": map[string]interface{}{
+					"image": map[string]interface{}{
+						"image":   "solanalabs/solana",
+						"version": "v1.13.3",
+					},
+					"resources": map[string]interface{}{
+						"requests": map[string]interface{}{
+							"cpu":    "2000m",
+							"memory": "4000Mi",
+						},
+						"limits": map[string]interface{}{
+							"cpu":    "2000m",
+							"memory": "4000Mi",
+						},
+					},
+				},
+			},
+		})).
 		AddHelm(chainlink.New(0, map[string]interface{}{
 			"replicas": nodes,
 			"env": map[string]interface{}{

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.20.1
 	github.com/rs/zerolog v1.27.0
 	github.com/satori/go.uuid v1.2.0
-	github.com/smartcontractkit/chainlink-env v0.2.31
+	github.com/smartcontractkit/chainlink-env v0.2.44
 	github.com/smartcontractkit/chainlink-solana v0.2.20-0.20220727214817-9d2526661be3
 	github.com/smartcontractkit/chainlink-testing-framework v1.5.2-0.20220726165703-ed4e6cabca38
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20220727205731-7d3de7be1c70


### PR DESCRIPTION
bump from 1.9.13 => 1.13.3
upstream bump in `chainlink-env`: https://github.com/smartcontractkit/chainlink-env/pull/195