### PR TITLE
update: use anza-xyz agave

### DIFF
--- a/integration-tests/testconfig/default.toml
+++ b/integration-tests/testconfig/default.toml
@@ -38,7 +38,7 @@ inside_k8 = false
 network = "localnet"
 user = "default"
 stateful_db = false
-devnet_image = "solanalabs/solana:v1.18.23"
+devnet_image = "anzaxyz/agave:v1.18.23"
 
 [OCR2]
 node_count = 6

--- a/scripts/install-solana-ci.sh
+++ b/scripts/install-solana-ci.sh
@@ -2,5 +2,5 @@
 
 set -euxo pipefail
 
-sh -c "$(curl -sSfL https://release.solana.com/v1.18.23/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.23/install)"
 echo "PATH=$HOME/.local/share/solana/install/active_release/bin:$PATH" >> $GITHUB_ENV

--- a/scripts/setup-localnet/localnet.sh
+++ b/scripts/setup-localnet/localnet.sh
@@ -11,8 +11,8 @@ container_name="chainlink-solana.test-validator"
 
 echo "Starting $container_name@$container_version"
 
-# NOTE: solanalabs/solana docker image only supports linux/amd64
-# https://hub.docker.com/r/solanalabs/solana/tags
+# NOTE: anzaxyz/agave docker image only supports linux/amd64
+# https://hub.docker.com/r/anzaxyz/agave/tags
 # If you are running on an ARM machine, Following error will be thrown:
 # "Incompatible CPU detected: missing AVX support. Please build from source on the target "
 docker run -d \
@@ -22,7 +22,7 @@ docker run -d \
   -p 127.0.0.1:9900:9900 \
   --name "${container_name}" \
   --entrypoint /bin/sh \
-  "solanalabs/solana:${container_version}" \
+  "anzaxyz/agave:${container_version}" \
   -c "solana-test-validator && echo 'Validator started successfully'"
   # 	--network-alias "${container_name}" \
   # 	--network chainlink \
@@ -46,7 +46,7 @@ do
 
   if [[ $output == *"Incompatible CPU detected"* || $output == *"Aborted"* ]]; then
     echo ""
-    echo "solanalabs/solana docker image only supports linux/amd64"
+    echo "anzaxyz/agave docker image only supports linux/amd64"
     exit 1
   fi
 

--- a/scripts/update-solana.sh
+++ b/scripts/update-solana.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 
-cliVersion=$(grep -oh "release.solana.com/v[0-9]*.[0-9]*.[0-9]*" scripts/install-solana-ci.sh)
+cliVersion=$(grep -oh "release.anza.xyz/v[0-9]*.[0-9]*.[0-9]*" scripts/install-solana-ci.sh)
 echo "Current Test CLI Version: $cliVersion"
 
 cd integration-tests
-testVersion=$(grep -oh "solanalabs/solana:v[0-9]*.[0-9]*.[0-9]*" testconfig/default.toml) 
+testVersion=$(grep -oh "anzaxyz/agave:v[0-9]*.[0-9]*.[0-9]*" testconfig/default.toml) 
 echo "Current E2E Test Version: $testVersion"
 cd ..
 
@@ -15,9 +15,9 @@ echo "Current Version in Localnet Container: $localnetVersion"
 nixVersion=$(grep -oh "version = \"v[0-9]*.[0-9]*.[0-9]*\"" solana.nix)
 echo "Current Version in Nix packages: $nixVersion"
 
-latestTag=$(curl https://api.github.com/repos/solana-labs/solana/releases/latest | jq -r '.tag_name')
-latestVersion="solanalabs/solana:$latestTag"
-latestCLI="release.solana.com/$latestTag"
+latestTag=$(curl https://api.github.com/repos/anza-xyz/agave/releases/latest | jq -r '.tag_name')
+latestVersion="anzaxyz/agave:$latestTag"
+latestCLI="release.anza.xyz/$latestTag"
 latestLocalnet="container_version=$latestTag"
 latestNix="version = \"$latestTag\""
 echo "Latest Solana Mainnet Version: $latestTag"


### PR DESCRIPTION
### Description

solanalabs/solana will be deprecated with the 2.0.X release - migrating to anza-xyz/agave before to be ready for incoming 2.0.X releases