### PR TITLE
fix gauntlet ocr2:close command to match expected variable name

### DIFF
--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/close.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/close.ts
@@ -40,7 +40,7 @@ export default class extends Close {
       .map((oracle) => ({ pubkey: oracle.payee, isWritable: true, isSigner: false }))
 
     const extraAccounts = {
-      tokenRecipient: tokenRecipient.address,
+      tokenReceiver: tokenRecipient.address,
       tokenVault: config.tokenVault,
       vaultAuthority,
       tokenProgram: TOKEN_PROGRAM_ID,


### PR DESCRIPTION
fixed gauntlet naming to match naming in program: https://github.com/smartcontractkit/chainlink-solana/blob/develop/contracts/programs/ocr2/src/lib.rs#L62