### PR TITLE
[Do Not Merge] fix: transmitter queuing error wrap

### DIFF
--- a/pkg/solana/transmitter.go
+++ b/pkg/solana/transmitter.go
@@ -84,8 +84,10 @@ func (c *Transmitter) Transmit(
 
 	// pass transmit payload to tx manager queue
 	c.lggr.Debugf("Queuing transmit tx: state (%s) + transmissions (%s)", c.stateID.String(), c.transmissionsID.String())
-	err = c.txManager.Enqueue(c.stateID.String(), tx)
-	return fmt.Errorf("error on Transmit.txManager.Enqueue: %w", err)
+	if err = c.txManager.Enqueue(c.stateID.String(), tx); err != nil {
+		return fmt.Errorf("error on Transmit.txManager.Enqueue: %w", err)
+	}
+	return nil
 }
 
 func (c *Transmitter) LatestConfigDigestAndEpoch(


### PR DESCRIPTION
branched from an earlier point to match branch point used in v2.13.0-rc0

(pointing to RC commit because new changes have been introduced since)
core ref: 63ad1cc553687bc8fc86e638527fc803b79ca739