### PR TITLE
improve CI contract build times

### DIFF
--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   relay_run_unit_tests:
     name: Relay Run Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8cores-32GB
     steps:
       - name: Collect Metrics
         id: collect-gha-metrics

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,36 @@ jobs:
         id: psversion
         uses: ./.github/actions/projectserum_version
 
+  build_image_test:
+    name: build image test
+    runs-on: ubuntu-latest
+    needs: [get_projectserum_version]
+    steps:
+    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+    - name: cache cargo target dir
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: contracts/target
+        key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}'
+    - name: cache docker build image
+      id: cache-image
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: contracts/docker-build.tar
+        key: ${{ runner.os }}-docker-build-${{ needs.get_projectserum_version.outputs.projectserum_version }}-${{ hashFiles('**/Cargo.lock') }}'
+    - name: build & save image
+      if: steps.cache-image.outputs.cache-hit != 'true'
+      run: |
+        docker buildx build . -t chainlink-solana:build --build-arg ANCHOR_CLI=${{ needs.get_projectserum_version.outputs.projectserum_version }}
+        docker save chainlink-solana > docker-build.tar
+    - name: load cached image
+      if: steps.cache-image.outputs.cache-hit == 'true'
+      run: |
+        docker load --input docker-build.tar
+    - name: build from cached artifacts
+      run: |
+        docker run -v "$(pwd)/../":/workdir chainlink-solana:build bash -c "cd /workdir/contracts && anchor build && chmod -R 755 ./target"
+
   rust_run_anchor_tests:
     name: Rust Run Anchor Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
         id: psversion
         uses: ./.github/actions/projectserum_version
 
-  build_image_test:
+  build_wrapped_anchor_image:
     name: build image test
     runs-on: ubuntu-latest
     needs: [get_projectserum_version]
@@ -44,43 +44,30 @@ jobs:
       run: |
         docker buildx build . -t chainlink-solana:build --build-arg ANCHOR_CLI=${{ needs.get_projectserum_version.outputs.projectserum_version }}
         docker save chainlink-solana > docker-build.tar
-    - name: load cached image
-      if: steps.cache-image.outputs.cache-hit == 'true'
-      run: |
-        docker load --input docker-build.tar
-    - name: build from cached artifacts
-      run: |
-        docker run -v "$(pwd)/../":/workdir chainlink-solana:build bash -c "cd /workdir/contracts && anchor build && chmod -R 755 ./target"
 
   rust_run_anchor_tests:
     name: Rust Run Anchor Tests
     runs-on: ubuntu-latest
-    needs: [get_projectserum_version]
+    needs: [get_projectserum_version, build_wrapped_anchor_image]
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-    - name: Cache cargo registry
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-v2-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Cache cargo index
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-v2-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
     - name: Cache cargo target dir
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: contracts/target
         key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: run tests
-      env:
-        psversion: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
+    - name: cache docker build image
+      id: cache-image
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: contracts/docker-build.tar
+        key: ${{ runner.os }}-docker-build-${{ needs.get_projectserum_version.outputs.projectserum_version }}-${{ hashFiles('**/Cargo.lock') }}'
+    - name: load cached image
       run: |
-        docker run -v "$(pwd)/../":/repo backpackapp/build:"${psversion}" bash -c "\
+        docker load --input docker-build.tar
+    - name: run tests
+      run: |
+        docker run -v "$(pwd)/../":/repo chainlink-solana:build bash -c "\
           set -eoux pipefail &&\
           RUSTUP_HOME=\"/root/.rustup\" &&\
           FORCE_COLOR=1 &&\
@@ -92,50 +79,31 @@ jobs:
           cd /repo/contracts &&\
           yarn install --frozen-lockfile &&\
           anchor test &&\
+          chmod -R 755 ./target &&\
           cd /repo/contracts/examples/hello-world &&\
           yarn install --frozen-lockfile &&\
           anchor test"
 
-    # - run: solana-keygen new -o id.json --no-bip39-passphrase
-    # - name: Compile typescript client
-    #   run: |
-    #    cd ../ts
-    #    yarn install --frozen-lockfile
-    #    yarn build
-    # - name: anchor test contracts
-    #   run: |
-    #     yarn install --frozen-lockfile
-    #     anchor test
-    # - name: anchor test hello-world
-    #   run: |
-    #    cd examples/hello-world
-    #    yarn install --frozen-lockfile
-    #    anchor test
-
   rust_lint:
     name: Rust Lint
     runs-on: ubuntu-latest
-    needs: [get_projectserum_version]
+    needs: [get_projectserum_version, build_wrapped_anchor_image]
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-    - name: Cache cargo registry
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-v2-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Cache cargo index
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-v2-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
     - name: Cache cargo target dir
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: contracts/target
         key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-    
+    - name: cache docker build image
+      id: cache-image
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: contracts/docker-build.tar
+        key: ${{ runner.os }}-docker-build-${{ needs.get_projectserum_version.outputs.projectserum_version }}-${{ hashFiles('**/Cargo.lock') }}'
+    - name: load cached image
+      run: |
+        docker load --input docker-build.tar
     - name: format contracts + artifacts
       run: |
         yarn install --frozen-lockfile
@@ -145,10 +113,8 @@ jobs:
         git diff --stat --exit-code
 
     - name: cargo check
-      env:
-        psversion: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
       run: |
-        docker run -v "$(pwd)/../":/repo backpackapp/build:"${psversion}" bash -c "\
+        docker run -v "$(pwd)/../":/repo chainlink-solana:build bash -c "\
           set -eoux pipefail &&\
           RUSTUP_HOME=\"/root/.rustup\" &&\
           FORCE_COLOR=1 &&\

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/projectserum_version
 
   build_wrapped_anchor_image:
-    name: build image test
+    name: build contract test image
     runs-on: ubuntu-latest
     needs: [get_projectserum_version]
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,11 +28,6 @@ jobs:
     needs: [get_projectserum_version]
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-    - name: cache cargo target dir
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: contracts/target
-        key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}'
     - name: cache docker build image
       id: cache-image
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
@@ -56,6 +51,11 @@ jobs:
       with:
         path: contracts/target
         key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache hello-world target dir
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: contracts/examples/hello-world/target
+        key: ${{ runner.os }}-v2-cargo-build-target-hello-world-${{ hashFiles('**/Cargo.lock') }}
     - name: cache docker build image
       id: cache-image
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
@@ -82,7 +82,8 @@ jobs:
           chmod -R 755 ./target &&\
           cd /repo/contracts/examples/hello-world &&\
           yarn install --frozen-lockfile &&\
-          anchor test"
+          anchor test &&\
+          chmod -R 755 ./target"
 
   rust_lint:
     name: Rust Lint

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
 
   rust_run_anchor_tests:
     name: Rust Run Anchor Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8cores-32GB
     needs: [get_projectserum_version, build_wrapped_anchor_image]
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5

--- a/contracts/.dockerignore
+++ b/contracts/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,0 +1,10 @@
+ARG ANCHOR_CLI
+
+FROM backpackapp/build:${ANCHOR_CLI}
+
+RUN git clone https://github.com/smartcontractkit/chainlink-solana.git /chainlink-solana
+
+RUN cd /chainlink-solana/contracts && anchor build
+
+# only keep downloaded artifacts in /root/.cargo cached
+RUN rm -rf /chainlink-solana

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -2,9 +2,9 @@ ARG ANCHOR_CLI
 
 FROM backpackapp/build:${ANCHOR_CLI}
 
-RUN git clone https://github.com/smartcontractkit/chainlink-solana.git /chainlink-solana
+COPY . /contracts
 
-RUN cd /chainlink-solana/contracts && anchor build
+RUN cd /contracts && anchor build
 
 # only keep downloaded artifacts in /root/.cargo cached
-RUN rm -rf /chainlink-solana
+RUN rm -rf /contracts


### PR DESCRIPTION
### Description

https://smartcontract-it.atlassian.net/browse/NONEVM-592

* improve caching of cargo compilation artifacts (contracts/target/* + contracts/examples/hello-world/target/*)
* cache additional cargo artifacts via a cached docker image (~/.cargo artifacts)
* increase runner size to next size up

old runtime = ~5.5 min ([link](https://github.com/smartcontractkit/chainlink-solana/actions/runs/11127999432))
![image](https://github.com/user-attachments/assets/babdacec-36f5-4f1c-971d-af19cd198a74)

new runtime with fully cached deps = 3.75 min ([link](https://github.com/smartcontractkit/chainlink-solana/actions/runs/11132968919))
![image](https://github.com/user-attachments/assets/54f1c796-2ce6-4cbf-a750-a513541714e3)

