### PR TITLE
BCF-2441: remove ChainSet concept

### DIFF
--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -7,8 +7,6 @@ import (
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 )
 
-type ChainSet = types.ChainSet[string, Chain]
-
 type Chain interface {
 	types.ChainService
 


### PR DESCRIPTION
BCF-2440 removed Chainset from core. This types is no longer used and can be removed