### PR TITLE
Pin upload artifact version to latest stable tag

### DIFF
--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -47,7 +47,7 @@ runs:
       run: anchor build
       working-directory: contracts
     - name: Upload Artifacts
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: artifacts
         path: contracts/target/deploy

--- a/.github/workflows/gauntlet.yml
+++ b/.github/workflows/gauntlet.yml
@@ -67,7 +67,7 @@ jobs:
       - run: nix develop -c yarn --cwd ./gauntlet eslint
       - name: Upload eslint report
         if: always()
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: gauntlet-eslint-report
           path: ./gauntlet/eslint-report.json

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
         run: nix develop -c make lint-go-integration-tests
       - name: Store lint report artifact
         if: always()
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: golangci-lint-integration-tests-report
           path: ./integration-tests/golangci-lint-integration-tests-report.xml
@@ -37,7 +37,7 @@ jobs:
         run: nix develop -c make lint-go-relay
       - name: Store lint report artifact
         if: always()
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: golangci-lint-relay-report
           path: ./pkg/golangci-lint-relay-report.xml

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -30,7 +30,7 @@ jobs:
         run: go test ./pkg/... -v -race -count=10 -timeout=15m -covermode=atomic -coverpkg=./... -coverprofile=race_coverage.txt
       - name: Upload Go test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: go-relay-test-results
           path: |


### PR DESCRIPTION
we were using the `master` tag for the build artifacts action and the code on master for the upload-artifact repo currently does not work. So pinning to the latest stable v3.x.x