### PR TITLE
fix: flakiness on parallel solana-test-validator operation

### DIFF
--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/onsi/gomega v1.30.0
 	github.com/rs/zerolog v1.30.0
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240213113935-001c2f4befd4
-	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240213123942-a5eff1e0a897
+	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240213161921-c4d342b761b0
 	github.com/smartcontractkit/chainlink-testing-framework v1.23.2
-	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240213151604-a92e5ecf8750
-	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240213151604-a92e5ecf8750
+	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240213180344-28b53e52609c
+	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240213180344-28b53e52609c
 	github.com/smartcontractkit/libocr v0.0.0-20240112202000-6359502d2ff1
 	github.com/stretchr/testify v1.8.4
 	github.com/testcontainers/testcontainers-go v0.23.0

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1407,10 +1407,10 @@ github.com/smartcontractkit/chainlink-testing-framework v1.23.2 h1:haXPd9Pg++Zs5
 github.com/smartcontractkit/chainlink-testing-framework v1.23.2/go.mod h1:StIOdxvwd8AMO6xuBtmD6FQfJXktEn/mJJEr7728BTc=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868/go.mod h1:Kn1Hape05UzFZ7bOUnm3GVsHzP0TNrVmpfXYNHdqGGs=
-github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240213151604-a92e5ecf8750 h1:mZXxWEm9GhTafnUJ3XjoxWI+xxhKul353X7xA2CAhf4=
-github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240213151604-a92e5ecf8750/go.mod h1:5QB8sGqla9SpXvBsQA2GcEyTvWrJgVclwZp1sLTmWx0=
-github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240213151604-a92e5ecf8750 h1:/GbWVQ+9hMnaUrIyhvYwMlQP/E9GHkduk4bjtDt0asA=
-github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240213151604-a92e5ecf8750/go.mod h1:XWlIlZ3Fsba2TRXSthI6e5ROLXF0MVHTX3DP0lj0/gk=
+github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240213180344-28b53e52609c h1:ug+FBXMbbBwpKIxWEnShIrFmI7WIsa2maDiMnPmPpSk=
+github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240213180344-28b53e52609c/go.mod h1:QU4anRctCTeJfeyLtIeRwwfXsh6V6k6FyGkeexN+IiI=
+github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240213180344-28b53e52609c h1:U3idXk41zJvLQ4rZ9ZXtetE8BByAgw5mWfwTCUMHu2g=
+github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240213180344-28b53e52609c/go.mod h1:KG1g0btrbUIDxu/imypYtte8KKOANY6NSuOmIFTC+oQ=
 github.com/smartcontractkit/go-plugin v0.0.0-20231003134350-e49dad63b306 h1:ko88+ZznniNJZbZPWAvHQU8SwKAdHngdDZ+pvVgB5ss=
 github.com/smartcontractkit/go-plugin v0.0.0-20231003134350-e49dad63b306/go.mod h1:w1sAEES3g3PuV/RzUrgow20W2uErMly84hhD3um1WL4=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f h1:hgJif132UCdjo8u43i7iPN1/MFnu49hv7lFGFftCHKU=

--- a/pkg/solana/client/test_helpers.go
+++ b/pkg/solana/client/test_helpers.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bytes"
-	"context"
 	"os/exec"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 // SetupLocalSolNode sets up a local solana node via solana cli, and returns the url
@@ -24,6 +24,7 @@ func SetupLocalSolNode(t *testing.T) string {
 		"--reset",
 		"--rpc-port", port,
 		"--faucet-port", faucetPort,
+		"--ledger", t.TempDir(),
 	)
 	var stdErr bytes.Buffer
 	cmd.Stderr = &stdErr
@@ -34,7 +35,7 @@ func SetupLocalSolNode(t *testing.T) string {
 		assert.NoError(t, cmd.Process.Kill())
 		if err2 := cmd.Wait(); assert.Error(t, err2) {
 			if !assert.Contains(t, err2.Error(), "signal: killed", cmd.ProcessState.String()) {
-				t.Log("solana-test-validator stderr:", stdErr.String())
+				t.Logf("solana-test-validator\n stdout: %s\n stderr: %s", stdOut.String(), stdErr.String())
 			}
 		}
 	})
@@ -44,7 +45,7 @@ func SetupLocalSolNode(t *testing.T) string {
 	for i := 0; i < 30; i++ {
 		time.Sleep(time.Second)
 		client := rpc.New(url)
-		out, err := client.GetHealth(context.Background())
+		out, err := client.GetHealth(tests.Context(t))
 		if err != nil || out != rpc.HealthOk {
 			t.Logf("API server not ready yet (attempt %d)\n", i+1)
 			continue


### PR DESCRIPTION
Problem: test flakiness start occurring after upgrading solana image for relay tests
```
test_helpers_test.go:37: 
        	Error Trace:	/home/runner/work/chainlink-solana/chainlink-solana/pkg/solana/client/test_helpers_test.go:37
        	            				/home/runner/work/chainlink-solana/chainlink-solana/pkg/solana/client/test_helpers_test.go:48
        	Error:      	Received unexpected error:
        	            	rpc call getBalance() on http://127.0.0.1:46261/: Post "http://127.0.0.1:46261/": dial tcp 127.0.0.1:46261: connect: connection refused
        	Test:       	TestSetupLocalSolNode_SimultaneousNetworks
    test_helpers.go:69: 
        	Error Trace:	/home/runner/work/chainlink-solana/chainlink-solana/pkg/solana/client/test_helpers.go:69
        	            				/home/runner/work/chainlink-solana/chainlink-solana/pkg/solana/client/test_helpers_test.go:40
        	            				/home/runner/work/chainlink-solana/chainlink-solana/pkg/solana/client/test_helpers_test.go:48
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestSetupLocalSolNode_SimultaneousNetworks
```

Solution:
* test validator should point to own directories instead of potentially waiting on the same directory and racing to use/delete it