### PR TITLE
fix: build test image

### DIFF
--- a/.github/actions/build-test-image/action.yml
+++ b/.github/actions/build-test-image/action.yml
@@ -48,7 +48,7 @@ runs:
       uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/mod-version@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
       with:
         go-project-path: ./integration-tests
-        module-name: github.com/smartcontractkit/chainlink-testing-framework
+        module-name: github.com/smartcontractkit/chainlink-testing-framework/lib
         enforce-semantic-tag: false
     - name: Build and Publish Test Runner
       if: steps.check-image.outputs.exists == 'false'


### PR DESCRIPTION
related to the CTF dependency update: https://github.com/smartcontractkit/chainlink-solana/pull/842
(code was moved from the root directory in CTF to the `/lib` folder)

❌ fixes failing integration test image build on develop: https://github.com/smartcontractkit/chainlink-solana/actions/runs/10740626181/job/29789578547

✅  demonstrated fix: https://github.com/smartcontractkit/chainlink-solana/actions/runs/10741398198/job/29791969141?pr=843