### PR TITLE
increase max duration query

### DIFF
--- a/integration-tests/common/common.go
+++ b/integration-tests/common/common.go
@@ -256,7 +256,7 @@ func OffChainConfigParamsFromNodes(nodes []*client.Chainlink, nkb []client.NodeK
 			AlphaReportPPB: uint64(0),
 			AlphaAcceptPPB: uint64(0),
 		}.Encode(),
-		MaxDurationQuery:                        0,
+		MaxDurationQuery:                        500 * time.Millisecond,
 		MaxDurationObservation:                  500 * time.Millisecond,
 		MaxDurationReport:                       500 * time.Millisecond,
 		MaxDurationShouldAcceptFinalizedReport:  500 * time.Millisecond,

--- a/ops/solana/solana.go
+++ b/ops/solana/solana.go
@@ -473,7 +473,7 @@ func (d Deployer) InitOCR(keys []opsChainlink.NodeKeys) error {
 			"alphaAcceptPpb":      uint64(0),       // accept all reports (if deviation matches number)
 			"deltaCNanoseconds":   0 * time.Second, // heartbeat
 		},
-		"maxDurationQueryNanoseconds":                        0 * time.Millisecond,
+		"maxDurationQueryNanoseconds":                        300 * time.Millisecond,
 		"maxDurationObservationNanoseconds":                  300 * time.Millisecond,
 		"maxDurationReportNanoseconds":                       300 * time.Millisecond,
 		"maxDurationShouldAcceptFinalizedReportNanoseconds":  1 * time.Second,


### PR DESCRIPTION
Using zero causes a context to be passed with an already expired deadline.