### PR TITLE
bump nodejs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-nodejs 14.19.1
+nodejs 16.13.2
 yarn 1.22.19
 rust 1.59.0
 golang 1.20.1


### PR DESCRIPTION
node14 not working on mac when install with asdf - bumping to node16

this matches the shell.nix config now