### PR TITLE
[fix]: flaky txm_enqueue_test

### DIFF
--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -681,6 +681,14 @@ func TestTxm_Enqueue(t *testing.T) {
 	mc := mocks.NewReaderWriter(t)
 	mc.On("SendTx", mock.Anything, mock.Anything).Return(solana.Signature{}, nil).Maybe()
 	mc.On("SimulateTx", mock.Anything, mock.Anything, mock.Anything).Return(&rpc.SimulateTransactionResult{}, nil).Maybe()
+	mc.On("SignatureStatuses", mock.Anything, mock.AnythingOfType("[]solana.Signature")).Return(
+		func(_ context.Context, sigs []solana.Signature) (out []*rpc.SignatureStatusesResult) {
+			for i := 0; i < len(sigs); i++ {
+				out = append(out, &rpc.SignatureStatusesResult{})
+			}
+			return out
+		}, nil,
+	).Maybe()
 	ctx := tests.Context(t)
 
 	// mock solana keystore


### PR DESCRIPTION
### Description

Occasional test error where the txm would progress faster and check signature statuses before shutdown.

```
TestTxm_Enqueue (0.00s) 
      20:33:3[9](https://github.com/smartcontractkit/chainlink-internal-integrations/actions/runs/11524961283/job/32086241949?pr=183#step:9:10).831283231	DEBUG	Txm	tx initial broadcast	{"id": "e1bf93f5-763a-4ca2-a8ca-0e5517bc3b45", "signature": "1111111111111111111111111111111111111111111111111111111111111111"}
      20:33:39.831331802	DEBUG	Txm	transaction sent	{"signature": "1111111111111111111111111111111111111111111111111111111111111111", "id": "e1bf93f5-763a-4ca2-a8ca-0e5517bc3b45"}
      20:33:39.831357390	DEBUG	Txm	stopped tx retry	{"id": "e1bf93f5-763a-4ca2-a8ca-0e5517bc3b45", "signatures": ["[11](https://github.com/smartcontractkit/chainlink-internal-integrations/actions/runs/11524961283/job/32086241949?pr=183#step:9:12)11111111111111111111111111111111111111111111111111111111111111"], "err": "context canceled"}
          assert: mock: I don't know what to return because the method call was unexpected.
          	Either do Mock.On("SignatureStatuses").Return(...) first, or remove the SignatureStatuses() call.
          	This method was unexpected:
          		SignatureStatuses(*context.cancelCtx,[]solana.Signature)
          		0: &context.cancelCtx{Context:context.backgroundCtx{emptyCtx:context.emptyCtx{}}, mu:sync.Mutex{state:0, sema:0x0}, done:atomic.Value{v:(chan struct {})(0xc0007ca0e0)}, children:map[context.canceler]struct {}(nil), err:(*errors.errorString)(0x19[13](https://github.com/smartcontractkit/chainlink-internal-integrations/actions/runs/11524961283/job/32086241949?pr=183#step:9:14)730), cause:(*errors.errorString)(0x1913730)}
          		1: []solana.Signature{solana.Signature{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}}
          	at: [/home/runner/work/chainlink-internal-integrations/chainlink-internal-integrations/solana/pkg/solana/client/mocks/ReaderWriter.go:226 /home/runner/work/chainlink-internal-integrations/chainlink-internal-integrations/solana/pkg/solana/txm/txm.go:456 /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.1.linux-amd64/src/runtime/asm_amd64.s:[17](https://github.com/smartcontractkit/chainlink-internal-integrations/actions/runs/11524961283/job/32086241949?pr=183#step:9:18)00]
```
