### PR TITLE
[NONEVM-695] - Integrate BHE within TXM

### DIFF
--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -166,9 +166,10 @@ func (txm *Txm) sendWithRetry(chanCtx context.Context, baseTx solanaGo.Transacti
 
 	// base compute unit price should only be calculated once
 	// prevent underlying base changing when bumping (could occur with RPC based estimation)
+	baseFee := txm.fee.BaseComputeUnitPrice()
 	getFee := func(count int) fees.ComputeUnitPrice {
 		fee := fees.CalculateFee(
-			txcfg.BaseComputeUnitPrice,
+			baseFee,
 			txcfg.ComputeUnitPriceMax,
 			txcfg.ComputeUnitPriceMin,
 			uint(count), //nolint:gosec // reasonable number of bumps should never cause overflow


### PR DESCRIPTION
**Acceptance Criteria:**
- BHE is effective getting transactions included on chain when integrated with the TXM
- we pay close (within a margin of 10%) to the median market price for most (90%) when integrated with the TXM

