### PR TITLE
Use Docker Run Instead of GHA container image for node 16 shutdown

### DIFF
--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Docker run
       if: ${{ inputs.image != '' && inputs.image-version != '' }}
       shell: bash
-      run: docker run -v $(pwd):/repo projectserum/build:v0.27.0 bash -c "/repo/scripts/build-contract-artifacts-action.sh \"${GITHUB_WORKSPACE}\""
+      run: docker run -v $(pwd):/repo projectserum/build:v0.27.0 bash -c "/repo/scripts/build-contract-artifacts-action.sh"
 
     # should be used again after moving from projectserum/build to backpackapp/build
     - name: Install latest Git version (>= 2.18.0) for actions/checkout

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Docker run
       if: ${{ inputs.image != '' && inputs.image-version != '' }}
       shell: bash
-      run: docker run -v $(pwd):/repo projectserum/build:v0.27.0 bash -c "/repo/scripts/build-contract-artifacts-action.sh"
+      run: docker run -v $(pwd):/repo projectserum/build:v0.27.0 bash -c "/repo/scripts/build-contract-artifacts-action.sh \"${GITHUB_WORKSPACE}\""
 
     # should be used again after moving from projectserum/build to backpackapp/build
     - name: Install latest Git version (>= 2.18.0) for actions/checkout

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -32,7 +32,7 @@ runs:
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Checkout solana
       if: ${{ inputs.image == "" && inputs.image-version == "" }}
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       with:
         repository: smartcontractkit/chainlink-solana
         ref: ${{ inputs.ref }}

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -4,11 +4,24 @@ inputs:
   ref:
     required: false
     description: The chainlink-solana ref to use
+  image:
+    required: false
+    description: docker image to use to build
+  image-version:
+    required: false
+    description: docker image version/tag to use for build
 
 runs:
   using: composite
   steps:
+    - name: Docker run
+      if: ${{ inputs.image != "" && inputs.image-version != "" }}
+      shell: bash
+      run: docker run -v $(pwd):/repo projectserum/build:v0.27.0 bash -c "/repo/scripts/build-contract-artifacts-action.sh"
+
+    # should be used again after moving from projectserum/build to backpackapp/build
     - name: Install latest Git version (>= 2.18.0) for actions/checkout
+      if: ${{ inputs.image == "" && inputs.image-version == "" }}
       shell: bash
       run: |
         apt-get update
@@ -17,35 +30,41 @@ runs:
         apt update
         apt install git -y
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - name: Checkout solana
+      if: ${{ inputs.image == "" && inputs.image-version == "" }}
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       with:
         repository: smartcontractkit/chainlink-solana
         ref: ${{ inputs.ref }}
     - name: Setup go
+      if: ${{ inputs.image == "" && inputs.image-version == "" }}
       uses: actions/setup-go@v4
       with:
         go-version-file: "go.mod"
         check-latest: true
-    - name: yarn install
-      shell: bash
-      run: yarn install --frozen-lockfile
     - name: Generate build artifacts for go bindings check
+      if: ${{ inputs.image == "" && inputs.image-version == "" }}
       shell: bash
       run: anchor build
       working-directory: contracts
     - name: Check generated go bindings are up to date
+      if: ${{ inputs.image == "" && inputs.image-version == "" }}
       shell: bash
       run: |
         go install github.com/gagliardetto/anchor-go@v0.2.3
         ./scripts/anchor-go-gen.sh
         git diff --stat --exit-code
     - name: Generate program_ids
+      if: ${{ inputs.image == "" && inputs.image-version == "" }}
       shell: bash
       run: ./scripts/programs-keys-gen.sh
     - name: Generate build artifacts with custom program_ids
+      if: ${{ inputs.image == "" && inputs.image-version == "" }}
       shell: bash
       run: anchor build
       working-directory: contracts
+
+    #save the contracts artifacts
     - name: Upload Artifacts
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -14,14 +14,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Docker run
-      if: ${{ inputs.image != '' && inputs.image-version != '' }}
-      shell: bash
-      run: docker run -v $(pwd):/repo projectserum/build:v0.27.0 bash -c "/repo/scripts/build-contract-artifacts-action.sh"
-
-    # should be used again after moving from projectserum/build to backpackapp/build
+    - name: Checkout solana
+      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      with:
+        repository: smartcontractkit/chainlink-solana
+        ref: ${{ inputs.ref }}
     - name: Install latest Git version (>= 2.18.0) for actions/checkout
-      if: ${{ inputs.image == '' && inputs.image-version  == '' }}
       shell: bash
       run: |
         apt-get update
@@ -30,12 +28,36 @@ runs:
         apt update
         apt install git -y
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - name: Checkout solana
-      if: ${{ inputs.image  == '' && inputs.image-version  == '' }}
-      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      with:
-        repository: smartcontractkit/chainlink-solana
-        ref: ${{ inputs.ref }}
+
+    # temporary docker run to build artifacts
+    - name: Builder Start
+      if: ${{ inputs.image != '' && inputs.image-version != '' }}
+      env:
+        image: ${{ inputs.image }}
+        image_version: ${{ inputs.image-version }}
+      shell: bash
+      run: docker run -d -v $(pwd):/repo --name build-container "${image}":"${image_version}" tail -f /dev/null
+    - name: Docker build
+      if: ${{ inputs.image != '' && inputs.image-version != '' }}
+      shell: bash
+      run: docker exec -it build-container bash -c "/repo/scripts/build-contract-artifacts-action.sh"
+    - name: Check generated go bindings are up to date
+      if: ${{ inputs.image  != '' && inputs.image-version  != '' }}
+      shell: bash
+      run: git diff --stat --exit-code
+    - name: Docker generate keys and build
+      if: ${{ inputs.image != '' && inputs.image-version != '' }}
+      shell: bash
+      run: |
+        docker exec -it build-container bash -c "\
+        export RUSTUP_HOME=\"/root/.rustup\" &&\
+        cd /repo &&\
+        ./scripts/programs-keys-gen.sh &&\
+        cd ./contracts &&\
+        anchor build"
+
+
+    # should be used again after moving from projectserum/build to backpackapp/build
     - name: Setup go
       if: ${{ inputs.image  == '' && inputs.image-version  == '' }}
       uses: actions/setup-go@v4

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Docker build
       if: ${{ inputs.image != '' && inputs.image-version != '' }}
       shell: bash
-      run: docker exec -it build-container bash -c "/repo/scripts/build-contract-artifacts-action.sh"
+      run: docker exec build-container bash -c "/repo/scripts/build-contract-artifacts-action.sh"
     - name: Check generated go bindings are up to date
       if: ${{ inputs.image  != '' && inputs.image-version  != '' }}
       shell: bash
@@ -40,7 +40,7 @@ runs:
       if: ${{ inputs.image != '' && inputs.image-version != '' }}
       shell: bash
       run: |
-        docker exec -it build-container bash -c "\
+        docker exec build-container bash -c "\
         export RUSTUP_HOME=\"/root/.rustup\" &&\
         cd /repo &&\
         ./scripts/programs-keys-gen.sh &&\

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -15,13 +15,13 @@ runs:
   using: composite
   steps:
     - name: Docker run
-      if: ${{ inputs.image != "" && inputs.image-version != "" }}
+      if: ${{ inputs.image != '' && inputs.image-version != '' }}
       shell: bash
       run: docker run -v $(pwd):/repo projectserum/build:v0.27.0 bash -c "/repo/scripts/build-contract-artifacts-action.sh"
 
     # should be used again after moving from projectserum/build to backpackapp/build
     - name: Install latest Git version (>= 2.18.0) for actions/checkout
-      if: ${{ inputs.image == "" && inputs.image-version == "" }}
+      if: ${{ inputs.image == '' && inputs.image-version  == '' }}
       shell: bash
       run: |
         apt-get update
@@ -31,35 +31,35 @@ runs:
         apt install git -y
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Checkout solana
-      if: ${{ inputs.image == "" && inputs.image-version == "" }}
+      if: ${{ inputs.image  == '' && inputs.image-version  == '' }}
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       with:
         repository: smartcontractkit/chainlink-solana
         ref: ${{ inputs.ref }}
     - name: Setup go
-      if: ${{ inputs.image == "" && inputs.image-version == "" }}
+      if: ${{ inputs.image  == '' && inputs.image-version  == '' }}
       uses: actions/setup-go@v4
       with:
         go-version-file: "go.mod"
         check-latest: true
     - name: Generate build artifacts for go bindings check
-      if: ${{ inputs.image == "" && inputs.image-version == "" }}
+      if: ${{ inputs.image  == '' && inputs.image-version  == '' }}
       shell: bash
       run: anchor build
       working-directory: contracts
     - name: Check generated go bindings are up to date
-      if: ${{ inputs.image == "" && inputs.image-version == "" }}
+      if: ${{ inputs.image  == '' && inputs.image-version  == '' }}
       shell: bash
       run: |
         go install github.com/gagliardetto/anchor-go@v0.2.3
         ./scripts/anchor-go-gen.sh
         git diff --stat --exit-code
     - name: Generate program_ids
-      if: ${{ inputs.image == "" && inputs.image-version == "" }}
+      if: ${{ inputs.image  == '' && inputs.image-version  == '' }}
       shell: bash
       run: ./scripts/programs-keys-gen.sh
     - name: Generate build artifacts with custom program_ids
-      if: ${{ inputs.image == "" && inputs.image-version == "" }}
+      if: ${{ inputs.image  == '' && inputs.image-version  == '' }}
       shell: bash
       run: anchor build
       working-directory: contracts

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -21,36 +21,35 @@ runs:
         ref: ${{ inputs.ref }}
 
     # temporary docker run to build artifacts
-    - name: Builder Start
+    - name: Docker Builder
       if: ${{ inputs.image != '' && inputs.image-version != '' }}
       env:
         image: ${{ inputs.image }}
         image_version: ${{ inputs.image-version }}
       shell: bash
-      run: docker run -d -v $(pwd):/repo --name build-container "${image}":"${image_version}" tail -f /dev/null
-    - name: Docker build
-      if: ${{ inputs.image != '' && inputs.image-version != '' }}
-      shell: bash
-      run: docker exec build-container bash -c "/repo/scripts/build-contract-artifacts-action.sh"
-    - name: Check generated go bindings are up to date
-      if: ${{ inputs.image  != '' && inputs.image-version  != '' }}
-      shell: bash
-      run: git diff --stat --exit-code
-    - name: Docker generate keys and build
-      if: ${{ inputs.image != '' && inputs.image-version != '' }}
-      shell: bash
       run: |
+        # start container
+        docker run -d -v $(pwd):/repo --name build-container "${image}":"${image_version}" tail -f /dev/null
+        # generate go bindings
         docker exec build-container bash -c "\
-        export RUSTUP_HOME=\"/root/.rustup\" &&\
-        cd /repo &&\
-        ./scripts/programs-keys-gen.sh &&\
-        cd ./contracts &&\
-        anchor build"
+          chown -R $(id -u):$(id -g) /repo &&\
+          /repo/scripts/build-contract-artifacts-action.sh"
+        # check go bindings
+        git diff --stat --exit-code
+        # build with keys
+        docker exec build-container bash -c "\
+          export RUSTUP_HOME=\"/root/.rustup\" &&\
+          cd /repo &&\
+          ./scripts/programs-keys-gen.sh &&\
+          cd ./contracts &&\
+          anchor build &&\
+          chown -R $(id -u):$(id -g) /repo"
+        # clean up the container
         docker stop build-container
         docker rm build-container
-    - name: Adjust permissions for artifacts
-      if: ${{ inputs.image != '' && inputs.image-version != '' }}
-      run: chmod -R 644 ./contracts/target/deploy/
+        # fix upload permissions
+        # chown -R $(whoami):$(whoami) ./contracts/target/deploy/
+        # chmod -R 644 ./contracts/target/deploy/
 
 
     # should be used again after moving from projectserum/build to backpackapp/build

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -46,6 +46,12 @@ runs:
         ./scripts/programs-keys-gen.sh &&\
         cd ./contracts &&\
         anchor build"
+        docker stop build-container
+        docker rm build-container
+    - name: Adjust permissions for artifacts
+      if: ${{ inputs.image != '' && inputs.image-version != '' }}
+      run: chmod -R 644 ./contracts/target/deploy/
+
 
     # should be used again after moving from projectserum/build to backpackapp/build
     - name: Install latest Git version (>= 2.18.0) for actions/checkout

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -31,9 +31,7 @@ runs:
         # start container
         docker run -d -v $(pwd):/repo --name build-container "${image}":"${image_version}" tail -f /dev/null
         # generate go bindings
-        docker exec build-container bash -c "\
-          chown -R $(id -u):$(id -g) /repo &&\
-          /repo/scripts/build-contract-artifacts-action.sh"
+        docker exec build-container bash -c "/repo/scripts/build-contract-artifacts-action.sh"
         # check go bindings
         git diff --stat --exit-code
         # build with keys
@@ -47,10 +45,6 @@ runs:
         # clean up the container
         docker stop build-container
         docker rm build-container
-        # fix upload permissions
-        # chown -R $(whoami):$(whoami) ./contracts/target/deploy/
-        # chmod -R 644 ./contracts/target/deploy/
-
 
     # should be used again after moving from projectserum/build to backpackapp/build
     - name: Install latest Git version (>= 2.18.0) for actions/checkout

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -19,15 +19,6 @@ runs:
       with:
         repository: smartcontractkit/chainlink-solana
         ref: ${{ inputs.ref }}
-    - name: Install latest Git version (>= 2.18.0) for actions/checkout
-      shell: bash
-      run: |
-        apt-get update
-        apt-get install software-properties-common -y
-        add-apt-repository ppa:git-core/ppa
-        apt update
-        apt install git -y
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     # temporary docker run to build artifacts
     - name: Builder Start
@@ -56,8 +47,17 @@ runs:
         cd ./contracts &&\
         anchor build"
 
-
     # should be used again after moving from projectserum/build to backpackapp/build
+    - name: Install latest Git version (>= 2.18.0) for actions/checkout
+      if: ${{ inputs.image  == '' && inputs.image-version  == '' }}
+      shell: bash
+      run: |
+        apt-get update
+        apt-get install software-properties-common -y
+        add-apt-repository ppa:git-core/ppa
+        apt update
+        apt install git -y
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Setup go
       if: ${{ inputs.image  == '' && inputs.image-version  == '' }}
       uses: actions/setup-go@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -16,7 +16,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Get ProjectSerum Version
         id: psversion
         uses: ./.github/actions/projectserum_version
@@ -24,14 +24,16 @@ jobs:
     name: Release Artifacts
     runs-on: ubuntu-latest
     needs: [get_projectserum_version]
-    container:
-      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
-      env:
-        RUSTUP_HOME: "/root/.rustup"
+    # container:
+    #   image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
+    #   env:
+    #     RUSTUP_HOME: "/root/.rustup"
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build Artifacts
-        run: anchor build
+        env:
+          psversion: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
+        run: docker run -v $(pwd):/repo projectserum/build:${psversion} bash -c "anchor build"
       - name: Generate archive
         run: |
           tar cfvz artifacts.tar.gz target/deploy/*.so target/idl/*

--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build Artifacts
         env:
           psversion: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
-        run: docker run -v $(pwd):/repo projectserum/build:${psversion} bash -c "anchor build"
+        run: docker run -v $(pwd):/repo projectserum/build:"${psversion}"" bash -c "anchor build"
       - name: Generate archive
         run: |
           tar cfvz artifacts.tar.gz target/deploy/*.so target/idl/*

--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Build Artifacts
         env:
           psversion: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
-        run: docker run -v $(pwd):/repo projectserum/build:"${psversion}"" bash -c "anchor build"
+        run: |
+          docker run -v $(pwd):/repo projectserum/build:"${psversion}" bash -c "\
+            anchor build &&\
+            chown -R $(id -u):$(id -g) /repo"
       - name: Generate archive
         run: |
           tar cfvz artifacts.tar.gz target/deploy/*.so target/idl/*

--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           psversion: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
         run: |
-          docker run -v $(pwd):/repo projectserum/build:"${psversion}" bash -c "\
+          docker run -v "$(pwd)":/repo projectserum/build:"${psversion}" bash -c "\
             anchor build &&\
             chown -R $(id -u):$(id -g) /repo"
       - name: Generate archive

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -55,16 +55,19 @@ jobs:
       contents: read
     runs-on: ubuntu-latest-32cores-128GB
     needs: [get_projectserum_version]
-    container:
-      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
-      env:
-        RUSTUP_HOME: "/root/.rustup"
-        FORCE_COLOR: 1
+    # container:
+    #   image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
+    #   env:
+    #     RUSTUP_HOME: "/root/.rustup"
+    #     FORCE_COLOR: 1
     steps:
       - name: Checkout the repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
+        with:
+          image: projectserum/build
+          image-version: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
 
   e2e_custom_build_custom_chainlink_image:
     name: E2E Custom Build Custom CL Image

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Setup go
         uses: actions/setup-go@v3
         with:
@@ -42,7 +42,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Get ProjectSerum Version
         id: psversion
         uses: ./.github/actions/projectserum_version
@@ -62,7 +62,7 @@ jobs:
     #     FORCE_COLOR: 1
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
         with:
@@ -147,7 +147,7 @@ jobs:
             echo "CUSTOM_CORE_REF=${core_ref}" >> "${GITHUB_ENV}"
           fi
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/e2e_testnet_daily.yml
+++ b/.github/workflows/e2e_testnet_daily.yml
@@ -141,10 +141,10 @@ jobs:
         get_solana_sha,
       ]
     container:
-      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
-      env:
-        RUSTUP_HOME: "/root/.rustup"
-        FORCE_COLOR: 1
+      # image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
+      # env:
+      #   RUSTUP_HOME: "/root/.rustup"
+      #   FORCE_COLOR: 1
     steps:
       - name: Collect Metrics
         if: needs.changes.outputs.src == 'true'
@@ -165,9 +165,11 @@ jobs:
           ref: ${{ needs.get_solana_sha.outputs.sha }}
       - name: Build contracts
         if: needs.changes.outputs.src == 'true' && needs.solana-test-image-exists.outputs.exists == 'false'
-        uses: smartcontractkit/chainlink-solana/.github/actions/build_contract_artifacts@21675b3a7dcdff8e790391708d4763020cace21e # stable action on December 18 2023
+        uses: ./.github/actions/build_contract_artifacts
         with:
           ref: ${{ needs.get_solana_sha.outputs.sha }}
+          image: projectserum/build
+          image-version: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
 
   e2e_custom_build_custom_chainlink_image:
     name: E2E Custom Build Custom CL Image

--- a/.github/workflows/gauntlet.yml
+++ b/.github/workflows/gauntlet.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       nodejs_version: ${{ steps.tool-versions.outputs.nodejs_version }}
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - uses: smartcontractkit/tool-versions-to-env-action@v1.0.8
         id: tool-versions
 
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tool_versions]
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Setup Node ${{ needs.tool_versions.outputs.nodejs_version }}
         uses: actions/setup-node@v2
         with:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tool_versions]
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Setup Node ${{ needs.tool_versions.outputs.nodejs_version }}
         uses: actions/setup-node@v2
         with:
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tool_versions]
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Setup Node ${{ needs.tool_versions.outputs.nodejs_version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -20,7 +20,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Get ProjectSerum Version
         id: psversion
         uses: ./.github/actions/projectserum_version
@@ -40,7 +40,7 @@ jobs:
     #     FORCE_COLOR: 1
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
         with:
@@ -66,7 +66,7 @@ jobs:
           this-job-name: Publish Integration Test Image
         continue-on-error: true
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Build Image

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -33,16 +33,19 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     needs: [get-projectserum-version]
-    container:
-      image: projectserum/build:${{ needs.get-projectserum-version.outputs.projectserum_version }}
-      env:
-        RUSTUP_HOME: "/root/.rustup"
-        FORCE_COLOR: 1
+    # container:
+    #   image: projectserum/build:${{ needs.get-projectserum-version.outputs.projectserum_version }}
+    #   env:
+    #     RUSTUP_HOME: "/root/.rustup"
+    #     FORCE_COLOR: 1
     steps:
       - name: Checkout the repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
+        with:
+          image: projectserum/build
+          image-version: ${{ needs.get-projectserum-version.outputs.projectserum_version }}
 
   publish-integration-test-image:
     environment: integration

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Run actionlint
         uses: reviewdog/action-actionlint@7556c222a14ff4583c0f772caeb7f65bb3816dc1 # v1.34.0

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Setup go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get_projectserum_version]
     container:
-      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
-      env:
-        RUSTUP_HOME: "/root/.rustup"
-        FORCE_COLOR: 1
+      # image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
+      # env:
+      #   RUSTUP_HOME: "/root/.rustup"
+      #   FORCE_COLOR: 1
 
     steps:
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -52,28 +52,51 @@ jobs:
         path: contracts/target
         key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-    - run: solana-keygen new -o id.json --no-bip39-passphrase
-    - name: Compile typescript client
+    - name: run tests
+      env:
+        psversion: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
       run: |
-       cd ../ts
-       yarn install --frozen-lockfile
-       yarn build
-    - run: yarn install --frozen-lockfile
-    - run: anchor test
-    - run: |
-       cd examples/hello-world
-       yarn install --frozen-lockfile
-       anchor test
+        docker run -v "$(pwd)/../":/repo projectserum/build:"${psversion}" bash -c "\
+          set -eoux pipefail &&\
+          RUSTUP_HOME=\"/root/.rustup\" &&\
+          FORCE_COLOR=1 &&\
+          cd /repo/contracts &&\
+          solana-keygen new -o id.json --no-bip39-passphrase &&\
+          cd /repo/ts &&\
+          yarn install --frozen-lockfile &&\
+          yarn build &&\
+          cd /repo/contracts &&\
+          yarn install --frozen-lockfile &&\
+          anchor test &&\
+          cd /repo/examples/hello-world &&\
+          yarn install --frozen-lockfile &&\
+          anchor test"
+
+    # - run: solana-keygen new -o id.json --no-bip39-passphrase
+    # - name: Compile typescript client
+    #   run: |
+    #    cd ../ts
+    #    yarn install --frozen-lockfile
+    #    yarn build
+    # - name: anchor test contracts
+    #   run: |
+    #     yarn install --frozen-lockfile
+    #     anchor test
+    # - name: anchor test hello-world
+    #   run: |
+    #    cd examples/hello-world
+    #    yarn install --frozen-lockfile
+    #    anchor test
 
   rust_lint:
     name: Rust Lint
     runs-on: ubuntu-latest
     needs: [get_projectserum_version]
     container:
-      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
-      env:
-        RUSTUP_HOME: "/root/.rustup"
-        FORCE_COLOR: 1
+      # image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
+      # env:
+      #   RUSTUP_HOME: "/root/.rustup"
+      #   FORCE_COLOR: 1
 
     steps:
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -95,5 +118,17 @@ jobs:
         path: contracts/target
         key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-    - run: cargo check
-    - run: cargo clippy -- -D warnings
+    - name: cargo check
+      env:
+        psversion: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
+      run: |
+        docker run -v "$(pwd)/../":/repo projectserum/build:"${psversion}" bash -c "\
+          set -eoux pipefail &&\
+          RUSTUP_HOME=\"/root/.rustup\" &&\
+          FORCE_COLOR=1 &&\
+          cd /repo/contracts &&\
+          cargo check &&\
+          cargo clippy -- -D warnings"
+    
+    # - run: cargo check
+    # - run: cargo clippy -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,7 @@ jobs:
           cd /repo/contracts &&\
           yarn install --frozen-lockfile &&\
           anchor test &&\
-          cd /repo/examples/hello-world &&\
+          cd /repo/contracts/examples/hello-world &&\
           yarn install --frozen-lockfile &&\
           anchor test"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Get ProjectSerum Version
         id: psversion
         uses: ./.github/actions/projectserum_version
@@ -33,7 +33,7 @@ jobs:
         FORCE_COLOR: 1
 
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: Cache cargo registry
       uses: actions/cache@v2.1.7
       with:
@@ -76,7 +76,7 @@ jobs:
         FORCE_COLOR: 1
 
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: Cache cargo registry
       uses: actions/cache@v2.1.7
       with:

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -67,17 +67,20 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     needs: [get_projectserum_version, test-image-exists]
-    container:
-      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
-      env:
-        RUSTUP_HOME: "/root/.rustup"
-        FORCE_COLOR: 1
+    # container:
+    #   image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
+    #   env:
+    #     RUSTUP_HOME: "/root/.rustup"
+    #     FORCE_COLOR: 1
     steps:
       - name: Checkout the repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Build contracts
         if: needs.test-image-exists.outputs.exists == 'false'
         uses: ./.github/actions/build_contract_artifacts
+        with:
+          image: projectserum/build
+          image-version: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
 
   soak_testing_build_custom_chainlink_image:
     name: Soak Testing Build Custom Chainlink Image

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -34,7 +34,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Get ProjectSerum Version
         id: psversion
         uses: ./.github/actions/projectserum_version
@@ -74,7 +74,7 @@ jobs:
     #     FORCE_COLOR: 1
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build contracts
         if: needs.test-image-exists.outputs.exists == 'false'
         uses: ./.github/actions/build_contract_artifacts
@@ -130,7 +130,7 @@ jobs:
       SELECTED_NETWORKS: SIMULATED
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           ref: ${{ env.REF_NAME }}
       - name: Build Test Image

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BIN_DIR = bin
 export GOPATH ?= $(shell go env GOPATH)
 export GO111MODULE ?= on
-export PROJECT_SERUM_VERSION ?=v0.25.0
+export PROJECT_SERUM_VERSION ?=v0.27.0
 export PROJECT_SERUM_IMAGE ?= projectserum/build:$(PROJECT_SERUM_VERSION)
 
 LINUX=LINUX

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BIN_DIR = bin
 export GOPATH ?= $(shell go env GOPATH)
 export GO111MODULE ?= on
-export PROJECT_SERUM_VERSION ?=v0.27.0
+export PROJECT_SERUM_VERSION ?=v0.25.0
 export PROJECT_SERUM_IMAGE ?= projectserum/build:$(PROJECT_SERUM_VERSION)
 
 LINUX=LINUX

--- a/scripts/build-contract-artifacts-action.sh
+++ b/scripts/build-contract-artifacts-action.sh
@@ -41,11 +41,11 @@ cd "${REPO}"
 ./scripts/anchor-go-gen.sh
 
 # check if the go interfaces have changed
-git diff --stat --exit-code
+# git diff --stat --exit-code
 
-# generate program keys
-./scripts/programs-keys-gen.sh
+# # generate program keys
+# ./scripts/programs-keys-gen.sh
 
-# build the contracts with updated keys
-cd "${CONTRACTS}"
-anchor build
+# # build the contracts with updated keys
+# cd "${CONTRACTS}"
+# anchor build

--- a/scripts/build-contract-artifacts-action.sh
+++ b/scripts/build-contract-artifacts-action.sh
@@ -26,7 +26,7 @@ add-apt-repository ppa:git-core/ppa
 apt update
 apt install git -y
 cd "${REPO}"
-git config --global --add safe.directory "$1"
+git config --global --add safe.directory "${REPO}"
 
 # install achor-go
 go install github.com/gagliardetto/anchor-go@v0.2.3

--- a/scripts/build-contract-artifacts-action.sh
+++ b/scripts/build-contract-artifacts-action.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -eoux pipefail
+
+export RUSTUP_HOME="/root/.rustup"
+export FORCE_COLOR=1
+
+WORKDIR=$(pwd)
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO=${SCRIPT_DIR}/../
+CONTRACTS=${REPO}/contracts
+
+yarndir=$(which yarn)
+
+function printthepaths () {
+    cd "${REPO}"
+    echo "yarn: "
+    which yarn || true
+    echo "go: "
+    which go || true
+    echo "anchor: "
+    which anchor || true
+    echo "anchor-go: "
+    which anchor-go || true
+    cd "${WORKDIR}"
+}
+
+# install go
+apt-get update
+apt-get install -y wget
+wget https://golang.org/dl/go1.21.7.linux-amd64.tar.gz
+tar -xvf go1.21.7.linux-amd64.tar.gz
+mv go /usr/local
+export PATH=/usr/local/go/bin:$PATH
+export GOPATH=$HOME/go
+export GOBIN=$GOPATH/bin
+export PATH=$GOBIN:$PATH
+go version
+
+# install git
+apt-get install software-properties-common -y
+add-apt-repository ppa:git-core/ppa
+apt update
+apt install git -y
+
+# install achor-go
+go install github.com/gagliardetto/anchor-go@v0.2.3
+
+# initial build
+cd "${CONTRACTS}"
+yarn install --frozen-lockfile
+anchor build
+
+# generate contract artifacts
+cd "${REPO}"
+./scripts/anchor-go-gen.sh
+
+# check if the go interfaces have changed
+git diff --stat --exit-code
+
+# generate program keys
+./scripts/programs-keys-gen.sh
+
+# build the contracts with updated keys
+cd "${CONTRACTS}"
+anchor build

--- a/scripts/build-contract-artifacts-action.sh
+++ b/scripts/build-contract-artifacts-action.sh
@@ -39,13 +39,3 @@ anchor build
 # generate contract artifacts
 cd "${REPO}"
 ./scripts/anchor-go-gen.sh
-
-# check if the go interfaces have changed
-# git diff --stat --exit-code
-
-# # generate program keys
-# ./scripts/programs-keys-gen.sh
-
-# # build the contracts with updated keys
-# cd "${CONTRACTS}"
-# anchor build

--- a/scripts/build-contract-artifacts-action.sh
+++ b/scripts/build-contract-artifacts-action.sh
@@ -4,25 +4,9 @@ set -eoux pipefail
 export RUSTUP_HOME="/root/.rustup"
 export FORCE_COLOR=1
 
-WORKDIR=$(pwd)
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO=${SCRIPT_DIR}/../
 CONTRACTS=${REPO}/contracts
-
-yarndir=$(which yarn)
-
-function printthepaths () {
-    cd "${REPO}"
-    echo "yarn: "
-    which yarn || true
-    echo "go: "
-    which go || true
-    echo "anchor: "
-    which anchor || true
-    echo "anchor-go: "
-    which anchor-go || true
-    cd "${WORKDIR}"
-}
 
 # install go
 apt-get update
@@ -41,6 +25,8 @@ apt-get install software-properties-common -y
 add-apt-repository ppa:git-core/ppa
 apt update
 apt install git -y
+cd "${REPO}"
+git config --global --add safe.directory "$1"
 
 # install achor-go
 go install github.com/gagliardetto/anchor-go@v0.2.3


### PR DESCRIPTION
This temporarily gets around node 16 shutdown causing this to break starting 5/13/2024
If the update to the backpackapp/build is done before Monday then this can be closed and or reverted.