### PR TITLE
SOM: bump common + add in fee exporter

### DIFF
--- a/cmd/monitoring/main.go
+++ b/cmd/monitoring/main.go
@@ -98,9 +98,14 @@ func main() {
 		logger.With(log, "component", "solana-prome-exporter"),
 		metrics.NewReportObservations(logger.With(log, "component", promMetrics)),
 	)
+	feesFactory := exporter.NewFeesFactory(
+		logger.With(log, "component", "solana-prome-exporter"),
+		metrics.NewFees(logger.With(log, "component", promMetrics)),
+	)
 	monitor.ExporterFactories = append(monitor.ExporterFactories,
 		feedBalancesExporterFactory,
 		reportObservationsFactory,
+		feesFactory,
 	)
 
 	// network exporters

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240422215914-3b758c48e596
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240425211313-03c74da4bc22
 	github.com/smartcontractkit/libocr v0.0.0-20240326191951-2bbe9382d052
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240422215914-3b758c48e596 h1:Wo+i2cPSO8eBQ3wgJFi1rBuh01n4yHcVZTkb1hYXti4=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240422215914-3b758c48e596/go.mod h1:GTDBbovHUSAUk+fuGIySF2A/whhdtHGaWmU61BoERks=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240425211313-03c74da4bc22 h1:8UgyBgGjlwY4aw5W/Ztk5yg9z+8Z5u4OiIM0aS3Ll2U=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240425211313-03c74da4bc22/go.mod h1:GTDBbovHUSAUk+fuGIySF2A/whhdtHGaWmU61BoERks=
 github.com/smartcontractkit/go-plugin v0.0.0-20231003134350-e49dad63b306 h1:ko88+ZznniNJZbZPWAvHQU8SwKAdHngdDZ+pvVgB5ss=
 github.com/smartcontractkit/go-plugin v0.0.0-20231003134350-e49dad63b306/go.mod h1:w1sAEES3g3PuV/RzUrgow20W2uErMly84hhD3um1WL4=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f h1:hgJif132UCdjo8u43i7iPN1/MFnu49hv7lFGFftCHKU=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/onsi/gomega v1.30.0
 	github.com/rs/zerolog v1.30.0
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240424132620-add4946c1c73
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240425211313-03c74da4bc22
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58
 	github.com/smartcontractkit/chainlink-testing-framework v1.28.4
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240424234616-7ec1d5b7abb5

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1412,8 +1412,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240424132620-add4946c1c73 h1:54hM3/SrOM166it2K35hGb5K7gQ49/Op0aHp9WkqpqU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240424132620-add4946c1c73/go.mod h1:GTDBbovHUSAUk+fuGIySF2A/whhdtHGaWmU61BoERks=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240425211313-03c74da4bc22 h1:8UgyBgGjlwY4aw5W/Ztk5yg9z+8Z5u4OiIM0aS3Ll2U=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240425211313-03c74da4bc22/go.mod h1:GTDBbovHUSAUk+fuGIySF2A/whhdtHGaWmU61BoERks=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240419213354-ea34a948e2ee h1:eFuBKyEbL2b+eyfgV/Eu9+8HuCEev+IcBi+K9l1dG7g=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240419213354-ea34a948e2ee/go.mod h1:uATrrJ8IsuBkOBJ46USuf73gz9gZy5k5bzGE5/ji/rc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/pkg/monitoring/types/txdetails.go
+++ b/pkg/monitoring/types/txdetails.go
@@ -16,9 +16,9 @@ import (
 var (
 	TxDetailsType = "txdetails"
 
-	ReportObservationMetric = "sol_report_observations"
-	TxFeeMetric             = "sol_tx_fee"
-	ComputeUnitPriceMetric  = "sol_tx_compute_unit_price"
+	ReportObservationMetric = "report_observations"
+	TxFeeMetric             = "tx_fee"
+	ComputeUnitPriceMetric  = "tx_compute_unit_price"
 
 	TxDetailsMetrics = []string{
 		ReportObservationMetric,


### PR DESCRIPTION
- bump `chainlink-common` for networkMonitor fix
- add in missing fee exporter