### PR TITLE
Fix failure when there are go test issues that do not create -json logs

### DIFF
--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -21,6 +21,7 @@ jobs:
           hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           this-job-name: Relay Run Unit Tests
           test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
+        continue-on-error: true
       - name: Checkout sources
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Setup go
@@ -42,7 +43,9 @@ jobs:
       - name: Build
         run: go build -v ./pkg/...
       - name: Test
-        run: go test ./pkg/... -json -tags integration -covermode=atomic -coverpkg=./... -coverprofile=integration_coverage.txt 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci
+        run: |
+          set -o pipefail
+          go test ./pkg/... -json -tags integration -covermode=atomic -coverpkg=./... -coverprofile=integration_coverage.txt 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci
       - name: Test with the race detector enabled
         run: go test ./pkg/... -v -race -count=10 -timeout=15m -covermode=atomic -coverpkg=./... -coverprofile=race_coverage.txt
       - name: Upload Go test results
@@ -51,5 +54,6 @@ jobs:
         with:
           name: go-relay-test-results
           path: |
+            /tmp/gotest.log
             ./race_coverage.txt
             ./integration_coverage.txt


### PR DESCRIPTION
- metrics collection failure should not fail pipeline
- when go test fails, its exit code should fail the step when it pipes its output to other tools