### PR TITLE
integration-tests-common: reduce MaxDurationQuery from 500ms to 100ms

### DIFF
--- a/integration-tests/common/common.go
+++ b/integration-tests/common/common.go
@@ -257,7 +257,7 @@ func OffChainConfigParamsFromNodes(nodes []*client.Chainlink, nkb []client.NodeK
 			AlphaReportPPB: uint64(0),
 			AlphaAcceptPPB: uint64(0),
 		}.Encode(),
-		MaxDurationQuery:                        500 * time.Millisecond,
+		MaxDurationQuery:                        100 * time.Millisecond,
 		MaxDurationObservation:                  500 * time.Millisecond,
 		MaxDurationReport:                       500 * time.Millisecond,
 		MaxDurationShouldAcceptFinalizedReport:  500 * time.Millisecond,


### PR DESCRIPTION
500ms was arbitrary and is more than necessary.
Supporting:
- https://github.com/smartcontractkit/chainlink/pull/9208

Which passed :+1: 