### PR TITLE
bump chainlink-relay; update Relayer.Healthy()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230309154839-2b6a5b078888
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230316183824-9f1e5e11e2b7
 	github.com/smartcontractkit/libocr v0.0.0-20221209172631-568a30f68407
 	github.com/stretchr/testify v1.8.2
 	go.uber.org/multierr v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230309154839-2b6a5b078888 h1:EGMHKJWQtjjJM3+FaPJMipvxGVio1P66y5NyqgBGoMk=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230309154839-2b6a5b078888/go.mod h1:Uqt8amCr4U4/6n+pvr1OMlNBzSqYSr6oeWAaBsBdPYE=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230316183824-9f1e5e11e2b7 h1:TClDxiM7MbjYlmEjqel7npTveEEhCZ4uNH6e94qw4u0=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230316183824-9f1e5e11e2b7/go.mod h1:Uqt8amCr4U4/6n+pvr1OMlNBzSqYSr6oeWAaBsBdPYE=
 github.com/smartcontractkit/libocr v0.0.0-20221209172631-568a30f68407 h1:P3dhh6UkjA6Fxj39y4vQflv7GoDCa+QC/Du7CCDxjfQ=
 github.com/smartcontractkit/libocr v0.0.0-20221209172631-568a30f68407/go.mod h1:5JnCHuYgmIP9ZyXzgAfI5Iwu0WxBtBKp+ApeT5o1Cjw=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/pkg/solana/relay.go
+++ b/pkg/solana/relay.go
@@ -65,16 +65,14 @@ func (r *Relayer) Ready() error {
 }
 
 // Healthy only if all subservices are healthy
-func (r *Relayer) Healthy() error {
-	return r.chainSet.Healthy()
-}
+func (r *Relayer) Healthy() error { return nil }
 
 func (r *Relayer) HealthReport() map[string]error {
 	return map[string]error{r.Name(): r.Healthy()}
 }
 
 func (r *Relayer) NewMercuryProvider(rargs relaytypes.RelayArgs, pargs relaytypes.PluginArgs) (relaytypes.MercuryProvider, error) {
-	return nil, errors.New("mercury is not supported for starknet")
+	return nil, errors.New("mercury is not supported for solana")
 }
 
 func (r *Relayer) NewConfigProvider(args relaytypes.RelayArgs) (relaytypes.ConfigProvider, error) {


### PR DESCRIPTION
`chainSet.Healthy()` is no longer available on latest chainlink-relay

Seems like passing the required e2e tests depends on:
- https://github.com/smartcontractkit/chainlink-starknet/pull/217