### PR TITLE
[NONEVM-695][SOAK] - Integrate Latest Block BHE within TXM

### DIFF
--- a/pkg/solana/config/config.go
+++ b/pkg/solana/config/config.go
@@ -23,7 +23,7 @@ var defaultConfigSet = Chain{
 	MaxRetries:          ptr(int64(0)), // max number of retries (default = 0). when config.MaxRetries < 0), interpreted as MaxRetries = nil and rpc node will do a reasonable number of retries
 
 	// fee estimator
-	FeeEstimatorMode:        ptr("fixed"),
+	FeeEstimatorMode:        ptr("blockhistory"),
 	ComputeUnitPriceMax:     ptr(uint64(1_000)),
 	ComputeUnitPriceMin:     ptr(uint64(0)),
 	ComputeUnitPriceDefault: ptr(uint64(0)),

--- a/pkg/solana/fees/block_history_test.go
+++ b/pkg/solana/fees/block_history_test.go
@@ -36,7 +36,6 @@ func TestBlockHistoryEstimator(t *testing.T) {
 	cfg.On("BlockHistoryPollPeriod").Return(100 * time.Millisecond)
 	lgr, logs := logger.TestObserved(t, zapcore.DebugLevel)
 	ctx := tests.Context(t)
-
 	// file contains legacy + v0 transactions
 	testBlockData, err := os.ReadFile("./blockdata.json")
 	require.NoError(t, err)

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -679,6 +679,8 @@ func TestTxm_Enqueue(t *testing.T) {
 	lggr := logger.Test(t)
 	cfg := config.NewDefault()
 	mc := mocks.NewReaderWriter(t)
+	mc.On("GetLatestBlock", mock.Anything).Return(&rpc.GetBlockResult{}, nil).Maybe()
+	mc.On("SlotHeight", mock.Anything).Return(uint64(0), nil).Maybe()
 	mc.On("SendTx", mock.Anything, mock.Anything).Return(solana.Signature{}, nil).Maybe()
 	mc.On("SimulateTx", mock.Anything, mock.Anything, mock.Anything).Return(&rpc.SimulateTransactionResult{}, nil).Maybe()
 	ctx := tests.Context(t)


### PR DESCRIPTION
## Latest Soak Test (Devnet)

Soak tests are being run using a [local set up](https://smartcontract-it.atlassian.net/wiki/spaces/QA/pages/601097421/Solana+testing+wiki#Integration-tests).
| Content |
| --- |
| `CommitHash` [751082dccfe53a2f06285f2c47e3e397d974c292](https://github.com/smartcontractkit/chainlink-solana/pull/906/commits/751082dccfe53a2f06285f2c47e3e397d974c292) (latest) |
| solana-gauntlet-embedded-cd143 |
| image tag: 5470c2461492f250df42e9ec91e41202fb5c6ee2 |
| ![Latest Test](https://img.shields.io/badge/Status-Completed-green) |
| [Grafana Logs](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1) |

## Grafana Stats
| Metric                                             | Query Link                                                                                                                                                                                                                                                           | Count (last 5h)|
|----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
| **Failed Transaction Sends**                       | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22failed%20to%20send%20transaction%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)             |    0   |
| **Failed Retry Transaction Sends**                 | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22failed%20to%20send%20retry%20transaction%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1) |     0  |
| **Failed Retry Transaction Builds**               | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22failed%20to%20build%20bumped%20retry%20tx%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)   |    0   |
| **Invariant Violations in Retries**                | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22INVARIANT%20VIOLATION%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)             |    0   |
| **Failed Enqueue Transactions**                   | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22failed%20to%20enqeue%20tx%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)                  |   0    |
| **Successfully Processed Transactions**           | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22tx%20state:%20processed%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)                    |  605  |
| **Successfully Confirmed Transactions**           | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22tx%20state:%20confirmed%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)                   |    4.28k  |
| **Not Found Transactions**           | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22tx%20state:%20not%20found%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)                    |    6.11k   |
| **Transaction Timeouts**                          | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22failed%20to%20find%20transaction%20within%20confirm%20timeout%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1) |   0    |
| **Failed to Move Beyond 'Processed'**             | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22tx%20failed%20to%20move%20beyond%20%27processed%27%20within%20confirm%20timeout%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1) |   0    |
| **Bumped Transactions**             | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-cd143%5C%22%7D%20%7C%3D%20%5C%22tx%20rebroadcast%20with%20bumped%20fee%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1) |   15   |

### Config
```
# This is the default configuration so OCR2 tests can run without issues
[ChainlinkImage]
version="solana.<image_tag_from_CI>"

[Logging]
test_log_collect=false

[Logging.LogStream]
log_targets=["file"]
log_producer_timeout="10s"
log_producer_retry_limit=10

[SolanaConfig]
ocr2_program_id = "cjg3oHmg9uuPsP8D6g29NWvhySJkdYdAo9D25PRbKXJ"
access_controller_program_id = "9xi644bRR8birboDGdTiwBq3C7VEeR7VuamRYYXCubUW"
store_program_id = "HEvSKofvBgfaexv23kMabbYqxasxU3mQ4ibBMEmJWHny"
link_token_address = "7CF1GrsZsny5j9JESPj98MdYVZK38RE8ZpmTEMwECK4c"
vault_address = "FdM4dnhVpFQfjPqNG6LEfzArhuGhUjtidYu89qtGwJCS"
secret=***

[Common]
internal_docker_repo = "***"
inside_k8 = true
network = "devnet"
user = "farber98"
stateful_db = true
devnet_image = "layerzerolabs/solana:1.17.31"

[OCR2]
node_count = 6
test_duration = "24h"
number_of_rounds = 3
```