### PR TITLE
fix: use correct WS url within tests

### DIFF
--- a/integration-tests/common/test_common.go
+++ b/integration-tests/common/test_common.go
@@ -238,9 +238,9 @@ func (m *OCRv2TestState) DeployContracts(contractsDir string) {
 
 // CreateJobs creating OCR jobs and EA stubs
 func (m *OCRv2TestState) CreateJobs() {
-	// Setting up RPC
-	c := rpc.New(*m.Config.TestConfig.Common.RPCURL)
-	wsc, err := ws.Connect(testcontext.Get(m.Config.T), *m.Config.TestConfig.Common.WsURL)
+	// Setting up RPC used for external network funding
+	c := rpc.New(m.Common.ChainDetails.RPCURLExternal)
+	wsc, err := ws.Connect(testcontext.Get(m.Config.T), m.Common.ChainDetails.WSURLExternal)
 	require.NoError(m.Config.T, err, "Error connecting to websocket client")
 
 	relayConfig := job.JSONConfig{


### PR DESCRIPTION
### Description

Fix e2e test errors related to:

```
Error Trace:	/home/runner/work/chainlink/chainlink/integration-tests/common/test_common.go:244 
        	            				/home/runner/work/chainlink/chainlink/integration-tests/smoke/ocr2_test.go:126 
        	Error:      	Received unexpected error: 
        	            	new ws client: dial: websocket: bad handshake 
        	Test:       	TestSolanaOCRV2Smoke/embedded 
        	Messages:   	Error connecting to websocket client
```

### Resolves Dependencies
- https://github.com/smartcontractkit/chainlink/pull/13728