### PR TITLE
bump nix versions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -150,3 +150,7 @@ issues:
       text: "^G404:"
       linters:
         - gosec
+    - path: _test.go
+      text: "G115:" # ignore integer overflow in test conversions
+      linters:
+        - gosec

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723991338,
-        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
+        "lastModified": 1727122398,
+        "narHash": "sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
+        "rev": "30439d93eb8b19861ccbe3e581abf97bdc91b093",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1724206841,
-        "narHash": "sha256-L8dKaX4T3k+TR2fEHCfGbH4UXdspovz/pj87iai9qmc=",
+        "lastModified": 1727317727,
+        "narHash": "sha256-yGYahXzCquyYEgf5GTtvtaN5hXbw20Ok2+o8uVxoaFs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "45e98fbd62c32e5927e952d2833fa1ba4fb35a61",
+        "rev": "a3d832f389606d7dc61a45b244c72ea472d1fcd4",
         "type": "github"
       },
       "original": {

--- a/integration-tests/solclient/deployer.go
+++ b/integration-tests/solclient/deployer.go
@@ -193,7 +193,7 @@ func (c *ContractDeployer) DeployOCRv2Store(billingAC string) (*Store, error) {
 	}, nil
 }
 
-func (c *ContractDeployer) CreateFeed(desc string, decimals uint8, granularity int, liveLength int) error {
+func (c *ContractDeployer) CreateFeed(desc string, decimals uint8, granularity uint8, liveLength uint32) error {
 	payer := c.Client.DefaultWallet
 	programWallet := c.Client.ProgramWallets["store-keypair.json"]
 	feedAccInstruction, err := c.Client.CreateAccInstr(c.Accounts.Feed.PublicKey(), OCRTransmissionsAccountSize, programWallet.PublicKey())
@@ -208,8 +208,8 @@ func (c *ContractDeployer) CreateFeed(desc string, decimals uint8, granularity i
 			store2.NewCreateFeedInstruction(
 				desc,
 				decimals,
-				uint8(granularity),
-				uint32(liveLength),
+				granularity,
+				liveLength,
 				c.Accounts.Feed.PublicKey(),
 				c.Accounts.Owner.PublicKey(),
 			).Build(),

--- a/integration-tests/solclient/ocr2.go
+++ b/integration-tests/solclient/ocr2.go
@@ -171,7 +171,7 @@ func (m *OCRv2) makeDigest() ([]byte, error) {
 		return nil, err
 	}
 	hasher := sha256.New()
-	hasher.Write(append([]byte{}, uint8(proposal.Oracles.Len)))
+	hasher.Write(append([]byte{}, uint8(proposal.Oracles.Len))) //nolint:gosec // number of oracles cannot exceed 225
 	for _, oracle := range proposal.Oracles.Xs[:proposal.Oracles.Len] {
 		hasher.Write(oracle.Signer.Key[:])
 		hasher.Write(oracle.Transmitter.Bytes())
@@ -182,7 +182,7 @@ func (m *OCRv2) makeDigest() ([]byte, error) {
 	hasher.Write(proposal.TokenMint.Bytes())
 	header := make([]byte, 8+4)
 	binary.BigEndian.PutUint64(header, proposal.OffchainConfig.Version)
-	binary.BigEndian.PutUint32(header[8:], uint32(proposal.OffchainConfig.Len))
+	binary.BigEndian.PutUint32(header[8:], uint32(proposal.OffchainConfig.Len)) // nolint:gosec
 	hasher.Write(header)
 	hasher.Write(proposal.OffchainConfig.Xs[:proposal.OffchainConfig.Len])
 	return hasher.Sum(nil), nil
@@ -334,7 +334,7 @@ func (m *OCRv2) proposeConfig(ocConfig contracts.OffChainAggregatorV2Config) err
 		[]solana.Instruction{
 			ocr_2.NewProposeConfigInstruction(
 				oracles,
-				uint8(ocConfig.F),
+				uint8(ocConfig.F), //nolint:gosec // F cannot exceed max oracles (255)
 				m.Proposal.PublicKey(),
 				m.Owner.PublicKey(),
 			).Build(),

--- a/pkg/monitoring/source_envelope.go
+++ b/pkg/monitoring/source_envelope.go
@@ -237,9 +237,9 @@ func getLinkAvailableForPayment(state pkgSolana.State, linkBalance *big.Int) (*b
 	}
 	var countUnpaidRounds, reimbursements uint64 = 0, 0
 	for _, oracle := range oracles {
-		numRounds := int(state.Config.LatestAggregatorRoundID) - int(oracle.FromRoundID)
-		if numRounds < 0 {
-			numRounds = 0
+		numRounds := uint32(0) // prevent overflow if RoundID is larger than latest aggregator RoundID
+		if state.Config.LatestAggregatorRoundID >= oracle.FromRoundID {
+			numRounds = state.Config.LatestAggregatorRoundID - oracle.FromRoundID
 		}
 		countUnpaidRounds += uint64(numRounds)
 		reimbursements += oracle.Payment

--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -327,7 +327,7 @@ func (c *chain) LatestHead(_ context.Context) (types.Head, error) {
 	return types.Head{
 		Height:    strconv.FormatUint(*latestBlock.BlockHeight, 10),
 		Hash:      hashBytes,
-		Timestamp: uint64(latestBlock.BlockTime.Time().Unix()),
+		Timestamp: uint64(latestBlock.BlockTime.Time().Unix()), //nolint:gosec // blocktime will never be negative (pre 1970)
 	}, nil
 }
 

--- a/pkg/solana/client/multinode/multi_node.go
+++ b/pkg/solana/client/multinode/multi_node.go
@@ -90,10 +90,10 @@ func (c *MultiNode[CHAIN_ID, RPC]) ChainID() CHAIN_ID {
 	return c.chainID
 }
 
-func (c *MultiNode[CHAIN_ID, RPC]) DoAll(ctx context.Context, do func(ctx context.Context, rpc RPC, isSendOnly bool)) error {
+func (c *MultiNode[CHAIN_ID, RPC]) DoAll(baseCtx context.Context, do func(ctx context.Context, rpc RPC, isSendOnly bool)) error {
 	var err error
 	ok := c.IfNotStopped(func() {
-		ctx, _ = c.chStop.Ctx(ctx)
+		ctx, _ := c.chStop.Ctx(baseCtx)
 
 		callsCompleted := 0
 		for _, n := range c.primaryNodes {

--- a/pkg/solana/config/config.go
+++ b/pkg/solana/config/config.go
@@ -122,7 +122,7 @@ func (c *Chain) SetDefaults() {
 		c.Commitment = (*string)(&defaultConfigSet.Commitment)
 	}
 	if c.MaxRetries == nil && defaultConfigSet.MaxRetries != nil {
-		i := int64(*defaultConfigSet.MaxRetries)
+		i := int64(*defaultConfigSet.MaxRetries) //nolint:gosec // reasonable default value does not cause overflow
 		c.MaxRetries = &i
 	}
 	if c.FeeEstimatorMode == nil {

--- a/pkg/solana/config/toml.go
+++ b/pkg/solana/config/toml.go
@@ -249,7 +249,7 @@ func (c *TOMLConfig) MaxRetries() *uint {
 	if *c.Chain.MaxRetries < 0 {
 		return nil // interpret negative numbers as nil (prevents unlikely case of overflow)
 	}
-	mr := uint(*c.Chain.MaxRetries)
+	mr := uint(*c.Chain.MaxRetries) //nolint:gosec // overflow check is handled above
 	return &mr
 }
 

--- a/pkg/solana/config_digester.go
+++ b/pkg/solana/config_digester.go
@@ -32,11 +32,11 @@ func (d OffchainConfigDigester) ConfigDigest(cfg types.ContractConfig) (types.Co
 		return digest, err
 	}
 
-	if err := binary.Write(buf, binary.BigEndian, uint32(cfg.ConfigCount)); err != nil {
+	if err := binary.Write(buf, binary.BigEndian, uint32(cfg.ConfigCount)); err != nil { //nolint:gosec // max onchain config count is u32
 		return digest, err
 	}
 
-	if err := binary.Write(buf, binary.BigEndian, uint8(len(cfg.Signers))); err != nil {
+	if err := binary.Write(buf, binary.BigEndian, uint8(len(cfg.Signers))); err != nil { //nolint:gosec // cannot be negative and protocol does not allow more than 255 signers
 		return digest, err
 	}
 
@@ -60,7 +60,7 @@ func (d OffchainConfigDigester) ConfigDigest(cfg types.ContractConfig) (types.Co
 		return digest, err
 	}
 
-	if err := binary.Write(buf, binary.BigEndian, uint32(len(cfg.OnchainConfig))); err != nil {
+	if err := binary.Write(buf, binary.BigEndian, uint32(len(cfg.OnchainConfig))); err != nil { //nolint:gosec // cannot be negative and omax u32 exceeds max onchain config length
 		return digest, err
 	}
 
@@ -72,7 +72,7 @@ func (d OffchainConfigDigester) ConfigDigest(cfg types.ContractConfig) (types.Co
 		return digest, err
 	}
 
-	if err := binary.Write(buf, binary.BigEndian, uint32(len(cfg.OffchainConfig))); err != nil {
+	if err := binary.Write(buf, binary.BigEndian, uint32(len(cfg.OffchainConfig))); err != nil { //nolint:gosec // cannot be negative and max u32 exceeds max offchain config length
 		return digest, err
 	}
 

--- a/pkg/solana/report.go
+++ b/pkg/solana/report.go
@@ -56,7 +56,7 @@ func (c ReportCodec) BuildReport(oo []median.ParsedAttributedObservation) (types
 	binary.BigEndian.PutUint32(time, timestamp)
 	report = append(report, time[:]...)
 
-	observersCount := uint8(n)
+	observersCount := uint8(n) //nolint:gosec // count can never be 0, and oracle network will never be larger than 255
 	report = append(report, observersCount)
 
 	report = append(report, observers[:]...)

--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,7 @@ pkgs.mkShell {
 
     # Golang
     # Keep this golang version in sync with the version in .tool-versions please
-    go_1_22
+    go_1_23
     gopls
     delve
     golangci-lint


### PR DESCRIPTION
bumps go + golangci-lint version in nix

adds fixes or explanations/ignores for gosec:g115 overflow errors