### PR TITLE
Add missing dependencies to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ ifeq ($(OSFLAG),$(OSX))
 	asdf plugin add actionlint || true
 	asdf plugin add shellcheck || true
 	asdf plugin add kubectl || true
+	asdf plugin add yarn || true
+	asdf plugin add golangci-lint || true
+	asdf plugin add mockery || true
 	asdf install
 	go install github.com/smartcontractkit/chainlink-testing-framework/tools/gotestloghelper@latest
 endif

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ ifeq ($(OSFLAG),$(WINDOWS))
 	exit 1
 endif
 ifeq ($(OSFLAG),$(OSX))
+	brew install gpg
 	brew install asdf
 	asdf plugin-add nodejs || true
 	asdf plugin-add rust || true


### PR DESCRIPTION
### Description
Add missing steps to the Makefile when setting up the repository and installing dependencies: `make build`
