### PR TITLE
[SOAK] - Fixed Price Estimator Soak Testing

### DIFF
--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -235,7 +235,7 @@ func (txm *Txm) sendWithRetry(ctx context.Context, baseTx solanaGo.Transaction, 
 		cancel() // cancel context when exiting early
 		return solanaGo.Transaction{}, uuid.Nil, solanaGo.Signature{}, fmt.Errorf("failed to save tx signature (%s) to inflight txs: %w", sig, initStoreErr)
 	}
-
+	//
 	// used for tracking rebroadcasting only in SendWithRetry
 	var sigs signatureList
 	sigs.Allocate()


### PR DESCRIPTION
## Latest Soak Test (Devnet)

Soak tests are being run using a [local set up](https://smartcontract-it.atlassian.net/wiki/spaces/QA/pages/601097421/Solana+testing+wiki#Integration-tests).
| Content |
| --- |
| `CommitHash` [36b287284e2952991bb6340b149e0d905c642882](https://github.com/smartcontractkit/chainlink-solana/pull/906/commits/751082dccfe53a2f06285f2c47e3e397d974c292) (latest) |
| solana-gauntlet-embedded-c66a8 |
| image tag: 03f969b6cba7ea07db65caa357d00cf5b3e60892 |
| ![Latest Test](https://img.shields.io/badge/Status-Complete-green) |
| [Grafana Logs](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-2d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1) |

## Grafana Stats
| Metric                                             | Query Link                                                                                                                                                                                                                                                           | Count (first 5h) |
|----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
| **Failed Transaction Sends**                       | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22failed%20to%20send%20transaction%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)             |    0   |
| **Failed Retry Transaction Sends**                 | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22failed%20to%20send%20retry%20transaction%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1) |     0  |
| **Failed Retry Transaction Builds**               | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22failed%20to%20build%20bumped%20retry%20tx%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)   |    0   |
| **Invariant Violations in Retries**                | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22INVARIANT%20VIOLATION%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)             |    0   |
| **Failed Enqueue Transactions**                   | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22failed%20to%20enqeue%20tx%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)                  |   0    |
| **Successfully Processed Transactions**           | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22tx%20state:%20processed%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)                    |  553 |
| **Successfully Confirmed Transactions**           | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22tx%20state:%20confirmed%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)                   |    4.04k   |
| **Not Found Transactions**           | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22tx%20state:%20not%20found%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1)                    |    6k   |
| **Transaction Timeouts**                          | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22failed%20to%20find%20transaction%20within%20confirm%20timeout%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1) |   0    |
| **Failed to Move Beyond 'Processed'**             | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22tx%20failed%20to%20move%20beyond%20%27processed%27%20within%20confirm%20timeout%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1) |   0    |
| **Bumped Transactions**             | [Query](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22u3i%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20%28app%29%20%28count_over_time%28%7Bnamespace%3D%5C%22solana-gauntlet-embedded-c66a8%5C%22%7D%20%7C%3D%20%5C%22tx%20rebroadcast%20with%20bumped%20fee%5C%22%20%5B5h%5D%29%29%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221730469600000%22,%22to%22:%221730487600000%22%7D%7D%7D&orgId=1) |   23   |

### Config
```
# This is the default configuration so OCR2 tests can run without issues
[ChainlinkImage]
version="solana.<image_tag_from_CI>"

[Logging]
test_log_collect=false

[Logging.LogStream]
log_targets=["file"]
log_producer_timeout="10s"
log_producer_retry_limit=10

[SolanaConfig]
ocr2_program_id = "cjg3oHmg9uuPsP8D6g29NWvhySJkdYdAo9D25PRbKXJ"
access_controller_program_id = "9xi644bRR8birboDGdTiwBq3C7VEeR7VuamRYYXCubUW"
store_program_id = "HEvSKofvBgfaexv23kMabbYqxasxU3mQ4ibBMEmJWHny"
link_token_address = "7CF1GrsZsny5j9JESPj98MdYVZK38RE8ZpmTEMwECK4c"
vault_address = "FdM4dnhVpFQfjPqNG6LEfzArhuGhUjtidYu89qtGwJCS"
secret=***

[Common]
internal_docker_repo = "***"
inside_k8 = true
network = "devnet"
user = "farber98"
stateful_db = true
devnet_image = "layerzerolabs/solana:1.17.31"

[OCR2]
node_count = 6
test_duration = "24h"
number_of_rounds = 3
```