### PR TITLE
Bumping libocr up to 482da3ed36d8 commit hash

### DIFF
--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -94,7 +94,7 @@ jobs:
           artifacts_location: /home/runner/work/chainlink-solana/chainlink-solana/tests/e2e/logs
           token: ${{ secrets.GITHUB_TOKEN }}
           triggered_by: ${{ env.TEST_TRIGGERED_BY }}
-          dep_chainlink_integration_tests: ${{ github.event.inputs.cl_branch_ref || 'develop' }}
+          dep_chainlink_integration_tests: ede2dc1e2b53 # ${{ github.event.inputs.cl_branch_ref || 'develop' }} # Use the version specified in go.mod until after ginkgo is removed
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/smartcontractkit/chainlink-relay v0.1.6-0.20221205145242-57d65316ed43
-	github.com/smartcontractkit/libocr v0.0.0-20220812191430-db92a9fdaa52
+	github.com/smartcontractkit/libocr v0.0.0-20221121171434-482da3ed36d8
 	github.com/stretchr/testify v1.7.5
 	go.uber.org/multierr v1.8.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartcontractkit/chainlink-relay v0.1.6-0.20221205145242-57d65316ed43 h1:lLZz8TuCpwwpCLon/tiNfA/ZYoAEG+cdehdsLD26elE=
 github.com/smartcontractkit/chainlink-relay v0.1.6-0.20221205145242-57d65316ed43/go.mod h1:v/QSrVm3z4/aPz/PLB6da05B/r4MHZy0/jder7iPxkQ=
-github.com/smartcontractkit/libocr v0.0.0-20220812191430-db92a9fdaa52 h1:Nac1UCKJwt0AY15bAaorscflOcBs/FnmO7NoCh8Tons=
-github.com/smartcontractkit/libocr v0.0.0-20220812191430-db92a9fdaa52/go.mod h1:5JnCHuYgmIP9ZyXzgAfI5Iwu0WxBtBKp+ApeT5o1Cjw=
+github.com/smartcontractkit/libocr v0.0.0-20221121171434-482da3ed36d8 h1:KcTNxuP5g3GGUqn3WJe7KKnTixqfVZjmHnMAnKkLGJw=
+github.com/smartcontractkit/libocr v0.0.0-20221121171434-482da3ed36d8/go.mod h1:5JnCHuYgmIP9ZyXzgAfI5Iwu0WxBtBKp+ApeT5o1Cjw=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION
No interface changes were introduced in this `libocr` release.

Summary of `libocr` improvements:
- Add oracle-side timestamps to telemetry messages.
- Improve OCR2 docs.
- Fix an issue with v2 networking where mistakenly opening an OCREndpoint for the second time would cause the original endpoint to stop working.
- Improve resource management in networking.
- Fix concurrency issue in v2 networking.
- Various typo fixes and logging improvements.
- Typo & linter fixes
- Replace some uses of abi.encodePacked with abi.encode where there is no semantic difference
- Fix a bug in transmission protocol database restore logic that could cause transmissions to become stuck for extended time periods
- Remove logic to restore latest expired transmission from OCR2
- Introduce new configuration helper that allows injecting an RNG