### PR TITLE
Bumping the setup-github-token action to version 0.2.1

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup GitHub Token
         if: '!steps.check.outputs.skip'
         id: token
-        uses: smartcontractkit/.github/actions/setup-github-token@7ac9af09dda8c553593d2153a975b43b6958fa9f # setup-github-token@0.1.2
+        uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_SOLANA_CICD_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.AWS_RELENG_TEAM_GATI_LAMBDA_URL }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,3 +16,6 @@
 
 # monitoring ownership
 /pkg/monitoring @smartcontractkit/realtime
+
+# CI/CD
+/.github/** @smartcontractkit/releng


### PR DESCRIPTION
## What

- Bumping the setup-github-token action to version 0.2.1 
- Adding code owners for the RelEng team

Ticket: https://smartcontract-it.atlassian.net/browse/RE-1943

## Why

The [setup-github-token](https://github.com/smartcontractkit/.github/blob/main/actions/setup-github-token/action.yml) action should have a role session name parameter which it passes to the configure-aws-credentials step.