### PR TITLE
fix: contract release workflow

### DIFF
--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -31,6 +31,7 @@ jobs:
           psversion: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
         run: |
           docker run -v "$(pwd)":/repo backpackapp/build:"${psversion}" bash -c "\
+            cd /repo &&\
             anchor build &&\
             chown -R $(id -u):$(id -g) /repo"
       - name: Generate archive


### PR DESCRIPTION
quick fix that points the command to the correct folder - otherwise it starts in the `/` rather than `/repo`

example test run: https://github.com/smartcontractkit/chainlink-solana/actions/runs/10185531634 (skips certain steps to not create actual release)