### PR TITLE
BCF-3015 Add Configuration for Encoding

### DIFF
--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -120,7 +120,7 @@ func (s *SolanaChainReaderService) init(namespaces map[string]config.ChainReader
 				return err
 			}
 
-			idlCodec, err := codec.NewIDLCodec(idl)
+			idlCodec, err := codec.NewIDLCodec(idl, config.BuilderForEncoding(method.Encoding))
 			if err != nil {
 				return err
 			}

--- a/pkg/solana/codec/solana.go
+++ b/pkg/solana/codec/solana.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/codec"
 	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings"
-	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings/binary"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
@@ -62,11 +61,11 @@ func NewNamedModifierCodec(original types.RemoteCodec, itemType string, modifier
 }
 
 // NewIDLCodec is for Anchor custom types
-func NewIDLCodec(idl IDL) (encodings.CodecFromTypeCodec, error) {
+func NewIDLCodec(idl IDL, builder encodings.Builder) (encodings.CodecFromTypeCodec, error) {
 	accounts := make(map[string]encodings.TypeCodec)
 
 	refs := &codecRefs{
-		builder:      binary.LittleEndian(),
+		builder:      builder,
 		codecs:       make(map[string]encodings.TypeCodec),
 		typeDefs:     idl.Types,
 		dependencies: make(map[string][]string),

--- a/pkg/solana/codec/solana_test.go
+++ b/pkg/solana/codec/solana_test.go
@@ -11,6 +11,7 @@ import (
 
 	codeccommon "github.com/smartcontractkit/chainlink-common/pkg/codec"
 	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings"
+	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings/binary"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
@@ -113,7 +114,7 @@ func TestNewIDLCodec_CircularDependency(t *testing.T) {
 		t.FailNow()
 	}
 
-	_, err := codec.NewIDLCodec(idl)
+	_, err := codec.NewIDLCodec(idl, binary.LittleEndian())
 
 	assert.ErrorIs(t, err, types.ErrInvalidConfig)
 }
@@ -127,7 +128,7 @@ func newTestIDLAndCodec(t *testing.T) (string, codec.IDL, encodings.CodecFromTyp
 		t.FailNow()
 	}
 
-	entry, err := codec.NewIDLCodec(idl)
+	entry, err := codec.NewIDLCodec(idl, binary.LittleEndian())
 	if err != nil {
 		t.Logf("failed to create new codec from test IDL: %s", err.Error())
 		t.FailNow()

--- a/pkg/solana/config/chain_reader.go
+++ b/pkg/solana/config/chain_reader.go
@@ -1,6 +1,14 @@
 package config
 
-import "github.com/smartcontractkit/chainlink-common/pkg/codec"
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/codec"
+	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings"
+	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings/binary"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+)
 
 type ChainReader struct {
 	Namespaces map[string]ChainReaderMethods `json:"namespaces" toml:"namespaces"`
@@ -11,29 +19,71 @@ type ChainReaderMethods struct {
 }
 
 type ChainDataReader struct {
-	AnchorIDL  string                 `json:"anchorIDL" toml:"anchorIDL"`
+	AnchorIDL string `json:"anchorIDL" toml:"anchorIDL"`
+	// Encoding defines the type of encoding used for on-chain data. Currently supported
+	// are 'borsh' and 'bincode'.
+	Encoding   EncodingType           `json:"encoding" toml:"encoding"`
 	Procedures []ChainReaderProcedure `json:"procedures" toml:"procedures"`
 }
 
-type ProcedureType int
+type EncodingType int
 
 const (
-	ProcedureTypeInternal ProcedureType = iota
-	ProcedureTypeAnchor
+	EncodingTypeBorsh EncodingType = iota
+	EncodingTypeBincode
+
+	encodingTypeBorshStr   = "borsh"
+	encodingTypeBincodeStr = "bincode"
 )
+
+func (t EncodingType) MarshalJSON() ([]byte, error) {
+	switch t {
+	case EncodingTypeBorsh:
+		return json.Marshal(encodingTypeBorshStr)
+	case EncodingTypeBincode:
+		return json.Marshal(encodingTypeBincodeStr)
+	default:
+		return nil, fmt.Errorf("%w: unrecognized encoding type: %d", types.ErrInvalidConfig, t)
+	}
+}
+
+func (t *EncodingType) UnmarshalJSON(data []byte) error {
+	var str string
+
+	if err := json.Unmarshal(data, &str); err != nil {
+		return fmt.Errorf("%w: %s", types.ErrInvalidConfig, err.Error())
+	}
+
+	switch str {
+	case encodingTypeBorshStr:
+		*t = EncodingTypeBorsh
+	case encodingTypeBincodeStr:
+		*t = EncodingTypeBincode
+	default:
+		return fmt.Errorf("%w: unrecognized encoding type: %s", types.ErrInvalidConfig, str)
+	}
+
+	return nil
+}
 
 type ChainReaderProcedure chainDataProcedureFields
 
 type chainDataProcedureFields struct {
 	// IDLAccount refers to the account defined in the IDL.
-	IDLAccount string `json:"idlAccount"`
-	// Type describes the procedure type to use such as internal for static values,
-	// anchor-read for using an anchor generated IDL to read values from an account,
-	// or custom structure for reading from a native account. Currently, only anchor
-	// reads are supported, but the type is a placeholder to allow internal functions
-	// to be run apart from anchor reads.
-	Type ProcedureType `json:"type"`
+	IDLAccount string `json:"idlAccount,omitempty"`
 	// OutputModifications provides modifiers to convert chain data format to custom
 	// output formats.
 	OutputModifications codec.ModifiersConfig `json:"outputModifications,omitempty"`
+}
+
+// BuilderForEncoding returns a builder for the encoding configuration. Defaults to little endian.
+func BuilderForEncoding(eType EncodingType) encodings.Builder {
+	switch eType {
+	case EncodingTypeBorsh:
+		return binary.LittleEndian()
+	case EncodingTypeBincode:
+		return binary.BigEndian()
+	default:
+		return binary.LittleEndian()
+	}
 }

--- a/pkg/solana/config/chain_reader_test.go
+++ b/pkg/solana/config/chain_reader_test.go
@@ -1,0 +1,118 @@
+package config_test
+
+import (
+	_ "embed"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	codeccommon "github.com/smartcontractkit/chainlink-common/pkg/codec"
+	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings/binary"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec/testutils"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
+)
+
+//go:embed testChainReader_valid.json
+var validJSON string
+
+//go:embed testChainReader_invalid.json
+var invalidJSON string
+
+func TestChainReaderConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid unmarshal", func(t *testing.T) {
+		t.Parallel()
+
+		var result config.ChainReader
+		require.NoError(t, json.Unmarshal([]byte(validJSON), &result))
+		assert.Equal(t, validChainReaderConfig, result)
+	})
+
+	t.Run("invalid unmarshal", func(t *testing.T) {
+		t.Parallel()
+
+		var result config.ChainReader
+		require.ErrorIs(t, json.Unmarshal([]byte(invalidJSON), &result), types.ErrInvalidConfig)
+	})
+
+	t.Run("marshal", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := json.Marshal(validChainReaderConfig)
+
+		require.NoError(t, err)
+
+		var conf config.ChainReader
+
+		require.NoError(t, json.Unmarshal(result, &conf))
+		assert.Equal(t, validChainReaderConfig, conf)
+	})
+}
+
+func TestEncodingType_Fail(t *testing.T) {
+	t.Parallel()
+
+	_, err := json.Marshal(config.EncodingType(100))
+
+	require.NotNil(t, err)
+
+	var tp config.EncodingType
+
+	require.ErrorIs(t, json.Unmarshal([]byte(`42`), &tp), types.ErrInvalidConfig)
+	require.ErrorIs(t, json.Unmarshal([]byte(`"invalid"`), &tp), types.ErrInvalidConfig)
+}
+
+func TestBuilderForEncoding_Default(t *testing.T) {
+	t.Parallel()
+
+	builder := config.BuilderForEncoding(config.EncodingType(100))
+	require.Equal(t, binary.LittleEndian(), builder)
+}
+
+var validChainReaderConfig = config.ChainReader{
+	Namespaces: map[string]config.ChainReaderMethods{
+		"Contract": {
+			Methods: map[string]config.ChainDataReader{
+				"Method": {
+					AnchorIDL: "test idl 1",
+					Encoding:  config.EncodingTypeBorsh,
+					Procedures: []config.ChainReaderProcedure{
+						{
+							IDLAccount: testutils.TestStructWithNestedStruct,
+						},
+					},
+				},
+				"MethodWithOpts": {
+					AnchorIDL: "test idl 2",
+					Encoding:  config.EncodingTypeBorsh,
+					Procedures: []config.ChainReaderProcedure{
+						{
+							IDLAccount: testutils.TestStructWithNestedStruct,
+							OutputModifications: codeccommon.ModifiersConfig{
+								&codeccommon.PropertyExtractorConfig{FieldName: "DurationVal"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"OtherContract": {
+			Methods: map[string]config.ChainDataReader{
+				"Method": {
+					AnchorIDL: "test idl 3",
+					Encoding:  config.EncodingTypeBincode,
+					Procedures: []config.ChainReaderProcedure{
+						{
+							IDLAccount: testutils.TestStructWithNestedStruct,
+						},
+					},
+				},
+			},
+		},
+	},
+}

--- a/pkg/solana/config/testChainReader_invalid.json
+++ b/pkg/solana/config/testChainReader_invalid.json
@@ -1,0 +1,15 @@
+{
+  "namespaces": {
+    "Contract": {
+      "methods": {
+        "Method": {
+          "anchorIDL": "test idl 1",
+          "encoding": "invalid",
+          "procedures": [{
+            "idlAccount": "StructWithNestedStruct"
+          }]
+        }
+      }
+    }
+  }
+}

--- a/pkg/solana/config/testChainReader_valid.json
+++ b/pkg/solana/config/testChainReader_valid.json
@@ -1,0 +1,37 @@
+{
+  "namespaces": {
+    "Contract": {
+      "methods": {
+        "Method": {
+          "anchorIDL": "test idl 1",
+          "encoding": "borsh",
+          "procedures": [{
+            "idlAccount": "StructWithNestedStruct"
+          }]
+        },
+        "MethodWithOpts": {
+          "anchorIDL": "test idl 2",
+          "encoding": "borsh",
+          "procedures": [{
+            "idlAccount": "StructWithNestedStruct",
+            "outputModifications": [{
+              "Type": "extract property",
+              "FieldName": "DurationVal"
+            }]
+          }]
+        }
+      }
+    },
+    "OtherContract": {
+      "methods": {
+        "Method": {
+          "anchorIDL": "test idl 3",
+          "encoding": "bincode",
+          "procedures": [{
+            "idlAccount": "StructWithNestedStruct"
+          }]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Solana allows multiple encoding types for account data. This commit adds support for
two encoding types `borsh` and `bincode`.