### PR TITLE
Use LINK as input units to fund and withdraw funds from aggregators

### DIFF
--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/fund.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/fund.ts
@@ -58,7 +58,7 @@ export default class Fund extends SolanaCommand {
     const from = await getAssociatedTokenAddress(linkPublicKey, signer)
     const amount = new BN(this.input.amount)
     logger.loading(
-      `Transferring ${amount.toString()} tokens to ${state.toString()} aggregator token vault ${tokenVault.toString()}...`,
+      `Transferring ${amount.toString()} (${this.flags.amount}) tokens to ${state.toString()} aggregator token vault ${tokenVault.toString()}...`,
     )
 
     const ix = createTransferInstruction(from, tokenVault, signer, amount.toNumber())

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/fund.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/fund.ts
@@ -4,9 +4,10 @@ import { PublicKey } from '@solana/web3.js'
 import { createTransferInstruction, getAssociatedTokenAddress } from '@solana/spl-token'
 import { CONTRACT_LIST, getContract } from '../../../lib/contracts'
 import { logger, BN, prompt } from '@chainlink/gauntlet-core/dist/utils'
+import { TOKEN_DECIMALS } from '../../../lib/constants'
 
 type Input = {
-  amount: number
+  amount: number | string
   link: string
 }
 
@@ -14,7 +15,7 @@ export default class Fund extends SolanaCommand {
   static id = 'ocr2:fund'
   static category = CONTRACT_LIST.OCR_2
 
-  static examples = ['yarn gauntlet ocr2:fund --network=devnet --amount=[AMOUNT] [AGGREGATOR_ADDRESS]']
+  static examples = ['yarn gauntlet ocr2:fund --network=devnet --amount=[AMOUNT in LINK] [AGGREGATOR_ADDRESS]']
 
   input: Input
 
@@ -39,7 +40,7 @@ export default class Fund extends SolanaCommand {
     const link = this.flags.link || process.env.LINK
     this.require(link, 'Please provide a link address with --link or env LINK')
     return {
-      amount: this.flags.amount,
+      amount: (BigInt(this.flags.amount) * BigInt(10) ** BigInt(TOKEN_DECIMALS)).toString(),
       link: this.flags.link || process.env.LINK,
     }
   }

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/withdrawFunds.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/withdrawFunds.ts
@@ -69,6 +69,10 @@ export default class WithdrawFunds extends SolanaCommand {
 
     const billingAC = new PublicKey(info.config.billingAccessController)
 
+    logger.loading(
+      `Withdrawing ${this.input.amountGjuels} (${this.flags.amount}) tokens from ${state.toString()} aggregator token vault ${tokenVault.toString()}...`,
+    )
+
     const data = await this.program.methods
       .withdrawFunds(new BN(this.input.amountGjuels))
       .accounts({

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/withdrawFunds.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/withdrawFunds.ts
@@ -5,6 +5,7 @@ import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import { utils } from '@project-serum/anchor'
 import { logger, BN, prompt } from '@chainlink/gauntlet-core/dist/utils'
 import { CONTRACT_LIST, getContract } from '../../../lib/contracts'
+import { TOKEN_DECIMALS } from '../../../lib/constants'
 
 type Input = {
   amountGjuels: number | string
@@ -16,7 +17,7 @@ export default class WithdrawFunds extends SolanaCommand {
   static category = CONTRACT_LIST.OCR_2
 
   static examples = [
-    'yarn gauntlet ocr2:withdraw_funds --network=devnet --amount=NUM_GJUELS --recipient=YOUR_LINK_ACCOUNT AGGREGATOR_ADDR',
+    'yarn gauntlet ocr2:withdraw_funds --network=devnet --amount=NUM_LINK --recipient=YOUR_LINK_ACCOUNT AGGREGATOR_ADDR',
     'yarn gauntlet ocr2:withdraw_funds --network=devnet --amount=100 --recipient=FTH1Kqvr5BhiAA786DdQVBQYJ1bs5XhKwTEETKCqYwMh 9hBz81AnfoeGgqVqQHKBiAXGJ2hKAs7A2KYFxn5yGgat',
   ]
 
@@ -26,7 +27,7 @@ export default class WithdrawFunds extends SolanaCommand {
     if (userInput) return userInput as Input
 
     if (!this.flags.amount) {
-      throw Error('Please specify --amount to withdraw')
+      throw Error('Please specify --amount to withdraw (in LINK)')
     }
 
     if (!this.flags.recipient) {
@@ -34,7 +35,7 @@ export default class WithdrawFunds extends SolanaCommand {
     }
 
     return {
-      amountGjuels: this.flags.amount,
+      amountGjuels: (BigInt(this.flags.amount) * BigInt(10) ** BigInt(TOKEN_DECIMALS)).toString(),
       recipient: new PublicKey(this.flags.recipient),
     }
   }


### PR DESCRIPTION
Previously, to fund or withdraw funds from a feed with 5700 LINK you had to use `--amount=5700000000000`. Now, you can use `--amount=5700`.

https://chainlink-core.slack.com/archives/C019ER74NJW/p1674838710250609

`Do not merge before all gauntlet-solana users are aware of change`

Example I/O:
```shell
% yarn gauntlet ocr2:fund --network=devnet --amount=10 ChMRWnXmBrppAyDVuKEcxpNpVbPUQxTokTxudGRReb2L

🧤  gauntlet 0.1.2
ℹ️   Loading Local wallet
Operator address is EybKTtqhgwxcEJ1cFPxKWe1t6ZvY6hS9aeSSZJdmkYYH
⏳  Transferring 10000000000 (10) tokens to ChMRWnXmBrppAyDVuKEcxpNpVbPUQxTokTxudGRReb2L aggregator token vault Ex3JzBk3vzy727M98hRHv7FuBRE2KdgRHJ4xy5wEin5c...
🤔  Continue funding feed? (Y / N)n

% yarn gauntlet ocr2:withdraw_funds --network=devnet --amount=10 --recipient=HZqYSwfFNjBtv6DrmaNNAquSJWGfw8cDtcxDY8tkvrY1 ChMRWnXmBrppAyDVuKEcxpNpVbPUQxTokTxudGRReb2L

🧤  gauntlet 0.1.2
ℹ️   Loading Local wallet
Operator address is EybKTtqhgwxcEJ1cFPxKWe1t6ZvY6hS9aeSSZJdmkYYH
⏳  Withdrawing 10000000000 (10) tokens from ChMRWnXmBrppAyDVuKEcxpNpVbPUQxTokTxudGRReb2L aggregator token vault Ex3JzBk3vzy727M98hRHv7FuBRE2KdgRHJ4xy5wEin5c...

```