### PR TITLE
[NONEVM-706][solana] - Support custom fee bumping strategies through RPC call 

### DIFF
--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -580,6 +580,7 @@ func (c *chain) sendTx(ctx context.Context, from, to string, amount *big.Int, ba
 		txm.SetComputeUnitPriceMax(0),
 		txm.SetComputeUnitPriceMin(0),
 		txm.SetBaseComputeUnitPrice(0),
+		txm.SetFeeBumpCriteria("fixed-interval"),
 		txm.SetFeeBumpPeriod(0),
 	)
 	if err != nil {

--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -574,7 +574,7 @@ func (c *chain) sendTx(ctx context.Context, from, to string, amount *big.Int, ba
 	}
 
 	chainTxm := c.TxManager()
-	err = chainTxm.Enqueue(ctx, "", tx, nil,
+	err = chainTxm.Enqueue(ctx, "", tx, nil, blockhash.Value.LastValidBlockHeight,
 		txm.SetComputeUnitLimit(500), // reduce from default 200K limit - should only take 450 compute units
 		// no fee bumping and no additional fee - makes validating balance accurate
 		txm.SetComputeUnitPriceMax(0),

--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -580,7 +580,7 @@ func (c *chain) sendTx(ctx context.Context, from, to string, amount *big.Int, ba
 		txm.SetComputeUnitPriceMax(0),
 		txm.SetComputeUnitPriceMin(0),
 		txm.SetBaseComputeUnitPrice(0),
-		txm.SetFeeBumpCriteria("fixed-interval"),
+		txm.SetFeeBumpCriteria("fixed-intervals"),
 		txm.SetFeeBumpPeriod(0),
 	)
 	if err != nil {

--- a/pkg/solana/chain_test.go
+++ b/pkg/solana/chain_test.go
@@ -17,13 +17,14 @@ import (
 	"github.com/gagliardetto/solana-go/programs/system"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/google/uuid"
-	"github.com/smartcontractkit/chainlink-common/pkg/config"
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
 	mn "github.com/smartcontractkit/chainlink-solana/pkg/solana/client/multinode"
@@ -536,7 +537,7 @@ func TestSolanaChain_MultiNode_Txm(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(0), receiverBal)
 
-	createTx := func(signer solana.PublicKey, sender solana.PublicKey, receiver solana.PublicKey, amt uint64) *solana.Transaction {
+	createTx := func(signer solana.PublicKey, sender solana.PublicKey, receiver solana.PublicKey, amt uint64) (*solana.Transaction, uint64) {
 		selectedClient, err = testChain.getClient()
 		assert.NoError(t, err)
 		hash, hashErr := selectedClient.LatestBlockhash(tests.Context(t))
@@ -553,11 +554,12 @@ func TestSolanaChain_MultiNode_Txm(t *testing.T) {
 			solana.TransactionPayer(signer),
 		)
 		require.NoError(t, txErr)
-		return tx
+		return tx, hash.Value.LastValidBlockHeight
 	}
 
 	// Send funds twice, along with an invalid transaction
-	require.NoError(t, testChain.txm.Enqueue(tests.Context(t), "test_success", createTx(pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil))
+	tx1, lastValidBlockHeight1 := createTx(pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
+	require.NoError(t, testChain.txm.Enqueue(tests.Context(t), "test_success", tx1, nil, lastValidBlockHeight1))
 
 	// Wait for new block hash
 	currentBh, err := selectedClient.LatestBlockhash(tests.Context(t))
@@ -578,8 +580,10 @@ NewBlockHash:
 		}
 	}
 
-	require.NoError(t, testChain.txm.Enqueue(tests.Context(t), "test_success_2", createTx(pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil))
-	require.Error(t, testChain.txm.Enqueue(tests.Context(t), "test_invalidSigner", createTx(pubKeyReceiver, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil)) // cannot sign tx before enqueuing
+	tx2, lastValidBlockHeight2 := createTx(pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
+	require.NoError(t, testChain.txm.Enqueue(tests.Context(t), "test_success_2", tx2, nil, lastValidBlockHeight2))
+	tx3, lastValidlastValidBlockHeight3 := createTx(pubKeyReceiver, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
+	require.Error(t, testChain.txm.Enqueue(tests.Context(t), "test_invalidSigner", tx3, nil, lastValidlastValidBlockHeight3)) // cannot sign tx before enqueuing
 
 	// wait for all txes to finish
 	ctx, cancel := context.WithCancel(tests.Context(t))

--- a/pkg/solana/config/config.go
+++ b/pkg/solana/config/config.go
@@ -28,6 +28,7 @@ var defaultConfigSet = Chain{
 	ComputeUnitPriceMax:      ptr(uint64(1_000)),
 	ComputeUnitPriceMin:      ptr(uint64(0)),
 	ComputeUnitPriceDefault:  ptr(uint64(0)),
+	FeeBumpCriteria:          ptr("fixed-interval"),                   // "interval": bumps fees every FeeBumpPeriod intervals; "expiration": checks if should bump fees every FeeBumpPeriod based on blockhash expiration
 	FeeBumpPeriod:            config.MustNewDuration(3 * time.Second), // set to 0 to disable fee bumping
 	BlockHistoryPollPeriod:   config.MustNewDuration(5 * time.Second),
 	BlockHistorySize:         ptr(uint64(1)),       // 1: uses latest block; >1: Uses multiple blocks, where n is number of blocks. DISCLAIMER: 1:1 ratio between n and RPC calls.
@@ -54,6 +55,7 @@ type Config interface {
 	ComputeUnitPriceMax() uint64
 	ComputeUnitPriceMin() uint64
 	ComputeUnitPriceDefault() uint64
+	FeeBumpCriteria() string
 	FeeBumpPeriod() time.Duration
 	BlockHistoryPollPeriod() time.Duration
 	BlockHistorySize() uint64
@@ -77,6 +79,7 @@ type Chain struct {
 	ComputeUnitPriceMax      *uint64
 	ComputeUnitPriceMin      *uint64
 	ComputeUnitPriceDefault  *uint64
+	FeeBumpCriteria          *string
 	FeeBumpPeriod            *config.Duration
 	BlockHistoryPollPeriod   *config.Duration
 	BlockHistorySize         *uint64
@@ -129,6 +132,9 @@ func (c *Chain) SetDefaults() {
 	}
 	if c.ComputeUnitPriceDefault == nil {
 		c.ComputeUnitPriceDefault = defaultConfigSet.ComputeUnitPriceDefault
+	}
+	if c.FeeBumpCriteria == nil {
+		c.FeeBumpCriteria = defaultConfigSet.FeeBumpCriteria
 	}
 	if c.FeeBumpPeriod == nil {
 		c.FeeBumpPeriod = defaultConfigSet.FeeBumpPeriod

--- a/pkg/solana/config/config.go
+++ b/pkg/solana/config/config.go
@@ -28,7 +28,7 @@ var defaultConfigSet = Chain{
 	ComputeUnitPriceMax:      ptr(uint64(1_000)),
 	ComputeUnitPriceMin:      ptr(uint64(0)),
 	ComputeUnitPriceDefault:  ptr(uint64(0)),
-	FeeBumpCriteria:          ptr("fixed-interval"),                   // "interval": bumps fees every FeeBumpPeriod intervals; "expiration": checks if should bump fees every FeeBumpPeriod based on blockhash expiration
+	FeeBumpCriteria:          ptr("fixed-intervals"),                  // "fixed-intervals": bumps fees every FeeBumpPeriod interval; "expiration": checks if should bump fees every FeeBumpPeriod based on blockhash expiration
 	FeeBumpPeriod:            config.MustNewDuration(3 * time.Second), // set to 0 to disable fee bumping
 	BlockHistoryPollPeriod:   config.MustNewDuration(5 * time.Second),
 	BlockHistorySize:         ptr(uint64(1)),       // 1: uses latest block; >1: Uses multiple blocks, where n is number of blocks. DISCLAIMER: 1:1 ratio between n and RPC calls.

--- a/pkg/solana/config/mocks/config.go
+++ b/pkg/solana/config/mocks/config.go
@@ -194,6 +194,24 @@ func (_m *Config) EstimateComputeUnitLimit() bool {
 	return r0
 }
 
+// FeeBumpCriteria provides a mock function with given fields:
+func (_m *Config) FeeBumpCriteria() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for FeeBumpCriteria")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // FeeBumpPeriod provides a mock function with given fields:
 func (_m *Config) FeeBumpPeriod() time.Duration {
 	ret := _m.Called()

--- a/pkg/solana/config/toml.go
+++ b/pkg/solana/config/toml.go
@@ -179,6 +179,9 @@ func setFromChain(c, f *Chain) {
 	if f.ComputeUnitPriceDefault != nil {
 		c.ComputeUnitPriceDefault = f.ComputeUnitPriceDefault
 	}
+	if f.FeeBumpCriteria != nil {
+		c.FeeBumpCriteria = f.FeeBumpCriteria
+	}
 	if f.FeeBumpPeriod != nil {
 		c.FeeBumpPeriod = f.FeeBumpPeriod
 	}
@@ -277,6 +280,10 @@ func (c *TOMLConfig) ComputeUnitPriceMin() uint64 {
 
 func (c *TOMLConfig) ComputeUnitPriceDefault() uint64 {
 	return *c.Chain.ComputeUnitPriceDefault
+}
+
+func (c *TOMLConfig) FeeBumpCriteria() string {
+	return *c.Chain.FeeBumpCriteria
 }
 
 func (c *TOMLConfig) FeeBumpPeriod() time.Duration {

--- a/pkg/solana/relay.go
+++ b/pkg/solana/relay.go
@@ -24,7 +24,7 @@ import (
 var _ TxManager = (*txm.Txm)(nil)
 
 type TxManager interface {
-	Enqueue(ctx context.Context, accountID string, tx *solana.Transaction, txID *string, txCfgs ...txm.SetTxConfig) error
+	Enqueue(ctx context.Context, accountID string, tx *solana.Transaction, txID *string, LastValidBlockHeight uint64, txCfgs ...txm.SetTxConfig) error
 }
 
 var _ relaytypes.Relayer = &Relayer{} //nolint:staticcheck

--- a/pkg/solana/transmitter.go
+++ b/pkg/solana/transmitter.go
@@ -84,7 +84,7 @@ func (c *Transmitter) Transmit(
 
 	// pass transmit payload to tx manager queue
 	c.lggr.Debugf("Queuing transmit tx: state (%s) + transmissions (%s)", c.stateID.String(), c.transmissionsID.String())
-	if err = c.txManager.Enqueue(ctx, c.stateID.String(), tx, nil); err != nil {
+	if err = c.txManager.Enqueue(ctx, c.stateID.String(), tx, nil, blockhash.Value.LastValidBlockHeight); err != nil {
 		return fmt.Errorf("error on Transmit.txManager.Enqueue: %w", err)
 	}
 	return nil

--- a/pkg/solana/transmitter_test.go
+++ b/pkg/solana/transmitter_test.go
@@ -26,7 +26,7 @@ type verifyTxSize struct {
 	s *solana.PrivateKey
 }
 
-func (txm verifyTxSize) Enqueue(_ context.Context, _ string, tx *solana.Transaction, txID *string, _ ...txm.SetTxConfig) error {
+func (txm verifyTxSize) Enqueue(_ context.Context, _ string, tx *solana.Transaction, txID *string, LastValidBlockHeight uint64, _ ...txm.SetTxConfig) error {
 	// additional components that transaction manager adds to the transaction
 	require.NoError(txm.t, fees.SetComputeUnitPrice(tx, 0))
 	require.NoError(txm.t, fees.SetComputeUnitLimit(tx, 0))

--- a/pkg/solana/txm/pendingtx.go
+++ b/pkg/solana/txm/pendingtx.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	"golang.org/x/exp/maps"
 )
 
@@ -30,6 +31,10 @@ type PendingTxContext interface {
 	ListAll() []solana.Signature
 	// Expired returns whether or not confirmation timeout amount of time has passed since creation
 	Expired(sig solana.Signature, confirmationTimeout time.Duration) bool
+	// IsBlockhashExpired returns whether or not the blockhash of a transaction has expired when compared to currHeight. Useful to check if should be bumped.
+	IsBlockhashExpired(id string, currHeight uint64) bool
+	// UpdateBlockhash updates the last valid block height for a transaction when expired and needs bumping in the context of FeeBumpCriteria='expiration'.
+	UpdateBlockhash(id string, blockhashResult *rpc.GetLatestBlockhashResult) error
 	// OnProcessed marks transactions as Processed
 	OnProcessed(sig solana.Signature) (string, error)
 	// OnConfirmed marks transaction as Confirmed and moves it from broadcast map to confirmed map
@@ -45,13 +50,14 @@ type PendingTxContext interface {
 }
 
 type pendingTx struct {
-	tx          solana.Transaction
-	cfg         TxConfig
-	signatures  []solana.Signature
-	id          string
-	createTs    time.Time
-	retentionTs time.Time
-	state       TxState
+	tx                   solana.Transaction
+	cfg                  TxConfig
+	signatures           []solana.Signature
+	id                   string
+	createTs             time.Time
+	retentionTs          time.Time
+	state                TxState
+	lastValidBlockHeight uint64
 }
 
 var _ PendingTxContext = &pendingTxContext{}
@@ -269,6 +275,30 @@ func (c *pendingTxContext) OnProcessed(sig solana.Signature) (string, error) {
 		c.broadcastedTxs[id] = tx
 		return id, nil
 	})
+}
+
+// IsBlockhashExpired returns whether or not the blockhash of a transaction has expired when compared to currHeight. Useful to check if should be bumped.
+func (c *pendingTxContext) IsBlockhashExpired(id string, currHeight uint64) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	tx, exists := c.broadcastedTxs[id]
+	if !exists {
+		return false
+	}
+	return tx.lastValidBlockHeight < currHeight
+}
+
+// UpdateBlockhash updates the blockhash and last valid block height for a transaction when expired and needs bumping in the context of FeeBumpCriteria='expiration'.
+func (c *pendingTxContext) UpdateBlockhash(id string, blockhashResult *rpc.GetLatestBlockhashResult) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if tx, exists := c.broadcastedTxs[id]; exists {
+		tx.tx.Message.RecentBlockhash = blockhashResult.Value.Blockhash
+		tx.lastValidBlockHeight = blockhashResult.Value.LastValidBlockHeight
+		c.broadcastedTxs[id] = tx
+		return nil
+	}
+	return fmt.Errorf("transaction not found for id: %s", id)
 }
 
 func (c *pendingTxContext) OnConfirmed(sig solana.Signature) (string, error) {
@@ -543,6 +573,14 @@ func (c *pendingTxContextWithProm) ListAll() []solana.Signature {
 
 func (c *pendingTxContextWithProm) Expired(sig solana.Signature, lifespan time.Duration) bool {
 	return c.pendingTx.Expired(sig, lifespan)
+}
+
+func (c *pendingTxContextWithProm) IsBlockhashExpired(id string, currHeight uint64) bool {
+	return c.pendingTx.IsBlockhashExpired(id, currHeight)
+}
+
+func (c *pendingTxContextWithProm) UpdateBlockhash(id string, blockhashResult *rpc.GetLatestBlockhashResult) error {
+	return c.pendingTx.UpdateBlockhash(id, blockhashResult)
 }
 
 // Success - tx finalized

--- a/pkg/solana/txm/pendingtx.go
+++ b/pkg/solana/txm/pendingtx.go
@@ -31,9 +31,9 @@ type PendingTxContext interface {
 	ListAll() []solana.Signature
 	// Expired returns whether or not confirmation timeout amount of time has passed since creation
 	Expired(sig solana.Signature, confirmationTimeout time.Duration) bool
-	// IsBlockhashExpired returns whether or not the blockhash of a transaction has expired when compared to currHeight. Useful to check if should be bumped.
+	// IsBlockhashExpired returns whether or not the blockhash of a transaction has expired when compared to currHeight.
 	IsBlockhashExpired(id string, currHeight uint64) bool
-	// UpdateBlockhash updates the last valid block height for a transaction when expired and needs bumping in the context of FeeBumpCriteria='expiration'.
+	// UpdateBlockhash updates the blockhash and last valid height for a transaction when expired and needs bumping.
 	UpdateBlockhash(id string, blockhashResult *rpc.GetLatestBlockhashResult) error
 	// OnProcessed marks transactions as Processed
 	OnProcessed(sig solana.Signature) (string, error)
@@ -277,7 +277,7 @@ func (c *pendingTxContext) OnProcessed(sig solana.Signature) (string, error) {
 	})
 }
 
-// IsBlockhashExpired returns whether or not the blockhash of a transaction has expired when compared to currHeight. Useful to check if should be bumped.
+// IsBlockhashExpired returns whether or not the blockhash of a transaction has expired when compared to currHeight.
 func (c *pendingTxContext) IsBlockhashExpired(id string, currHeight uint64) bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
@@ -288,7 +288,7 @@ func (c *pendingTxContext) IsBlockhashExpired(id string, currHeight uint64) bool
 	return tx.lastValidBlockHeight < currHeight
 }
 
-// UpdateBlockhash updates the blockhash and last valid block height for a transaction when expired and needs bumping in the context of FeeBumpCriteria='expiration'.
+// UpdateBlockhash updates the blockhash and last valid height for a transaction when expired and needs bumping.
 func (c *pendingTxContext) UpdateBlockhash(id string, blockhashResult *rpc.GetLatestBlockhashResult) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/pkg/solana/txm/pendingtx_test.go
+++ b/pkg/solana/txm/pendingtx_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1029,6 +1030,101 @@ func TestGetTxState(t *testing.T) {
 	state, err = txs.GetTxState("unknown id")
 	require.Error(t, err)
 	require.Equal(t, NotFound, state)
+}
+
+func TestIsBlockhashExpired(t *testing.T) {
+	t.Parallel()
+	currHeight := uint64(100)
+	txs := newPendingTxContext()
+
+	t.Run("returns true when transaction is expired", func(t *testing.T) {
+		txID := uuid.NewString()
+		pTx := pendingTx{id: txID, lastValidBlockHeight: currHeight - 1}
+		txs.broadcastedTxs[txID] = pTx
+		require.True(t, txs.IsBlockhashExpired(txID, currHeight), "Transaction should be expired")
+	})
+
+	t.Run("returns false when transaction is not expired (equal lastValidBlockHeight)", func(t *testing.T) {
+		txID := uuid.NewString()
+		pTx := pendingTx{id: txID, lastValidBlockHeight: currHeight}
+		txs.broadcastedTxs[txID] = pTx
+		require.False(t, txs.IsBlockhashExpired(txID, currHeight), "Transaction should not be expired")
+	})
+
+	t.Run("returns false when transaction is not expired (greater lastValidBlockHeight)", func(t *testing.T) {
+		txID := uuid.NewString()
+		pTx := pendingTx{id: txID, lastValidBlockHeight: currHeight + 10}
+		txs.broadcastedTxs[txID] = pTx
+		require.False(t, txs.IsBlockhashExpired(txID, currHeight), "Transaction should not be expired")
+	})
+
+	t.Run("returns false when transaction does not exist", func(t *testing.T) {
+		txID := uuid.NewString()
+		require.False(t, txs.IsBlockhashExpired(txID, currHeight), "Unknown transaction should not be expired")
+	})
+}
+
+func TestUpdateBlockhash(t *testing.T) {
+	t.Parallel()
+	txs := newPendingTxContext()
+
+	t.Run("successfully updates blockhash and lastValidBlockHeight for existing transaction", func(t *testing.T) {
+		// Create transaction with initial values
+		txID := uuid.NewString()
+		sig := randomSignature(t)
+		oldHash, _ := solana.HashFromBase58("oldHash")
+		msg := pendingTx{
+			id: txID,
+			tx: solana.Transaction{
+				Message: solana.Message{
+					RecentBlockhash: oldHash,
+				},
+			},
+			lastValidBlockHeight: 100,
+		}
+
+		// Add the transaction to broadcastedTxs
+		err := txs.New(msg, sig, func() {})
+		require.NoError(t, err)
+
+		// Update the transaction with new blockhash and lastValidBlockHeight
+		newHash, _ := solana.HashFromBase58("newHash")
+		newLastValidBlockHeight := uint64(200)
+		blockhashResult := &rpc.GetLatestBlockhashResult{
+			Value: &rpc.LatestBlockhashResult{
+				Blockhash:            newHash,
+				LastValidBlockHeight: newLastValidBlockHeight,
+			},
+		}
+		require.NoError(t, txs.UpdateBlockhash(txID, blockhashResult))
+
+		// Lock to read the updated transaction
+		txs.lock.RLock()
+		updatedTx, exists := txs.broadcastedTxs[txID]
+		txs.lock.RUnlock()
+
+		// Check that the transaction exists and RecentBlockhash and lastValidBlockHeight have been updated
+		require.True(t, exists, "Transaction should exist in broadcastedTxs")
+		require.Equal(t, newHash, updatedTx.tx.Message.RecentBlockhash, "RecentBlockhash should be updated")
+		require.Equal(t, newLastValidBlockHeight, updatedTx.lastValidBlockHeight, "lastValidBlockHeight should be updated")
+	})
+
+	t.Run("returns error when transaction does not exist", func(t *testing.T) {
+		// Use a random txID that is not in broadcastedTxs
+		txID := uuid.NewString()
+		someHash, _ := solana.HashFromBase58("someBlockhash")
+		blockhashResult := &rpc.GetLatestBlockhashResult{
+			Value: &rpc.LatestBlockhashResult{
+				Blockhash:            someHash,
+				LastValidBlockHeight: uint64(150),
+			},
+		}
+
+		// Expect an error indicating the transaction was not found
+		err := txs.UpdateBlockhash(txID, blockhashResult)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "transaction not found for id")
+	})
 }
 
 func randomSignature(t *testing.T) solana.Signature {

--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -73,8 +73,8 @@ type TxConfig struct {
 	Timeout time.Duration // transaction broadcast timeout
 
 	// compute unit price config
-	FeeBumpCriteria      string        // "fixed-interval": bump every fixed period. "expiration": bump based on blockhash expiration
-	FeeBumpPeriod        time.Duration // "fixed-interval": how often to bump. "expiration": how often to check if should blockhash has expired and we need to bump
+	FeeBumpCriteria      string        // "fixed-intervals": bump every fixed period. "expiration": bump based on blockhash expiration
+	FeeBumpPeriod        time.Duration // "fixed-intervals": how often to bump. "expiration": how often to check if should blockhash has expired and we need to bump
 	BaseComputeUnitPrice uint64        // starting price
 	ComputeUnitPriceMin  uint64        // min price
 	ComputeUnitPriceMax  uint64        // max price
@@ -359,35 +359,41 @@ func (txm *Txm) getFee(count int) fees.ComputeUnitPrice {
 func (txm *Txm) bumpFeeAndUpdateBlockhash(ctx context.Context, txID string, bumpTime time.Time) (shouldBump bool, needBlockhashUpdate bool, newBumpTime time.Time, err error) {
 	// helper function to get current height
 	getCurrentHeight := func(ctx context.Context) (uint64, error) {
-		client, err := txm.client.Get()
-		if err != nil {
-			return 0, err
+		client, errClient := txm.client.Get()
+		if errClient != nil {
+			return 0, errClient
 		}
 
-		currHeight, err := client.SlotHeight(ctx)
-		if err != nil {
-			return 0, err
+		currHeight, errSlot := client.SlotHeight(ctx)
+		if errSlot != nil {
+			return 0, errSlot
 		}
 
 		return currHeight, nil
 	}
 
 	newBumpTime = bumpTime
+	currHeight, err := getCurrentHeight(ctx)
+	if err != nil {
+		return false, false, bumpTime, fmt.Errorf("failed to get current height: %w", err)
+	}
+
 	// Check if fee bumping is enabled and decide based on the criteria
 	if txm.cfg.FeeBumpPeriod() > 0 {
 		switch txm.cfg.FeeBumpCriteria() {
 		case FeeBumpCriteriaFixedIntervals:
-			// Bump the fee at fixed intervals
+			// Bump the fee at fixed intervals. We may want to bump without blockhash being expired.
 			if time.Since(bumpTime) >= txm.cfg.FeeBumpPeriod() {
 				shouldBump = true
 				newBumpTime = time.Now()
 			}
-		case FeeBumpCriteriaExpiration:
-			// Bump the fee if the blockhash has expired
-			currHeight, err := getCurrentHeight(ctx)
-			if err != nil {
-				return false, false, bumpTime, fmt.Errorf("failed to get current height: %w", err)
+
+			// in case blockhash has expired, we need to update it.
+			if txm.txs.IsBlockhashExpired(txID, currHeight) {
+				needBlockhashUpdate = true
 			}
+		case FeeBumpCriteriaExpiration:
+			// Bump the fee only if the blockhash has expired
 			if txm.txs.IsBlockhashExpired(txID, currHeight) {
 				shouldBump = true
 				needBlockhashUpdate = true
@@ -420,7 +426,7 @@ func (txm *Txm) prepareRetryTx(ctx context.Context, baseTx solanaGo.Transaction,
 		return blockhashResult, nil
 	}
 
-	// We need to update blockhash in retryTx and pendingTx context if it has expired. Only meaningful for FeeBumpCriteria='expiration'.
+	// We need to update blockhash in retryTx and pendingTx context if it has expired
 	if needBlockhashUpdate {
 		// Updates Blockhash and LastValidBlockHeight in the retry transaction
 		blockhashResult, err := getLatestBlockhash(ctx)

--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -33,6 +33,11 @@ const (
 	MaxSigsToConfirm               = 256              // max number of signatures in GetSignatureStatus call
 	EstimateComputeUnitLimitBuffer = 10               // percent buffer added on top of estimated compute unit limits to account for any variance
 	TxReapInterval                 = 10 * time.Second // interval of time between reaping transactions that have met the retention threshold
+	FeeEstimatorModeFixed          = "fixed"
+	FeeEstimatorModeBlockHistory   = "blockhistory"
+	FeeBumpCriteriaFixedIntervals  = "fixed-intervals"
+	FeeBumpCriteriaExpiration      = "expiration"
+	FeeBumpCriteriaNone            = "none"
 )
 
 var _ services.Service = (*Txm)(nil)
@@ -109,21 +114,12 @@ func NewTxm(chainID string, client internal.Loader[client.ReaderWriter],
 // Start subscribes to queuing channel and processes them.
 func (txm *Txm) Start(ctx context.Context) error {
 	return txm.StartOnce("Txm", func() error {
-		// determine estimator type
-		var estimator fees.Estimator
-		var err error
-		switch strings.ToLower(txm.cfg.FeeEstimatorMode()) {
-		case "fixed":
-			estimator, err = fees.NewFixedPriceEstimator(txm.cfg)
-		case "blockhistory":
-			estimator, err = fees.NewBlockHistoryEstimator(txm.client, txm.cfg, txm.lggr)
-		default:
-			err = fmt.Errorf("unknown solana fee estimator type: %s", txm.cfg.FeeEstimatorMode())
-		}
-		if err != nil {
+		// validate config
+		if err := txm.validateConfig(); err != nil {
 			return err
 		}
-		txm.fee = estimator
+
+		// start loops
 		if err := txm.fee.Start(ctx); err != nil {
 			return err
 		}
@@ -141,6 +137,33 @@ func (txm *Txm) Start(ctx context.Context) error {
 
 		return nil
 	})
+}
+
+// validateConfig validates consistency of configs when starting the services.
+func (txm *Txm) validateConfig() (err error) {
+	// Validate fee estimator configuration
+	var estimator fees.Estimator
+	switch strings.ToLower(txm.cfg.FeeEstimatorMode()) {
+	case FeeEstimatorModeFixed:
+		estimator, err = fees.NewFixedPriceEstimator(txm.cfg)
+	case FeeEstimatorModeBlockHistory:
+		estimator, err = fees.NewBlockHistoryEstimator(txm.client, txm.cfg, txm.lggr)
+	default:
+		err = fmt.Errorf("unknown solana fee estimator type: %s", txm.cfg.FeeEstimatorMode())
+	}
+	if err != nil {
+		return err
+	}
+	txm.fee = estimator
+
+	// Validate fee bumping configuration if it's enabled.
+	if txm.cfg.FeeBumpPeriod() > 0 {
+		if txm.cfg.FeeBumpCriteria() != FeeBumpCriteriaFixedIntervals && txm.cfg.FeeBumpCriteria() != FeeBumpCriteriaExpiration && txm.cfg.FeeBumpCriteria() != FeeBumpCriteriaNone {
+			return errors.New("invalid FeeBumpCriteria; must be 'fixed-intervals', 'expiration' or 'none'")
+		}
+	}
+
+	return err
 }
 
 func (txm *Txm) run() {
@@ -176,24 +199,13 @@ func (txm *Txm) run() {
 	}
 }
 
+// sendWithRetry sends a transaction and retries it with exponential backoff if necessary.
+// It builds the initial transaction, sends it, and then starts a retry mechanism in a goroutine.
 func (txm *Txm) sendWithRetry(ctx context.Context, msg pendingTx) (solanaGo.Transaction, string, solanaGo.Signature, error) {
 	// get key
 	// fee payer account is index 0 account
 	// https://github.com/gagliardetto/solana-go/blob/main/transaction.go#L252
 	key := msg.tx.Message.AccountKeys[0].String()
-
-	// base compute unit price should only be calculated once
-	// prevent underlying base changing when bumping (could occur with RPC based estimation)
-	getFee := func(count int) fees.ComputeUnitPrice {
-		fee := fees.CalculateFee(
-			msg.cfg.BaseComputeUnitPrice,
-			msg.cfg.ComputeUnitPriceMax,
-			msg.cfg.ComputeUnitPriceMin,
-			uint(count), //nolint:gosec // reasonable number of bumps should never cause overflow
-		)
-		return fees.ComputeUnitPrice(fee)
-	}
-
 	baseTx := msg.tx
 
 	// add compute unit limit instruction - static for the transaction
@@ -204,32 +216,8 @@ func (txm *Txm) sendWithRetry(ctx context.Context, msg pendingTx) (solanaGo.Tran
 		}
 	}
 
-	buildTx := func(ctx context.Context, base solanaGo.Transaction, retryCount int) (solanaGo.Transaction, error) {
-		newTx := base // make copy
-
-		// set fee
-		// fee bumping can be enabled by moving the setting & signing logic to the broadcaster
-		if computeUnitErr := fees.SetComputeUnitPrice(&newTx, getFee(retryCount)); computeUnitErr != nil {
-			return solanaGo.Transaction{}, computeUnitErr
-		}
-
-		// sign tx
-		txMsg, marshalErr := newTx.Message.MarshalBinary()
-		if marshalErr != nil {
-			return solanaGo.Transaction{}, fmt.Errorf("error in soltxm.SendWithRetry.MarshalBinary: %w", marshalErr)
-		}
-		sigBytes, signErr := txm.ks.Sign(ctx, key, txMsg)
-		if signErr != nil {
-			return solanaGo.Transaction{}, fmt.Errorf("error in soltxm.SendWithRetry.Sign: %w", signErr)
-		}
-		var finalSig [64]byte
-		copy(finalSig[:], sigBytes)
-		newTx.Signatures = append(newTx.Signatures, finalSig)
-
-		return newTx, nil
-	}
-
-	initTx, initBuildErr := buildTx(ctx, baseTx, 0)
+	// Build the initial transaction
+	initTx, initBuildErr := txm.buildTx(ctx, baseTx, key, 0)
 	if initBuildErr != nil {
 		return solanaGo.Transaction{}, "", solanaGo.Signature{}, initBuildErr
 	}
@@ -259,7 +247,7 @@ func (txm *Txm) sendWithRetry(ctx context.Context, msg pendingTx) (solanaGo.Tran
 		return solanaGo.Transaction{}, "", solanaGo.Signature{}, fmt.Errorf("failed to save initial signature in signature list: %w", initSetErr)
 	}
 
-	txm.lggr.Debugw("tx initial broadcast", "id", msg.id, "fee", getFee(0), "signature", sig)
+	txm.lggr.Debugw("tx initial broadcast", "id", msg.id, "fee", txm.getFee(0), "signature", sig)
 
 	txm.done.Add(1)
 	// retry with exponential backoff
@@ -267,35 +255,38 @@ func (txm *Txm) sendWithRetry(ctx context.Context, msg pendingTx) (solanaGo.Tran
 	// pass in copy of baseTx (used to build new tx with bumped fee) and broadcasted tx == initTx (used to retry tx without bumping)
 	go func(ctx context.Context, baseTx, currentTx solanaGo.Transaction) {
 		defer txm.done.Done()
-		deltaT := 1 // ms
-		tick := time.After(0)
-		bumpCount := 0
+		retryInterval := time.Millisecond // Initial retry interval (1ms)
+		bumpCount := 0                    // Number of times the fee has been bumped
 		bumpTime := time.Now()
 		var wg sync.WaitGroup
+
+		// Create a timer that fires immediately
+		retryTimer := time.NewTimer(0)
+		defer retryTimer.Stop()
 
 		for {
 			select {
 			case <-ctx.Done():
-				// stop sending tx after retry tx ctx times out (does not stop confirmation polling for tx)
+				// Wait for any ongoing retries to finish before exiting
 				wg.Wait()
 				txm.lggr.Debugw("stopped tx retry", "id", msg.id, "signatures", sigs.List(), "err", context.Cause(ctx))
 				return
-			case <-tick:
-				var shouldBump bool
-				// bump if period > 0 and past time
-				if msg.cfg.FeeBumpPeriod != 0 && time.Since(bumpTime) > msg.cfg.FeeBumpPeriod {
-					bumpCount++
-					bumpTime = time.Now()
-					shouldBump = true
+			case <-retryTimer.C:
+				// Determine if we should bump the fee and/or update the blockhash
+				shouldBump, needBlockhashUpdate, newBumpTime, err := txm.bumpFeeAndUpdateBlockhash(ctx, msg.id, bumpTime)
+				if err != nil {
+					txm.lggr.Errorw("error determining if should bump fee", "error", err)
+					return
 				}
+				bumpTime = newBumpTime
 
-				// if fee should be bumped, build new tx and replace currentTx
 				if shouldBump {
-					var retryBuildErr error
-					currentTx, retryBuildErr = buildTx(ctx, baseTx, bumpCount)
-					if retryBuildErr != nil {
-						txm.lggr.Errorw("failed to build bumped retry tx", "error", retryBuildErr, "id", msg.id)
-						return // exit func if cannot build tx for retrying
+					bumpCount++
+					// Prepare the retry transaction with a bumped fee and updated blockhash if needed
+					currentTx, err = txm.prepareRetryTx(ctx, baseTx, key, &msg, bumpCount, needBlockhashUpdate)
+					if err != nil {
+						txm.lggr.Errorw("failed to prepare retry transaction", "error", err, "id", msg.id)
+						return
 					}
 					ind := sigs.Allocate()
 					if ind != bumpCount {
@@ -304,65 +295,218 @@ func (txm *Txm) sendWithRetry(ctx context.Context, msg pendingTx) (solanaGo.Tran
 					}
 				}
 
-				// take currentTx and broadcast, if bumped fee -> save signature to list
 				wg.Add(1)
 				go func(bump bool, count int, retryTx solanaGo.Transaction) {
 					defer wg.Done()
-
-					retrySig, retrySendErr := txm.sendTx(ctx, &retryTx)
-					// this could occur if endpoint goes down or if ctx cancelled
-					if retrySendErr != nil {
-						if strings.Contains(retrySendErr.Error(), "context canceled") || strings.Contains(retrySendErr.Error(), "context deadline exceeded") {
-							txm.lggr.Debugw("ctx error on send retry transaction", "error", retrySendErr, "signatures", sigs.List(), "id", msg.id)
-						} else {
-							txm.lggr.Warnw("failed to send retry transaction", "error", retrySendErr, "signatures", sigs.List(), "id", msg.id)
-						}
-						return
-					}
-
-					// save new signature if fee bumped
-					if bump {
-						if retryStoreErr := txm.txs.AddSignature(msg.id, retrySig); retryStoreErr != nil {
-							txm.lggr.Warnw("error in adding retry transaction", "error", retryStoreErr, "id", msg.id)
-							return
-						}
-						if setErr := sigs.Set(count, retrySig); setErr != nil {
-							// this should never happen
-							txm.lggr.Errorw("INVARIANT VIOLATION", "error", setErr)
-						}
-						txm.lggr.Debugw("tx rebroadcast with bumped fee", "id", msg.id, "fee", getFee(count), "signatures", sigs.List())
-					}
-
-					// prevent locking on waitgroup when ctx is closed
-					wait := make(chan struct{})
-					go func() {
-						defer close(wait)
-						sigs.Wait(count) // wait until bump tx has set the tx signature to compare rebroadcast signatures
-					}()
-					select {
-					case <-ctx.Done():
-						return
-					case <-wait:
-					}
-
-					// this should never happen (should match the signature saved to sigs)
-					if fetchedSig, fetchErr := sigs.Get(count); fetchErr != nil || retrySig != fetchedSig {
-						txm.lggr.Errorw("original signature does not match retry signature", "expectedSignatures", sigs.List(), "receivedSignature", retrySig, "error", fetchErr)
-					}
+					// Send the retry transaction in a separate goroutine
+					txm.sendRetryTx(ctx, bump, count, retryTx, msg.id, &sigs)
 				}(shouldBump, bumpCount, currentTx)
 			}
 
-			// exponential increase in wait time, capped at 250ms
-			deltaT *= 2
-			if deltaT > MaxRetryTimeMs {
-				deltaT = MaxRetryTimeMs
-			}
-			tick = time.After(time.Duration(deltaT) * time.Millisecond)
+			// Calculate the next retry interval with exponential backoff. Capped at MaxRetryTimeMs.
+			retryInterval = getNextRetryInterval(retryInterval)
+			resetTimer(retryTimer, retryInterval)
 		}
 	}(ctx, baseTx, initTx)
 
 	// return signed tx, id, signature for use in simulation
 	return initTx, msg.id, sig, nil
+}
+
+// buildTx constructs a new transaction with the specified fee and signs it.
+// It updates the compute unit price and appends the signature to the transaction.
+func (txm *Txm) buildTx(ctx context.Context, baseTx solanaGo.Transaction, key string, retryCount int) (solanaGo.Transaction, error) {
+	// Set fee
+	if computeUnitErr := fees.SetComputeUnitPrice(&baseTx, txm.getFee(retryCount)); computeUnitErr != nil {
+		return solanaGo.Transaction{}, computeUnitErr
+	}
+
+	// Serialize the transaction message for signing
+	txMsg, marshalErr := baseTx.Message.MarshalBinary()
+	if marshalErr != nil {
+		return solanaGo.Transaction{}, fmt.Errorf("error in MarshalBinary: %w", marshalErr)
+	}
+
+	// Sign the transaction message using the key
+	sigBytes, signErr := txm.ks.Sign(ctx, key, txMsg)
+	if signErr != nil {
+		return solanaGo.Transaction{}, fmt.Errorf("error in Sign: %w", signErr)
+	}
+
+	// Append the signature to the transaction
+	var finalSig [64]byte
+	copy(finalSig[:], sigBytes)
+	baseTx.Signatures = append(baseTx.Signatures, finalSig)
+
+	return baseTx, nil
+}
+
+// getFee calculates the compute unit price for a transaction based on the number of retries.
+func (txm *Txm) getFee(count int) fees.ComputeUnitPrice {
+	// base compute unit price should only be calculated once
+	// prevent underlying base changing when bumping (could occur with RPC based estimation)
+	fee := fees.CalculateFee(
+		txm.cfg.ComputeUnitPriceDefault(),
+		txm.cfg.ComputeUnitPriceMax(),
+		txm.cfg.ComputeUnitPriceMin(),
+		uint(count), //nolint:gosec // reasonable number of bumps should never cause overflow
+	)
+	return fees.ComputeUnitPrice(fee)
+}
+
+// bumpFeeAndUpdateBlockhash determines whether the transaction fee should be bumped
+// and whether the blockhash needs to be updated based on the configured criteria.
+func (txm *Txm) bumpFeeAndUpdateBlockhash(ctx context.Context, txID string, bumpTime time.Time) (shouldBump bool, needBlockhashUpdate bool, newBumpTime time.Time, err error) {
+	// helper function to get current height
+	getCurrentHeight := func(ctx context.Context) (uint64, error) {
+		client, err := txm.client.Get()
+		if err != nil {
+			return 0, err
+		}
+
+		currHeight, err := client.SlotHeight(ctx)
+		if err != nil {
+			return 0, err
+		}
+
+		return currHeight, nil
+	}
+
+	newBumpTime = bumpTime
+	// Check if fee bumping is enabled and decide based on the criteria
+	if txm.cfg.FeeBumpPeriod() > 0 {
+		switch txm.cfg.FeeBumpCriteria() {
+		case FeeBumpCriteriaFixedIntervals:
+			// Bump the fee at fixed intervals
+			if time.Since(bumpTime) >= txm.cfg.FeeBumpPeriod() {
+				shouldBump = true
+				newBumpTime = time.Now()
+			}
+		case FeeBumpCriteriaExpiration:
+			// Bump the fee if the blockhash has expired
+			currHeight, err := getCurrentHeight(ctx)
+			if err != nil {
+				return false, false, bumpTime, fmt.Errorf("failed to get current height: %w", err)
+			}
+			if txm.txs.IsBlockhashExpired(txID, currHeight) {
+				shouldBump = true
+				needBlockhashUpdate = true
+			}
+		case FeeBumpCriteriaNone:
+			// Do not bump the fee
+			shouldBump = false
+		default:
+			txm.lggr.Errorw("unknown fee bump criteria", "criteria", txm.cfg.FeeBumpCriteria())
+		}
+	}
+
+	return shouldBump, needBlockhashUpdate, newBumpTime, nil
+}
+
+// prepareRetryTx prepares a new transaction for retrying by optionally updating the blockhash
+// and rebuilding the transaction with a bumped fee.
+func (txm *Txm) prepareRetryTx(ctx context.Context, baseTx solanaGo.Transaction, key string, msg *pendingTx, retryCount int, needBlockhashUpdate bool) (solanaGo.Transaction, error) {
+	// helper function to get latest blockhash
+	getLatestBlockhash := func(ctx context.Context) (*rpc.GetLatestBlockhashResult, error) {
+		client, err := txm.client.Get()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get client: %w", err)
+		}
+		blockhashResult, err := client.LatestBlockhash(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get latest blockhash: %w", err)
+		}
+
+		return blockhashResult, nil
+	}
+
+	// We need to update blockhash in retryTx and pendingTx context if it has expired. Only meaningful for FeeBumpCriteria='expiration'.
+	if needBlockhashUpdate {
+		// Updates Blockhash and LastValidBlockHeight in the retry transaction
+		blockhashResult, err := getLatestBlockhash(ctx)
+		if err != nil {
+			return solanaGo.Transaction{}, fmt.Errorf("failed to get latest blockhash: %w", err)
+		}
+		baseTx.Message.RecentBlockhash = blockhashResult.Value.Blockhash
+		msg.lastValidBlockHeight = blockhashResult.Value.LastValidBlockHeight
+
+		// updates Blockhash and LastValidBlockHeight in txPending context.
+		err = txm.txs.UpdateBlockhash(msg.id, blockhashResult)
+		if err != nil {
+			return solanaGo.Transaction{}, fmt.Errorf("failed to update blockhash in txPending context: %w", err)
+		}
+	}
+
+	// return new transaction with bumped fee and blockhash updated if needed.
+	return txm.buildTx(ctx, baseTx, key, retryCount)
+}
+
+// sendRetryTx sends a retry transaction with an optional fee bump.
+// It handles sending the transaction and updating the signature tracking.
+func (txm *Txm) sendRetryTx(ctx context.Context, bump bool, count int, retryTx solanaGo.Transaction, txID string, sigs *signatureList) {
+	retrySig, retrySendErr := txm.sendTx(ctx, &retryTx)
+	// Handle send errors
+	if retrySendErr != nil {
+		if strings.Contains(retrySendErr.Error(), "context canceled") || strings.Contains(retrySendErr.Error(), "context deadline exceeded") {
+			txm.lggr.Debugw("ctx error on send retry transaction", "error", retrySendErr, "signatures", sigs.List(), "id", txID)
+		} else {
+			txm.lggr.Warnw("failed to send retry transaction", "error", retrySendErr, "signatures", sigs.List(), "id", txID)
+		}
+		return
+	}
+
+	// If the fee was bumped, save the new signature and update tracking
+	if bump {
+		if retryStoreErr := txm.txs.AddSignature(txID, retrySig); retryStoreErr != nil {
+			txm.lggr.Warnw("error in adding retry transaction", "error", retryStoreErr, "id", txID)
+			return
+		}
+		if setErr := sigs.Set(count, retrySig); setErr != nil {
+			txm.lggr.Errorw("INVARIANT VIOLATION", "error", setErr)
+		}
+		txm.lggr.Debugw("tx rebroadcast with bumped fee", "id", txID, "fee", txm.getFee(count), "signatures", sigs.List())
+	}
+
+	// Wait for signature synchronization. Prevent locking on waitgroup when ctx is closed
+	wait := make(chan struct{})
+	go func() {
+		defer close(wait)
+		sigs.Wait(count)
+	}()
+	select {
+	case <-ctx.Done():
+		return
+	case <-wait:
+	}
+
+	// Check for invariant violation. Verify that the fetched signature matches the expected one
+	if fetchedSig, fetchErr := sigs.Get(count); fetchErr != nil || retrySig != fetchedSig {
+		txm.lggr.Errorw("original signature does not match retry signature", "expectedSignatures", sigs.List(), "receivedSignature", retrySig, "error", fetchErr)
+	}
+}
+
+// getNextRetryInterval calculates the next retry interval using exponential backoff.
+// It doubles the current interval up to a maximum defined by MaxRetryTimeMs.
+func getNextRetryInterval(currentInterval time.Duration) time.Duration {
+	nextInterval := currentInterval * 2
+	maxInterval := time.Duration(MaxRetryTimeMs) * time.Millisecond
+	if nextInterval > maxInterval {
+		return maxInterval
+	}
+	return nextInterval
+}
+
+// resetTimer safely resets a time.Timer to the new interval.
+// It ensures that the timer is stopped and the channel is drained before resetting.
+func resetTimer(timer *time.Timer, newInterval time.Duration) {
+	if !timer.Stop() {
+		// If the timer has already expired, drain the channel to prevent race conditions.
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(newInterval)
 }
 
 // goroutine that polls to confirm implementation
@@ -564,7 +708,7 @@ func (txm *Txm) reap() {
 }
 
 // Enqueue enqueues a msg destined for the solana chain.
-func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Transaction, txID *string, txCfgs ...SetTxConfig) error {
+func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Transaction, txID *string, LastValidBlockHeight uint64, txCfgs ...SetTxConfig) error {
 	if err := txm.Ready(); err != nil {
 		return fmt.Errorf("error in soltxm.Enqueue: %w", err)
 	}
@@ -609,9 +753,10 @@ func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Tran
 		id = *txID
 	}
 	msg := pendingTx{
-		tx:  *tx,
-		cfg: cfg,
-		id:  id,
+		tx:                   *tx,
+		cfg:                  cfg,
+		id:                   id,
+		lastValidBlockHeight: LastValidBlockHeight,
 	}
 
 	select {

--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -68,7 +68,8 @@ type TxConfig struct {
 	Timeout time.Duration // transaction broadcast timeout
 
 	// compute unit price config
-	FeeBumpPeriod        time.Duration // how often to bump fee
+	FeeBumpCriteria      string        // "fixed-interval": bump every fixed period. "expiration": bump based on blockhash expiration
+	FeeBumpPeriod        time.Duration // "fixed-interval": how often to bump. "expiration": how often to check if should blockhash has expired and we need to bump
 	BaseComputeUnitPrice uint64        // starting price
 	ComputeUnitPriceMin  uint64        // min price
 	ComputeUnitPriceMax  uint64        // max price
@@ -755,6 +756,7 @@ func (txm *Txm) HealthReport() map[string]error { return map[string]error{txm.Na
 func (txm *Txm) defaultTxConfig() TxConfig {
 	return TxConfig{
 		Timeout:                  txm.cfg.TxRetryTimeout(),
+		FeeBumpCriteria:          txm.cfg.FeeBumpCriteria(),
 		FeeBumpPeriod:            txm.cfg.FeeBumpPeriod(),
 		BaseComputeUnitPrice:     txm.fee.BaseComputeUnitPrice(),
 		ComputeUnitPriceMin:      txm.cfg.ComputeUnitPriceMin(),

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -1003,6 +1003,7 @@ func TestTxm_Enqueue(t *testing.T) {
 	lggr := logger.Test(t)
 	cfg := config.NewDefault()
 	mc := mocks.NewReaderWriter(t)
+	mc.On("SlotHeight", mock.Anything).Return(uint64(1000), nil).Maybe()
 	mc.On("SendTx", mock.Anything, mock.Anything).Return(solana.Signature{}, nil).Maybe()
 	mc.On("SimulateTx", mock.Anything, mock.Anything, mock.Anything).Return(&rpc.SimulateTransactionResult{}, nil).Maybe()
 	mc.On("SignatureStatuses", mock.Anything, mock.AnythingOfType("[]solana.Signature")).Return(

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -1078,3 +1078,292 @@ func TestTxm_Enqueue(t *testing.T) {
 		})
 	}
 }
+func TestTxm_fee_bumping(t *testing.T) {
+	tests := []struct {
+		name                string
+		feeBumpCriteria     string
+		txRetentionTimeout  time.Duration
+		txConfirmTimeout    time.Duration
+		expectedSendCount   int
+		expectedPromMetrics soltxmProm
+	}{
+		{
+			name:               "fixed intervals",
+			feeBumpCriteria:    FeeBumpCriteriaFixedIntervals,
+			txConfirmTimeout:   7 * time.Second,
+			txRetentionTimeout: 3 * time.Second,
+			expectedPromMetrics: soltxmProm{
+				confirmed: 1,
+				finalized: 1,
+			},
+		},
+		{
+			name:               "expiration",
+			feeBumpCriteria:    FeeBumpCriteriaExpiration,
+			txConfirmTimeout:   3 * time.Second,
+			txRetentionTimeout: 7 * time.Second,
+			expectedPromMetrics: soltxmProm{
+				confirmed: 1,
+				finalized: 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Configure short timeouts for testing
+			estimator := "fixed"
+			id := "mocknet-" + estimator + "-" + uuid.NewString()
+			t.Logf("Starting fee bumping test: %s", id)
+
+			ctx := context.Background()
+			lggr := logger.Test(t)
+
+			// Set short TxConfirmTimeout and TxRetentionTimeout
+			cfg := config.NewDefault()
+			cfg.Chain.FeeEstimatorMode = &estimator
+			cfg.Chain.TxRetentionTimeout = relayconfig.MustNewDuration(tt.txRetentionTimeout)
+			cfg.Chain.TxConfirmTimeout = relayconfig.MustNewDuration(tt.txConfirmTimeout)
+			cfg.Chain.FeeBumpCriteria = &tt.feeBumpCriteria
+			computeUnitLimitDefault := fees.ComputeUnitLimit(cfg.ComputeUnitLimitDefault())
+
+			// Initialize mocked Solana client
+			mc := mocks.NewReaderWriter(t)
+			mc.On("GetLatestBlock", mock.Anything).Return(&rpc.GetBlockResult{}, nil).Maybe()
+			mc.On("SlotHeight", mock.Anything).Return(uint64(1000), nil).Maybe()
+			mc.On("LatestBlockhash", mock.Anything).Return(&rpc.GetLatestBlockhashResult{
+				Value: &rpc.LatestBlockhashResult{
+					LastValidBlockHeight: 1100, // expired because slotHeight is 1000. Will retry.
+					Blockhash:            solana.Hash{},
+				},
+			}, nil).Maybe()
+
+			// mock solana keystore
+			mkey := keyMocks.NewSimpleKeystore(t)
+			mkey.On("Sign", mock.Anything, mock.Anything, mock.Anything).Return([]byte{}, nil)
+
+			loader := utils.NewLazyLoad(func() (client.ReaderWriter, error) { return mc, nil })
+			txm := NewTxm(id, loader, nil, cfg, mkey, lggr)
+			require.NoError(t, txm.Start(ctx))
+			t.Cleanup(func() { require.NoError(t, txm.Close()) })
+
+			// tracking prom metrics
+			prom := soltxmProm{id: id}
+
+			// handle signature statuses calls
+			statuses := map[solana.Signature]func() *rpc.SignatureStatusesResult{}
+			mc.On("SignatureStatuses", mock.Anything, mock.AnythingOfType("[]solana.Signature")).Return(
+				func(_ context.Context, sigs []solana.Signature) (out []*rpc.SignatureStatusesResult) {
+					for i := range sigs {
+						get, exists := statuses[sigs[i]]
+						if !exists {
+							out = append(out, nil)
+							continue
+						}
+						out = append(out, get())
+					}
+					return out
+				}, nil,
+			)
+
+			// Prepare transaction expired and bump that won't get through
+			tx, signed := getTx(t, 1000, mkey)
+			sig := randomSignature(t)
+			retry0 := randomSignature(t)
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			mc.On("SlotHeight", mock.Anything).Return(uint64(1200), nil)
+			sendCount := 0
+			var countRW sync.RWMutex
+			mc.On("SendTx", mock.Anything, signed(0, true, computeUnitLimitDefault)).Run(func(mock.Arguments) {
+				countRW.Lock()
+				sendCount++
+				countRW.Unlock()
+			}).After(500*time.Millisecond).Return(sig, nil)
+			mc.On("SendTx", mock.Anything, signed(1, true, computeUnitLimitDefault)).Run(func(mock.Arguments) {
+				countRW.Lock()
+				sendCount++
+				countRW.Unlock()
+			}).After(500*time.Millisecond).Return(retry0, nil)
+			mc.On("SimulateTx", mock.Anything, signed(0, true, computeUnitLimitDefault), mock.Anything).Run(func(mock.Arguments) {
+				wg.Done()
+			}).Return(&rpc.SimulateTransactionResult{}, nil).Once()
+
+			// We want the bumped tx to be processed, confirmed and finalized.
+			statuses[sig] = func() (out *rpc.SignatureStatusesResult) {
+				out = &rpc.SignatureStatusesResult{}
+				return
+			}
+			statusCount := 0
+			statuses[retry0] = func() (out *rpc.SignatureStatusesResult) {
+				defer func() { statusCount++ }()
+				out = &rpc.SignatureStatusesResult{}
+				if statusCount == 1 {
+					out.ConfirmationStatus = rpc.ConfirmationStatusConfirmed
+					return
+				}
+				if statusCount == 2 {
+					out.ConfirmationStatus = rpc.ConfirmationStatusFinalized
+					wg.Done()
+					return
+				}
+				out.ConfirmationStatus = rpc.ConfirmationStatusProcessed
+				return
+			}
+
+			// tx should be able to queue
+			testTxID := uuid.New().String()
+			assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
+			wg.Wait()                                                       // wait to be picked up and processed
+			waitFor(t, tt.txConfirmTimeout+1*time.Second, txm, prom, empty) // inflight txs cleared after timeout
+
+			// transaction should be sent multiple times
+			countRW.RLock()
+			assert.Greater(t, sendCount, 2)
+			countRW.RUnlock()
+
+			// panic if sendTx called after context cancelled
+			mc.On("SendTx", mock.Anything, tx).Panic("SendTx should not be called anymore").Maybe()
+
+			// check prom metric
+			prom.confirmed++ // bumped tx should be confirmed
+			prom.finalized++ // bumped tx should be finalized
+			prom.assertEqual(t)
+
+			// check transaction status which should still be stored
+			status, err := txm.GetTransactionStatus(ctx, testTxID)
+			require.NoError(t, err)
+			require.Equal(t, types.Finalized, status)
+
+			// Sleep until retention period has passed for transaction and for another reap cycle to run
+			time.Sleep(tt.txRetentionTimeout + 1*time.Second)
+
+			// check if transaction has been purged from memory
+			status, err = txm.GetTransactionStatus(ctx, testTxID)
+			require.Error(t, err)
+			require.Equal(t, types.Unknown, status)
+		})
+	}
+}
+
+func TestTxm_no_fee_bumping(t *testing.T) {
+	// Configure short timeouts for testing
+	estimator := "fixed"
+	id := "mocknet-" + estimator + "-" + uuid.NewString()
+	t.Logf("Starting no fee bumping test: %s", id)
+
+	ctx := context.Background()
+	lggr := logger.Test(t)
+
+	// Set short TxConfirmTimeout and TxRetentionTimeout
+	cfg := config.NewDefault()
+	cfg.Chain.FeeEstimatorMode = &estimator
+	cfg.Chain.TxRetentionTimeout = relayconfig.MustNewDuration(5 * time.Second)
+	cfg.Chain.TxConfirmTimeout = relayconfig.MustNewDuration(2 * time.Second)
+	feeBumpCriteriaNone := FeeBumpCriteriaNone
+	cfg.Chain.FeeBumpCriteria = &feeBumpCriteriaNone
+	cfg.Chain.FeeBumpPeriod = relayconfig.MustNewDuration(0 * time.Second)
+	computeUnitLimitDefault := fees.ComputeUnitLimit(cfg.ComputeUnitLimitDefault())
+
+	// Initialize mocked Solana client
+	mc := mocks.NewReaderWriter(t)
+	mc.On("GetLatestBlock", mock.Anything).Return(&rpc.GetBlockResult{}, nil).Maybe()
+	mc.On("SlotHeight", mock.Anything).Return(uint64(1000), nil).Maybe()
+	mc.On("LatestBlockhash", mock.Anything).Return(&rpc.GetLatestBlockhashResult{
+		Value: &rpc.LatestBlockhashResult{
+			LastValidBlockHeight: 1100, // expired because slotHeight is 1000. Won't retry.
+			Blockhash:            solana.Hash{},
+		},
+	}, nil).Maybe()
+
+	// mock solana keystore
+	mkey := keyMocks.NewSimpleKeystore(t)
+	mkey.On("Sign", mock.Anything, mock.Anything, mock.Anything).Return([]byte{}, nil)
+
+	loader := utils.NewLazyLoad(func() (client.ReaderWriter, error) { return mc, nil })
+	txm := NewTxm(id, loader, nil, cfg, mkey, lggr)
+	require.NoError(t, txm.Start(ctx))
+	t.Cleanup(func() { require.NoError(t, txm.Close()) })
+
+	// tracking prom metrics
+	prom := soltxmProm{id: id}
+
+	// handle signature statuses calls
+	statuses := map[solana.Signature]func() *rpc.SignatureStatusesResult{}
+	mc.On("SignatureStatuses", mock.Anything, mock.AnythingOfType("[]solana.Signature")).Return(
+		func(_ context.Context, sigs []solana.Signature) (out []*rpc.SignatureStatusesResult) {
+			for i := range sigs {
+				get, exists := statuses[sigs[i]]
+				if !exists {
+					out = append(out, nil)
+					continue
+				}
+				out = append(out, get())
+			}
+			return out
+		}, nil,
+	)
+
+	// Prepare transaction that won't get through
+	tx, signed := getTx(t, 1000, mkey)
+	sig := randomSignature(t)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	mc.On("SlotHeight", mock.Anything).Return(uint64(1200), nil)
+	sendCount := 0
+	var countRW sync.RWMutex
+	mc.On("SendTx", mock.Anything, signed(0, true, computeUnitLimitDefault)).Run(func(mock.Arguments) {
+		countRW.Lock()
+		sendCount++
+		countRW.Unlock()
+	}).After(500*time.Millisecond).Return(sig, nil)
+	mc.On("SimulateTx", mock.Anything, signed(0, true, computeUnitLimitDefault), mock.Anything).Run(func(mock.Arguments) {
+		wg.Done()
+	}).Return(&rpc.SimulateTransactionResult{}, nil).Once()
+
+	// We don't want the tx to go through.
+	statuses[sig] = func() (out *rpc.SignatureStatusesResult) {
+		out = &rpc.SignatureStatusesResult{}
+		out.ConfirmationStatus = rpc.ConfirmationStatusProcessed
+		return
+	}
+
+	// tx should be able to queue
+	testTxID := uuid.New().String()
+	assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
+	wg.Wait() // wait to be picked up and processed
+
+	// check transaction is pending
+	status, err := txm.GetTransactionStatus(ctx, testTxID)
+	require.NoError(t, err)
+	require.Equal(t, types.Pending, status)
+
+	// inflight txs cleared after timeout
+	waitFor(t, cfg.Chain.TxRetentionTimeout.Duration()+1*time.Second, txm, prom, empty)
+
+	// transaction should be sent multiple times but shouldn't get through
+	countRW.RLock()
+	assert.Greater(t, sendCount, 1)
+	countRW.RUnlock()
+
+	// check transaction is failed
+	status, err = txm.GetTransactionStatus(ctx, testTxID)
+	require.NoError(t, err)
+	require.Equal(t, types.Failed, status)
+
+	// panic if sendTx called after context cancelled
+	mc.On("SendTx", mock.Anything, tx).Panic("SendTx should not be called anymore").Maybe()
+
+	// check prom metric. Bumped tx should be dropped an errored.
+	prom.error++
+	prom.drop++
+	prom.assertEqual(t)
+
+	// check transaction was deleted from memory
+	time.Sleep(cfg.Chain.TxRetentionTimeout.Duration() + 3*time.Second)
+	status, err = txm.GetTransactionStatus(ctx, testTxID)
+	require.Error(t, err)
+	require.Equal(t, types.Unknown, status)
+}

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -805,6 +805,7 @@ func TestTxm_disabled_confirm_timeout_with_retention(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	mc.On("SlotHeight", mock.Anything).Return(uint64(1000), nil)
 	mc.On("SendTx", mock.Anything, signed(0, true, computeUnitLimitDefault)).Return(sig, nil)
 	mc.On("SendTx", mock.Anything, signed(1, true, computeUnitLimitDefault)).Return(retry0, nil).Maybe()
 	mc.On("SendTx", mock.Anything, signed(2, true, computeUnitLimitDefault)).Return(retry1, nil).Maybe()
@@ -916,6 +917,8 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 
 		computeUnitConsumed := uint64(1_000_000)
 		computeUnitLimit := fees.ComputeUnitLimit(uint32(bigmath.AddPercentage(new(big.Int).SetUint64(computeUnitConsumed), EstimateComputeUnitLimitBuffer).Uint64()))
+
+		mc.On("SlotHeight", mock.Anything).Return(uint64(1000), nil)
 		mc.On("SendTx", mock.Anything, signed(0, true, computeUnitLimit)).Return(sig, nil)
 		// First simulated before broadcast without signature or compute unit limit set
 		mc.On("SimulateTx", mock.Anything, tx, mock.Anything).Run(func(mock.Arguments) {
@@ -973,6 +976,7 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 		tx, signed := getTx(t, 1, mkey)
 		sig := randomSignature(t)
 
+		mc.On("SlotHeight", mock.Anything).Return(uint64(1000), nil)
 		mc.On("SendTx", mock.Anything, signed(0, true, fees.ComputeUnitLimit(0))).Return(sig, nil).Panic("SendTx should never be called").Maybe()
 		mc.On("SimulateTx", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("simulation failed")).Once()
 
@@ -985,6 +989,7 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 		tx, signed := getTx(t, 1, mkey)
 		sig := randomSignature(t)
 
+		mc.On("SlotHeight", mock.Anything).Return(uint64(1000), nil)
 		mc.On("SendTx", mock.Anything, signed(0, true, fees.ComputeUnitLimit(0))).Return(sig, nil).Panic("SendTx should never be called").Maybe()
 		mc.On("SimulateTx", mock.Anything, tx, mock.Anything).Return(&rpc.SimulateTransactionResult{Err: errors.New("tx err")}, nil).Once()
 

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -136,7 +136,7 @@ func TestTxm(t *testing.T) {
 			loader := utils.NewLazyLoad(func() (client.ReaderWriter, error) { return mc, nil })
 			txm := NewTxm(id, loader, nil, cfg, mkey, lggr)
 			require.NoError(t, txm.Start(ctx))
-			t.Cleanup(func () { require.NoError(t, txm.Close())})
+			t.Cleanup(func() { require.NoError(t, txm.Close()) })
 
 			// tracking prom metrics
 			prom := soltxmProm{id: id}
@@ -203,7 +203,7 @@ func TestTxm(t *testing.T) {
 
 				// send tx
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait()
 
 				// no transactions stored inflight txs list
@@ -239,7 +239,7 @@ func TestTxm(t *testing.T) {
 
 				// tx should be able to queue
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait() // wait to be picked up and processed
 
 				// no transactions stored inflight txs list
@@ -271,7 +271,7 @@ func TestTxm(t *testing.T) {
 
 				// tx should be able to queue
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait()                                  // wait to be picked up and processed
 				waitFor(t, waitDuration, txm, prom, empty) // txs cleared quickly
 
@@ -307,7 +307,7 @@ func TestTxm(t *testing.T) {
 
 				// tx should be able to queue
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait()                                  // wait to be picked up and processed
 				waitFor(t, waitDuration, txm, prom, empty) // txs cleared after timeout
 
@@ -347,7 +347,7 @@ func TestTxm(t *testing.T) {
 
 				// tx should be able to queue
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait()                                  // wait to be picked up and processed
 				waitFor(t, waitDuration, txm, prom, empty) // txs cleared after timeout
 
@@ -398,7 +398,7 @@ func TestTxm(t *testing.T) {
 
 				// tx should be able to queue
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait()                                  // wait to be picked up and processed
 				waitFor(t, waitDuration, txm, prom, empty) // txs cleared after timeout
 
@@ -440,7 +440,7 @@ func TestTxm(t *testing.T) {
 
 				// tx should be able to queue
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait()                                  // wait to be picked up and processed
 				waitFor(t, waitDuration, txm, prom, empty) // txs cleared after timeout
 
@@ -485,7 +485,7 @@ func TestTxm(t *testing.T) {
 
 				// tx should be able to queue
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait()                                  // wait to be picked up and processed
 				waitFor(t, waitDuration, txm, prom, empty) // inflight txs cleared after timeout
 
@@ -537,7 +537,7 @@ func TestTxm(t *testing.T) {
 
 				// tx should be able to queue
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait()                                  // wait to be picked up and processed
 				waitFor(t, waitDuration, txm, prom, empty) // inflight txs cleared after timeout
 
@@ -575,7 +575,7 @@ func TestTxm(t *testing.T) {
 
 				// tx should be able to queue
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait()                                  // wait to be picked up and processed
 				waitFor(t, waitDuration, txm, prom, empty) // inflight txs cleared after timeout
 
@@ -621,7 +621,7 @@ func TestTxm(t *testing.T) {
 
 				// send tx
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 				wg.Wait()
 
 				// no transactions stored inflight txs list
@@ -675,7 +675,7 @@ func TestTxm(t *testing.T) {
 
 				// send tx - with disabled fee bumping
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, SetFeeBumpPeriod(0)))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0), SetFeeBumpPeriod(0)))
 				wg.Wait()
 
 				// no transactions stored inflight txs list
@@ -727,7 +727,7 @@ func TestTxm(t *testing.T) {
 
 				// send tx - with disabled fee bumping and disabled compute unit limit
 				testTxID := uuid.New().String()
-				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, SetFeeBumpPeriod(0), SetComputeUnitLimit(0)))
+				assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0), SetFeeBumpPeriod(0), SetComputeUnitLimit(0)))
 				wg.Wait()
 
 				// no transactions stored inflight txs list
@@ -776,7 +776,7 @@ func TestTxm_disabled_confirm_timeout_with_retention(t *testing.T) {
 	loader := utils.NewLazyLoad(func() (client.ReaderWriter, error) { return mc, nil })
 	txm := NewTxm(id, loader, nil, cfg, mkey, lggr)
 	require.NoError(t, txm.Start(ctx))
-	t.Cleanup(func () { require.NoError(t, txm.Close())})
+	t.Cleanup(func() { require.NoError(t, txm.Close()) })
 
 	// tracking prom metrics
 	prom := soltxmProm{id: id}
@@ -833,7 +833,7 @@ func TestTxm_disabled_confirm_timeout_with_retention(t *testing.T) {
 
 	// tx should be able to queue
 	testTxID := uuid.New().String()
-	assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+	assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 	wg.Wait()                                   // wait to be picked up and processed
 	waitFor(t, 5*time.Second, txm, prom, empty) // inflight txs cleared after timeout
 
@@ -851,7 +851,7 @@ func TestTxm_disabled_confirm_timeout_with_retention(t *testing.T) {
 	require.Equal(t, types.Finalized, status)
 
 	// Sleep until retention period has passed for transaction and for another reap cycle to run
-	time.Sleep(10 *time.Second)
+	time.Sleep(10 * time.Second)
 
 	// check if transaction has been purged from memory
 	status, err = txm.GetTransactionStatus(ctx, testTxID)
@@ -886,7 +886,7 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 	loader := utils.NewLazyLoad(func() (client.ReaderWriter, error) { return mc, nil })
 	txm := NewTxm(id, loader, nil, cfg, mkey, lggr)
 	require.NoError(t, txm.Start(ctx))
-	t.Cleanup(func () { require.NoError(t, txm.Close())})
+	t.Cleanup(func() { require.NoError(t, txm.Close()) })
 
 	// tracking prom metrics
 	prom := soltxmProm{id: id}
@@ -949,7 +949,7 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 
 		// send tx
 		testTxID := uuid.New().String()
-		assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID))
+		assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, uint64(0)))
 		wg.Wait()
 
 		// no transactions stored inflight txs list
@@ -977,7 +977,7 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 		mc.On("SimulateTx", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("simulation failed")).Once()
 
 		// tx should NOT be able to queue
-		assert.Error(t, txm.Enqueue(ctx, t.Name(), tx, nil))
+		assert.Error(t, txm.Enqueue(ctx, t.Name(), tx, nil, uint64(0)))
 	})
 
 	t.Run("simulation_returns_error", func(t *testing.T) {
@@ -989,7 +989,7 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 		mc.On("SimulateTx", mock.Anything, tx, mock.Anything).Return(&rpc.SimulateTransactionResult{Err: errors.New("tx err")}, nil).Once()
 
 		// tx should NOT be able to queue
-		assert.Error(t, txm.Enqueue(ctx, t.Name(), tx, nil))
+		assert.Error(t, txm.Enqueue(ctx, t.Name(), tx, nil, uint64(0)))
 	})
 }
 
@@ -1047,7 +1047,7 @@ func TestTxm_Enqueue(t *testing.T) {
 	loader := utils.NewLazyLoad(func() (client.ReaderWriter, error) { return mc, nil })
 	txm := NewTxm("enqueue_test", loader, nil, cfg, mkey, lggr)
 
-	require.ErrorContains(t, txm.Enqueue(ctx, "txmUnstarted", &solana.Transaction{}, nil), "not started")
+	require.ErrorContains(t, txm.Enqueue(ctx, "txmUnstarted", &solana.Transaction{}, nil, uint64(0)), "not started")
 	require.NoError(t, txm.Start(ctx))
 	t.Cleanup(func() { require.NoError(t, txm.Close()) })
 
@@ -1065,10 +1065,10 @@ func TestTxm_Enqueue(t *testing.T) {
 	for _, run := range txs {
 		t.Run(run.name, func(t *testing.T) {
 			if !run.fail {
-				assert.NoError(t, txm.Enqueue(ctx, run.name, run.tx, nil))
+				assert.NoError(t, txm.Enqueue(ctx, run.name, run.tx, nil, uint64(0)))
 				return
 			}
-			assert.Error(t, txm.Enqueue(ctx, run.name, run.tx, nil))
+			assert.Error(t, txm.Enqueue(ctx, run.name, run.tx, nil, uint64(0)))
 		})
 	}
 }

--- a/pkg/solana/txm/txm_load_test.go
+++ b/pkg/solana/txm/txm_load_test.go
@@ -84,14 +84,10 @@ func TestTxm_Integration(t *testing.T) {
 			// already started
 			assert.Error(t, txm.Start(ctx))
 
-			getLatestBlockhash := func() (solana.Hash, uint64) {
-				hash, err := client.LatestBlockhash(ctx)
-				require.NoError(t, err)
-				return hash.Value.Blockhash, hash.Value.LastValidBlockHeight
-			}
-
-			createTx := func(hash solana.Hash, signer solana.PublicKey, sender solana.PublicKey, receiver solana.PublicKey, amt uint64) *solana.Transaction {
+			createTx := func(signer solana.PublicKey, sender solana.PublicKey, receiver solana.PublicKey, amt uint64) (*solana.Transaction, uint64) {
 				// create transfer tx
+				hash, err := client.LatestBlockhash(ctx)
+				assert.NoError(t, err)
 				tx, err := solana.NewTransaction(
 					[]solana.Instruction{
 						system.NewTransferInstruction(
@@ -100,28 +96,30 @@ func TestTxm_Integration(t *testing.T) {
 							receiver,
 						).Build(),
 					},
-					hash,
+					hash.Value.Blockhash,
 					solana.TransactionPayer(signer),
 				)
 				require.NoError(t, err)
-				return tx
+				return tx, hash.Value.LastValidBlockHeight
 			}
 
 			// enqueue txs (must pass to move on to load test)
-			blockhash1, lastValidBlockHeight1 := getLatestBlockhash()
-			require.NoError(t, txm.Enqueue(ctx, "test_success_0", createTx(blockhash1, pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil, lastValidBlockHeight1))
-			require.Error(t, txm.Enqueue(ctx, "test_invalidSigner", createTx(blockhash1, pubKeyReceiver, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil, lastValidBlockHeight1)) // cannot sign tx before enqueuing
-			require.NoError(t, txm.Enqueue(ctx, "test_invalidReceiver", createTx(blockhash1, pubKey, pubKey, solana.PublicKey{}, solana.LAMPORTS_PER_SOL), nil, lastValidBlockHeight1))
-
-			// use new blockhash
-			blockhash2, lastValidBlockHeight2 := getLatestBlockhash()
-			require.NoError(t, txm.Enqueue(ctx, "test_success_1", createTx(blockhash2, pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil, lastValidBlockHeight2))
-			require.NoError(t, txm.Enqueue(ctx, "test_txFail", createTx(blockhash2, pubKey, pubKey, pubKeyReceiver, 1000*solana.LAMPORTS_PER_SOL), nil, lastValidBlockHeight2))
+			tx1, lastValidBlockHeight1 := createTx(pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
+			require.NoError(t, txm.Enqueue(ctx, "test_success_0", tx1, nil, lastValidBlockHeight1))
+			tx2, lastValidBlockHeight2 := createTx(pubKeyReceiver, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
+			require.Error(t, txm.Enqueue(ctx, "test_invalidSigner", tx2, nil, lastValidBlockHeight2)) // cannot sign tx before enqueuing
+			tx3, lastValidBlockHeight3 := createTx(pubKey, pubKey, solana.PublicKey{}, solana.LAMPORTS_PER_SOL)
+			require.NoError(t, txm.Enqueue(ctx, "test_invalidReceiver", tx3, nil, lastValidBlockHeight3))
+			time.Sleep(500 * time.Millisecond) // pause 0.5s for new blockhash
+			tx4, lastValidBlockHeight4 := createTx(pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
+			require.NoError(t, txm.Enqueue(ctx, "test_success_1", tx4, nil, lastValidBlockHeight4))
+			tx5, lastValidBlockHeight5 := createTx(pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
+			require.NoError(t, txm.Enqueue(ctx, "test_txFail", tx5, nil, lastValidBlockHeight5))
 
 			// load test: try to overload txs, confirm, or simulation
 			for i := 0; i < 1000; i++ {
-				blockhash, lastValidBlockHeight := getLatestBlockhash()
-				assert.NoError(t, txm.Enqueue(ctx, fmt.Sprintf("load_%d", i), createTx(blockhash, loadTestKey.PublicKey(), loadTestKey.PublicKey(), loadTestKey.PublicKey(), uint64(i)), nil, lastValidBlockHeight))
+				tx, lastValidBlockHeight := createTx(loadTestKey.PublicKey(), loadTestKey.PublicKey(), loadTestKey.PublicKey(), uint64(i))
+				assert.NoError(t, txm.Enqueue(ctx, fmt.Sprintf("load_%d", i), tx, nil, lastValidBlockHeight))
 				time.Sleep(10 * time.Millisecond) // ~100 txs per second (note: have run 5ms delays for ~200tx/s succesfully)
 			}
 

--- a/pkg/solana/txm/txm_load_test.go
+++ b/pkg/solana/txm/txm_load_test.go
@@ -84,10 +84,14 @@ func TestTxm_Integration(t *testing.T) {
 			// already started
 			assert.Error(t, txm.Start(ctx))
 
-			createTx := func(signer solana.PublicKey, sender solana.PublicKey, receiver solana.PublicKey, amt uint64) *solana.Transaction {
-				// create transfer tx
+			getLatestBlockhash := func() (solana.Hash, uint64) {
 				hash, err := client.LatestBlockhash(ctx)
-				assert.NoError(t, err)
+				require.NoError(t, err)
+				return hash.Value.Blockhash, hash.Value.LastValidBlockHeight
+			}
+
+			createTx := func(hash solana.Hash, signer solana.PublicKey, sender solana.PublicKey, receiver solana.PublicKey, amt uint64) *solana.Transaction {
+				// create transfer tx
 				tx, err := solana.NewTransaction(
 					[]solana.Instruction{
 						system.NewTransferInstruction(
@@ -96,7 +100,7 @@ func TestTxm_Integration(t *testing.T) {
 							receiver,
 						).Build(),
 					},
-					hash.Value.Blockhash,
+					hash,
 					solana.TransactionPayer(signer),
 				)
 				require.NoError(t, err)
@@ -104,16 +108,20 @@ func TestTxm_Integration(t *testing.T) {
 			}
 
 			// enqueue txs (must pass to move on to load test)
-			require.NoError(t, txm.Enqueue(ctx, "test_success_0", createTx(pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil))
-			require.Error(t, txm.Enqueue(ctx, "test_invalidSigner", createTx(pubKeyReceiver, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil)) // cannot sign tx before enqueuing
-			require.NoError(t, txm.Enqueue(ctx, "test_invalidReceiver", createTx(pubKey, pubKey, solana.PublicKey{}, solana.LAMPORTS_PER_SOL), nil))
-			time.Sleep(500 * time.Millisecond) // pause 0.5s for new blockhash
-			require.NoError(t, txm.Enqueue(ctx, "test_success_1", createTx(pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil))
-			require.NoError(t, txm.Enqueue(ctx, "test_txFail", createTx(pubKey, pubKey, pubKeyReceiver, 1000*solana.LAMPORTS_PER_SOL), nil))
+			blockhash1, lastValidBlockHeight1 := getLatestBlockhash()
+			require.NoError(t, txm.Enqueue(ctx, "test_success_0", createTx(blockhash1, pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil, lastValidBlockHeight1))
+			require.Error(t, txm.Enqueue(ctx, "test_invalidSigner", createTx(blockhash1, pubKeyReceiver, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil, lastValidBlockHeight1)) // cannot sign tx before enqueuing
+			require.NoError(t, txm.Enqueue(ctx, "test_invalidReceiver", createTx(blockhash1, pubKey, pubKey, solana.PublicKey{}, solana.LAMPORTS_PER_SOL), nil, lastValidBlockHeight1))
+
+			// use new blockhash
+			blockhash2, lastValidBlockHeight2 := getLatestBlockhash()
+			require.NoError(t, txm.Enqueue(ctx, "test_success_1", createTx(blockhash2, pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL), nil, lastValidBlockHeight2))
+			require.NoError(t, txm.Enqueue(ctx, "test_txFail", createTx(blockhash2, pubKey, pubKey, pubKeyReceiver, 1000*solana.LAMPORTS_PER_SOL), nil, lastValidBlockHeight2))
 
 			// load test: try to overload txs, confirm, or simulation
 			for i := 0; i < 1000; i++ {
-				assert.NoError(t, txm.Enqueue(ctx, fmt.Sprintf("load_%d", i), createTx(loadTestKey.PublicKey(), loadTestKey.PublicKey(), loadTestKey.PublicKey(), uint64(i)), nil))
+				blockhash, lastValidBlockHeight := getLatestBlockhash()
+				assert.NoError(t, txm.Enqueue(ctx, fmt.Sprintf("load_%d", i), createTx(blockhash, loadTestKey.PublicKey(), loadTestKey.PublicKey(), loadTestKey.PublicKey(), uint64(i)), nil, lastValidBlockHeight))
 				time.Sleep(10 * time.Millisecond) // ~100 txs per second (note: have run 5ms delays for ~200tx/s succesfully)
 			}
 

--- a/pkg/solana/txm/txm_race_test.go
+++ b/pkg/solana/txm/txm_race_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gagliardetto/solana-go"
 	solanaGo "github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -119,6 +121,7 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 			},
 			nil,
 		)
+		mockSlotHeightAndBlockhash(client)
 		testRunner(t, client)
 	})
 
@@ -155,6 +158,7 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 			},
 			nil,
 		)
+		mockSlotHeightAndBlockhash(client)
 		testRunner(t, client)
 	})
 
@@ -202,6 +206,7 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 			},
 			nil,
 		)
+		mockSlotHeightAndBlockhash(client)
 		testRunner(t, client)
 	})
 
@@ -236,7 +241,20 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 		require.NoError(t, fees.SetComputeUnitLimit(&msg3.tx, 200_000))
 		msg3.tx.Signatures = make([]solanaGo.Signature, 1)
 		client.On("SendTx", mock.Anything, &msg3.tx).Return(solanaGo.Signature{4}, nil)
-
+		mockSlotHeightAndBlockhash(client)
 		testRunner(t, client)
 	})
+}
+
+func mockSlotHeightAndBlockhash(client *clientmocks.ReaderWriter) {
+	// Mock SlotHeight
+	client.On("SlotHeight", mock.Anything).Return(uint64(1000), nil)
+	// Mock LatestBlockhash
+	blockhash, _ := solana.HashFromBase58("blockhash")
+	client.On("LatestBlockhash", mock.Anything).Return(&rpc.GetLatestBlockhashResult{
+		Value: &rpc.LatestBlockhashResult{
+			Blockhash:            blockhash,
+			LastValidBlockHeight: uint64(2000),
+		},
+	}, nil)
 }

--- a/pkg/solana/txm/txm_race_test.go
+++ b/pkg/solana/txm/txm_race_test.go
@@ -53,7 +53,8 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 	// config mock
 	cfg.On("ComputeUnitPriceMax").Return(uint64(10))
 	cfg.On("ComputeUnitPriceMin").Return(uint64(0))
-	cfg.On("FeeBumpCriteria").Return("fixed-interval")
+	cfg.On("ComputeUnitPriceDefault").Return(uint64(0))
+	cfg.On("FeeBumpCriteria").Return("fixed-intervals")
 	cfg.On("FeeBumpPeriod").Return(txRetryDuration / 6)
 	cfg.On("TxRetryTimeout").Return(txRetryDuration)
 	cfg.On("ComputeUnitLimitDefault").Return(uint32(200_000)) // default value, cannot not use 0

--- a/pkg/solana/txm/txm_race_test.go
+++ b/pkg/solana/txm/txm_race_test.go
@@ -53,6 +53,7 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 	// config mock
 	cfg.On("ComputeUnitPriceMax").Return(uint64(10))
 	cfg.On("ComputeUnitPriceMin").Return(uint64(0))
+	cfg.On("FeeBumpCriteria").Return("fixed-interval")
 	cfg.On("FeeBumpPeriod").Return(txRetryDuration / 6)
 	cfg.On("TxRetryTimeout").Return(txRetryDuration)
 	cfg.On("ComputeUnitLimitDefault").Return(uint32(200_000)) // default value, cannot not use 0

--- a/pkg/solana/txm/utils.go
+++ b/pkg/solana/txm/utils.go
@@ -188,6 +188,11 @@ func SetTimeout(t time.Duration) SetTxConfig {
 		cfg.Timeout = t
 	}
 }
+func SetFeeBumpCriteria(s string) SetTxConfig {
+	return func(cfg *TxConfig) {
+		cfg.FeeBumpCriteria = s
+	}
+}
 func SetFeeBumpPeriod(t time.Duration) SetTxConfig {
 	return func(cfg *TxConfig) {
 		cfg.FeeBumpPeriod = t


### PR DESCRIPTION
### Description
Current Solana TXM implementation bumps fees at at a specified interval of time without waiting for previous transaction expiration. CCIP should not automatically bump fees without ensuring expiration to prevent excessive bumping

### Acceptance Criteria
- The TXM should be able to `detect when a transaction has expired`
- The TXM should be configurable to `enable/disable bumping`
- The TXM should be configurable to wait for either `interval of time` or `tx expiry` before bumping, if enabled

### This PR
**New `FeeBumpCriteria` Options:**
- `fixed-intervals`: Bumps the transaction fee at regular, fixed intervals.
- `expiration`: Bumps the fee based on blockhash expiration, ensuring transactions remain valid.
- `none`: Disables fee bumping

**sendWithRetry refactorization:**
- Organized the retry logic into clear, manageable steps using helper functions for better readability and maintenance.
- Integrate Fee Bumping based on `FeeBumpCriteria`
	- `Fixed Intervals` bump every `FeeBumpPeriod`. Added blockhash expiration handling here too.
	- `Expiration` checks every `FeeBumpPeriod` if we need a bump based on blockhash expiration.
	- Added `lastValidBlockHeight` to the `pendingTx` struct so we can monitor blockhash expiration. This is stored when we request a new blockhash for a tx.
	- Added `IsBlockhashExpired` and `UpdateBlockhash` to handle changes in our in-memory layer.
