### PR TITLE
Add discriminator to the account and allow encoding/decoding of non-account types

### DIFF
--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -187,7 +187,7 @@ func (s *SolanaChainReaderService) init(namespaces map[string]config.ChainReader
 				return err
 			}
 
-			idlCodec, err := codec.NewIDLCodec(idl, config.BuilderForEncoding(method.Encoding))
+			idlCodec, err := codec.NewIDLAccountCodec(idl, config.BuilderForEncoding(method.Encoding))
 			if err != nil {
 				return err
 			}

--- a/pkg/solana/chainreader/chain_reader_test.go
+++ b/pkg/solana/chainreader/chain_reader_test.go
@@ -271,7 +271,7 @@ func newTestIDLAndCodec(t *testing.T) (string, codec.IDL, types.RemoteCodec) {
 		t.FailNow()
 	}
 
-	entry, err := codec.NewIDLCodec(idl, binary.LittleEndian())
+	entry, err := codec.NewIDLAccountCodec(idl, binary.LittleEndian())
 	if err != nil {
 		t.Logf("failed to create new codec from test IDL: %s", err.Error())
 		t.FailNow()
@@ -328,6 +328,7 @@ type mockedRPCCall struct {
 	delay time.Duration
 }
 
+// TODO BCI-3156 use a localnet for testing instead of a mock.
 type mockedRPCClient struct {
 	mu                sync.Mutex
 	responseByAddress map[string]mockedRPCCall
@@ -722,7 +723,7 @@ func makeTestCodec(t *testing.T, rawIDL string, encoding config.EncodingType) ty
 		t.FailNow()
 	}
 
-	testCodec, err := codec.NewIDLCodec(idl, config.BuilderForEncoding(encoding))
+	testCodec, err := codec.NewIDLAccountCodec(idl, config.BuilderForEncoding(encoding))
 	if err != nil {
 		t.Logf("failed to create new codec from test IDL: %s", err.Error())
 		t.FailNow()

--- a/pkg/solana/codec/discriminator.go
+++ b/pkg/solana/codec/discriminator.go
@@ -1,0 +1,71 @@
+package codec
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"reflect"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+)
+
+const discriminatorLength = 8
+
+func NewDiscriminator(name string) encodings.TypeCodec {
+	sum := sha256.Sum256([]byte("account:" + name))
+	return &discriminator{hashPrefix: sum[:discriminatorLength]}
+}
+
+type discriminator struct {
+	hashPrefix []byte
+}
+
+func (d discriminator) Encode(value any, into []byte) ([]byte, error) {
+	if value == nil {
+		return append(into, d.hashPrefix...), nil
+	}
+
+	raw, ok := value.(*[]byte)
+	if !ok {
+		return nil, fmt.Errorf("%w: value must be a byte slice got %T", types.ErrInvalidType, value)
+	}
+
+	// inject if not specified
+	if raw == nil {
+		return append(into, d.hashPrefix...), nil
+	}
+
+	// Not sure if we should really be encoding accounts...
+	if !bytes.Equal(*raw, d.hashPrefix) {
+		return nil, fmt.Errorf("%w: invalid discriminator expected %x got %x", types.ErrInvalidType, d.hashPrefix, raw)
+	}
+
+	return append(into, *raw...), nil
+}
+
+func (d discriminator) Decode(encoded []byte) (any, []byte, error) {
+	raw, remaining, err := encodings.SafeDecode(encoded, discriminatorLength, func(raw []byte) []byte { return raw })
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !bytes.Equal(raw, d.hashPrefix) {
+		return nil, nil, fmt.Errorf("%w: invalid discriminator expected %x got %x", types.ErrInvalidEncoding, d.hashPrefix, raw)
+	}
+
+	return &raw, remaining, nil
+}
+
+func (d discriminator) GetType() reflect.Type {
+	// Pointer type so that nil can inject values and so that the NamedCodec won't wrap with no-nil pointer.
+	return reflect.TypeOf(&[]byte{})
+}
+
+func (d discriminator) Size(_ int) (int, error) {
+	return discriminatorLength, nil
+}
+
+func (d discriminator) FixedSize() (int, error) {
+	return discriminatorLength, nil
+}

--- a/pkg/solana/codec/discriminator_test.go
+++ b/pkg/solana/codec/discriminator_test.go
@@ -1,0 +1,83 @@
+package codec_test
+
+import (
+	"crypto/sha256"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
+)
+
+func TestDiscriminator(t *testing.T) {
+	t.Run("encode and decode return the discriminator", func(t *testing.T) {
+		tmp := sha256.Sum256([]byte("account:Foo"))
+		expected := tmp[:8]
+		c := codec.NewDiscriminator("Foo")
+		encoded, err := c.Encode(&expected, nil)
+		require.NoError(t, err)
+		require.Equal(t, expected, encoded)
+		actual, remaining, err := c.Decode(encoded)
+		require.NoError(t, err)
+		require.Equal(t, &expected, actual)
+		require.Len(t, remaining, 0)
+	})
+
+	t.Run("encode returns an error if the discriminator is invalid", func(t *testing.T) {
+		c := codec.NewDiscriminator("Foo")
+		_, err := c.Encode(&[]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}, nil)
+		require.True(t, errors.Is(err, types.ErrInvalidType))
+	})
+
+	t.Run("encode injects the discriminator if it's not provided", func(t *testing.T) {
+		tmp := sha256.Sum256([]byte("account:Foo"))
+		expected := tmp[:8]
+		c := codec.NewDiscriminator("Foo")
+		encoded, err := c.Encode(nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, expected, encoded)
+		encoded, err = c.Encode((*[]byte)(nil), nil)
+		require.NoError(t, err)
+		require.Equal(t, expected, encoded)
+	})
+
+	t.Run("decode returns an error if the encoded value is too short", func(t *testing.T) {
+		c := codec.NewDiscriminator("Foo")
+		_, _, err := c.Decode([]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06})
+		require.True(t, errors.Is(err, types.ErrInvalidEncoding))
+	})
+
+	t.Run("decode returns an error if the discriminator is invalid", func(t *testing.T) {
+		c := codec.NewDiscriminator("Foo")
+		_, _, err := c.Decode([]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07})
+		require.True(t, errors.Is(err, types.ErrInvalidEncoding))
+	})
+
+	t.Run("encode returns an error if the value is not a byte slice", func(t *testing.T) {
+		c := codec.NewDiscriminator("Foo")
+		_, err := c.Encode(42, nil)
+		require.True(t, errors.Is(err, types.ErrInvalidType))
+	})
+
+	t.Run("GetType returns the type of the discriminator", func(t *testing.T) {
+		c := codec.NewDiscriminator("Foo")
+		require.Equal(t, reflect.TypeOf(&[]byte{}), c.GetType())
+	})
+
+	t.Run("Size returns the length of the discriminator", func(t *testing.T) {
+		c := codec.NewDiscriminator("Foo")
+		size, err := c.Size(0)
+		require.NoError(t, err)
+		require.Equal(t, 8, size)
+	})
+
+	t.Run("FixedSize returns the length of the discriminator", func(t *testing.T) {
+		c := codec.NewDiscriminator("Foo")
+		size, err := c.FixedSize()
+		require.NoError(t, err)
+		require.Equal(t, 8, size)
+	})
+}

--- a/pkg/solana/codec/testutils/testIDL.json
+++ b/pkg/solana/codec/testutils/testIDL.json
@@ -78,6 +78,79 @@
   ],
   "types": [
     {
+      "name": "StructWithNestedStructType",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "u8"
+          },
+          {
+            "name": "innerStruct",
+            "type": {
+              "defined": "ObjectRef1"
+            }
+          },
+          {
+            "name": "basicNestedArray",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u32",
+                    3
+                  ]
+                },
+                3
+              ]
+            }
+          },
+          {
+            "name": "option",
+            "type": {
+              "option": "string"
+            }
+          },
+          {
+            "name": "definedArray",
+            "type": {
+              "array": [
+                {
+                  "defined": "ObjectRef2"
+                },
+                2
+              ]
+            }
+          },
+          {
+            "name": "basicVector",
+            "type": {
+              "vec": "string"
+            }
+          },
+          {
+            "name": "timeVal",
+            "type": "unixTimestamp"
+          },
+          {
+            "name": "durationVal",
+            "type": "duration"
+          },
+          {
+            "name": "publicKey",
+            "type": "publicKey"
+          },
+          {
+            "name": "enumVal",
+            "type": {
+              "defined": "SimpleEnum"
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "ObjectRef1",
       "type": {
         "kind": "struct",

--- a/pkg/solana/codec/testutils/types.go
+++ b/pkg/solana/codec/testutils/types.go
@@ -9,9 +9,10 @@ import (
 )
 
 var (
-	TestStructWithNestedStruct = "StructWithNestedStruct"
-	DefaultStringRef           = "test string"
-	DefaultTestStruct          = StructWithNestedStruct{
+	TestStructWithNestedStruct     = "StructWithNestedStruct"
+	TestStructWithNestedStructType = "StructWithNestedStructType"
+	DefaultStringRef               = "test string"
+	DefaultTestStruct              = StructWithNestedStruct{
 		Value: 80,
 		InnerStruct: ObjectRef1{
 			Prop1: 10,


### PR DESCRIPTION
When an account is stored from an Anchor contract on Solana, a discriminator is added as the first 8 bytes to ensure that the right data is being loaded.  This was missed when decoding the account.

Additionally, users can define types and should be able to encode them to either sign or write to chain. This PR adds that ability as well.