### PR TITLE
Disable MultiNode

### DIFF
--- a/integration-tests/testconfig/testconfig.go
+++ b/integration-tests/testconfig/testconfig.go
@@ -267,7 +267,7 @@ func (c *TestConfig) GetNodeConfigTOML() (string, error) {
 
 	mnConfig := solcfg.MultiNodeConfig{
 		MultiNode: solcfg.MultiNode{
-			Enabled:       ptr.Ptr(true),
+			Enabled:       ptr.Ptr(false),
 			SyncThreshold: ptr.Ptr(uint32(170)),
 		},
 	}


### PR DESCRIPTION
### Description

Disable MultiNode in Smoke Tests by default since heads are not fully produced in testing causing integration tests to be flaky.

