### PR TITLE
fix: race condition in tracking retry signatures

### DIFF
--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -293,7 +293,7 @@ func (txm *Txm) sendWithRetry(chanCtx context.Context, baseTx solanaGo.Transacti
 					wait := make(chan struct{})
 					go func() {
 						defer close(wait)
-						sigs.Wait(int(count)).Wait() // wait until bump tx has set the tx signature to compare rebroadcast signatures
+						sigs.Wait(int(count)) // wait until bump tx has set the tx signature to compare rebroadcast signatures
 					}()
 					select {
 					case <-ctx.Done():

--- a/pkg/solana/txm/txm_race_test.go
+++ b/pkg/solana/txm/txm_race_test.go
@@ -3,6 +3,7 @@ package txm
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	solanaClient "github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
 	clientmocks "github.com/smartcontractkit/chainlink-solana/pkg/solana/client/mocks"
 	cfgmocks "github.com/smartcontractkit/chainlink-solana/pkg/solana/config/mocks"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/fees"
 	feemocks "github.com/smartcontractkit/chainlink-solana/pkg/solana/fees/mocks"
 	ksmocks "github.com/smartcontractkit/chainlink-solana/pkg/solana/txm/mocks"
 
@@ -23,6 +25,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func NewTestTx() (tx solanaGo.Transaction) {
+	tx.Message.AccountKeys = append(tx.Message.AccountKeys, solanaGo.PublicKey{})
+	return tx
+}
 
 // Test race condition for saving + reading signatures when bumping fees
 // A slow RPC can cause the tx (before bump) to be processed after the bumped tx
@@ -48,25 +55,41 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 	ks.On("Sign", mock.Anything, mock.Anything, mock.Anything).Return([]byte{}, nil)
 
 	// assemble minimal tx for testing retry
-	tx := solanaGo.Transaction{}
-	tx.Message.AccountKeys = append(tx.Message.AccountKeys, solanaGo.PublicKey{})
+	tx := NewTestTx()
 
-	t.Run("delay in rebroadcasting tx", func(t *testing.T) {
-		client := clientmocks.NewReaderWriter(t)
+	testRunner := func(t *testing.T, client solanaClient.ReaderWriter) {
 		getClient := func() (solanaClient.ReaderWriter, error) {
 			return client, nil
 		}
 
+		// build minimal txm
+		txm := NewTxm("retry_race", getClient, cfg, ks, lggr)
+		txm.fee = fee
+
+		_, _, _, err := txm.sendWithRetry(
+			utils.Context(t),
+			tx,
+			txRetryDuration,
+		)
+		require.NoError(t, err)
+
+		time.Sleep(txRetryDuration / 4 * 5)                                     // wait 1.25x longer of tx life to capture all logs
+		assert.Equal(t, observer.FilterLevelExact(zapcore.ErrorLevel).Len(), 0) // assert no error logs
+		lastLog := observer.All()[len(observer.All())-1]
+		assert.Contains(t, lastLog.Message, "stopped tx retry") // assert that all retry goroutines exit successfully
+	}
+
+	t.Run("delay in rebroadcasting tx", func(t *testing.T) {
+		client := clientmocks.NewReaderWriter(t)
 		// client mock
 		txs := map[string]solanaGo.Signature{}
 		var lock sync.RWMutex
 		client.On("SendTx", mock.Anything, mock.Anything).Return(
 			// build new sig if tx is different
-			// rebroadcast txs will be delayed
 			func(_ context.Context, tx *solanaGo.Transaction) solanaGo.Signature {
 				strTx := tx.String()
 
-				// if exists previously slow down client response to trigger race
+				// if exists, slow down client response to trigger race
 				lock.RLock()
 				val, exists := txs[strTx]
 				lock.RUnlock()
@@ -90,34 +113,51 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 			},
 			nil,
 		)
-
-		// build minimal txm
-		txm := NewTxm("retry_race", getClient, cfg, ks, lggr)
-		txm.fee = fee
-
-		_, _, _, err := txm.sendWithRetry(
-			utils.Context(t),
-			tx,
-			txRetryDuration,
-		)
-		require.NoError(t, err)
-
-		time.Sleep(txRetryDuration / 4 * 5) // wait 1.25x longer of tx life to capture all logs
-		assert.Equal(t, observer.FilterLevelExact(zapcore.ErrorLevel).Len(), 0)
+		testRunner(t, client)
 	})
 
 	t.Run("delay in broadcasting new tx", func(t *testing.T) {
 		client := clientmocks.NewReaderWriter(t)
-		getClient := func() (solanaClient.ReaderWriter, error) {
-			return client, nil
-		}
-
 		// client mock
 		txs := map[string]solanaGo.Signature{}
 		var lock sync.RWMutex
 		client.On("SendTx", mock.Anything, mock.Anything).Return(
 			// build new sig if tx is different
-			// new tx will be delayed
+			func(_ context.Context, tx *solanaGo.Transaction) solanaGo.Signature {
+				strTx := tx.String()
+
+				lock.Lock()
+				// check existence
+				val, exists := txs[strTx]
+				if exists {
+					lock.Unlock()
+					return val
+				}
+				sig := make([]byte, 16)
+				rand.Read(sig)
+				txs[strTx] = solanaGo.SignatureFromBytes(sig)
+				lock.Unlock()
+
+				// don't lock on delay
+				// delay every new bumping tx
+				time.Sleep(txRetryDuration / 3)
+
+				lock.RLock()
+				defer lock.RUnlock()
+				return txs[strTx]
+			},
+			nil,
+		)
+		testRunner(t, client)
+	})
+
+	t.Run("overlapping bumping tx", func(t *testing.T) {
+		client := clientmocks.NewReaderWriter(t)
+		// client mock
+		txs := map[string]solanaGo.Signature{}
+		var lock sync.RWMutex
+		client.On("SendTx", mock.Anything, mock.Anything).Return(
+			// build new sig if tx is different
 			func(_ context.Context, tx *solanaGo.Transaction) solanaGo.Signature {
 				strTx := tx.String()
 
@@ -131,10 +171,22 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 				sig := make([]byte, 16)
 				rand.Read(sig)
 				txs[strTx] = solanaGo.SignatureFromBytes(sig)
+
+				triggerDelay := len(txs) == 2
 				lock.Unlock()
 
 				// don't lock on delay
-				time.Sleep(txRetryDuration / 3)
+				// only delay on the first bump tx
+				// ------------------------------
+				// init tx - no delay
+				// rebroadcast - no delay (tx + sig already exists, does not reach this point)
+				// first bump tx - DELAY
+				// rebroadcast bump tx - no delay (tx + sig already exists, does not reach this point)
+				// second bump tx - no delay
+				// etc
+				if triggerDelay {
+					time.Sleep(txRetryDuration * 2 / 3)
+				}
 
 				lock.RLock()
 				defer lock.RUnlock()
@@ -142,19 +194,37 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 			},
 			nil,
 		)
+		testRunner(t, client)
+	})
 
-		// build minimal txm
-		txm := NewTxm("retry_race", getClient, cfg, ks, lggr)
-		txm.fee = fee
+	t.Run("bumping tx errors and ctx cleans up waitgroup blocks", func(t *testing.T) {
+		client := clientmocks.NewReaderWriter(t)
+		// client mock - first tx is always successful
+		tx0 := NewTestTx()
+		require.NoError(t, fees.SetComputeUnitPrice(&tx0, 0))
+		tx0.Signatures = make([]solanaGo.Signature, 1)
+		client.On("SendTx", mock.Anything, &tx0).Return(solanaGo.Signature{1}, nil)
 
-		_, _, _, err := txm.sendWithRetry(
-			utils.Context(t),
-			tx,
-			txRetryDuration,
-		)
-		require.NoError(t, err)
+		// init bump tx fails, rebroadcast is successful
+		tx1 := NewTestTx()
+		require.NoError(t, fees.SetComputeUnitPrice(&tx1, 1))
+		tx1.Signatures = make([]solanaGo.Signature, 1)
+		client.On("SendTx", mock.Anything, &tx1).Return(solanaGo.Signature{}, fmt.Errorf("BUMP FAILED")).Once()
+		client.On("SendTx", mock.Anything, &tx1).Return(solanaGo.Signature{2}, nil)
 
-		time.Sleep(txRetryDuration / 4 * 5) // wait 1.25x longer of tx life to capture all logs
-		assert.Equal(t, observer.FilterLevelExact(zapcore.ErrorLevel).Len(), 0)
+		// init bump tx success, rebroadcast fails
+		tx2 := NewTestTx()
+		require.NoError(t, fees.SetComputeUnitPrice(&tx2, 2))
+		tx2.Signatures = make([]solanaGo.Signature, 1)
+		client.On("SendTx", mock.Anything, &tx2).Return(solanaGo.Signature{3}, nil).Once()
+		client.On("SendTx", mock.Anything, &tx2).Return(solanaGo.Signature{}, fmt.Errorf("REBROADCAST FAILED"))
+
+		// always successful
+		tx3 := NewTestTx()
+		require.NoError(t, fees.SetComputeUnitPrice(&tx3, 4))
+		tx3.Signatures = make([]solanaGo.Signature, 1)
+		client.On("SendTx", mock.Anything, &tx3).Return(solanaGo.Signature{4}, nil)
+
+		testRunner(t, client)
 	})
 }

--- a/pkg/solana/txm/utils.go
+++ b/pkg/solana/txm/utils.go
@@ -129,8 +129,12 @@ func (s *signatureList) Set(index int, sig solana.Signature) error {
 	return nil
 }
 
-func (s *signatureList) Wait(index int) {
+func (s *signatureList) Wait(index int) *sync.WaitGroup {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	if index < len(s.wg) {
-		s.wg[index].Wait()
+		return s.wg[index]
 	}
+
+	return &sync.WaitGroup{} // return empty waitgroup if index doesn't exist
 }

--- a/pkg/solana/txm/utils_test.go
+++ b/pkg/solana/txm/utils_test.go
@@ -54,7 +54,7 @@ func TestSignatureList_AllocateWaitSet(t *testing.T) {
 	assert.ErrorContains(t, sigs.Set(0, solana.Signature{1}), "trying to set signature when already set")
 
 	// waitgroup does not block on invalid index
-	sigs.Wait(100000)
+	sigs.Wait(100000).Wait()
 
 	// waitgroup blocks between allocate and set
 	ind1 := sigs.Allocate()
@@ -65,8 +65,8 @@ func TestSignatureList_AllocateWaitSet(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		sigs.Wait(ind1)
-		sigs.Wait(ind2)
+		sigs.Wait(ind1).Wait()
+		sigs.Wait(ind2).Wait()
 		wg.Done()
 	}()
 	assert.NoError(t, sigs.Set(ind2, solana.Signature{1}))

--- a/pkg/solana/txm/utils_test.go
+++ b/pkg/solana/txm/utils_test.go
@@ -54,7 +54,7 @@ func TestSignatureList_AllocateWaitSet(t *testing.T) {
 	assert.ErrorContains(t, sigs.Set(0, solana.Signature{1}), "trying to set signature when already set")
 
 	// waitgroup does not block on invalid index
-	sigs.Wait(100000).Wait()
+	sigs.Wait(100000)
 
 	// waitgroup blocks between allocate and set
 	ind1 := sigs.Allocate()
@@ -65,8 +65,8 @@ func TestSignatureList_AllocateWaitSet(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		sigs.Wait(ind1).Wait()
-		sigs.Wait(ind2).Wait()
+		sigs.Wait(ind1)
+		sigs.Wait(ind2)
 		wg.Done()
 	}()
 	assert.NoError(t, sigs.Set(ind2, solana.Signature{1}))

--- a/pkg/solana/txm/utils_test.go
+++ b/pkg/solana/txm/utils_test.go
@@ -1,6 +1,7 @@
 package txm
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/gagliardetto/solana-go"
@@ -37,4 +38,38 @@ func TestSortSignaturesAndResults(t *testing.T) {
 	assert.Equal(t, solana.Signature{3}, sig[1])
 	assert.Equal(t, solana.Signature{0}, sig[2])
 	assert.Equal(t, solana.Signature{2}, sig[3])
+}
+
+func TestSignatureList_AllocateWaitSet(t *testing.T) {
+	sigs := signatureList{}
+	assert.Equal(t, 0, sigs.Length())
+
+	// can't set without pre-allocating
+	assert.ErrorContains(t, sigs.Set(0, solana.Signature{}), "invalid index")
+
+	// can't set on index that has already been set
+	assert.Equal(t, 0, sigs.Allocate())
+	assert.Equal(t, 1, sigs.Length())
+	assert.NoError(t, sigs.Set(0, solana.Signature{1}))
+	assert.ErrorContains(t, sigs.Set(0, solana.Signature{1}), "trying to set signature when already set")
+
+	// waitgroup does not block on invalid index
+	sigs.Wait(100000)
+
+	// waitgroup blocks between allocate and set
+	ind1 := sigs.Allocate()
+	assert.Equal(t, 1, ind1)
+	ind2 := sigs.Allocate()
+	assert.Equal(t, 2, ind2)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		sigs.Wait(ind1)
+		sigs.Wait(ind2)
+		wg.Done()
+	}()
+	assert.NoError(t, sigs.Set(ind2, solana.Signature{1}))
+	assert.NoError(t, sigs.Set(ind1, solana.Signature{1}))
+	wg.Wait()
 }


### PR DESCRIPTION
adding test case for checking race condition in broadcasting and tracking signatures

there are two types of txs:
* (type 1) first bumped tx which saves the tx signature to the tracking list
* (type 2) follow up txs that rebroadcast the bumped tx and compare the rebroadcast sig to the one in the list

there are a few race conditions that can occur depending on client response times (broadcasting pattern is type 1 -> X of type 2 -> type 1 again -> repeat until timeout
* type 1 returns quickly, type 2 returns slowly, new type 1 is broadcast: this mixes up which index is used to check the signature against. Solution: use bump count as the index
* type 1 returns slowly, type 2 returns quickly: the rebroadcast txs return before the original bumped tx. the signature is not present when the type 2 txs need to check against it. Solution: use a waitgroup to which will cause the comparison to wait until the type 1 tx returns and saves the signature
* first type 1 returns slowly, type 2 returns normally, new type 1 returns quickly: this can mix up the order of signatures in the list. Solution: instead of using `append()` allocate an index and set.