### PR TITLE
Add new fatal error cases to txm error parser

### DIFF
--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -935,7 +935,7 @@ func TestTxm_disabled_confirm_timeout_with_retention(t *testing.T) {
 		// check transaction status which should still be stored
 		status, err := txm.GetTransactionStatus(ctx, testTxID)
 		require.NoError(t, err)
-		require.Equal(t, types.Failed, status)
+		require.Equal(t, types.Fatal, status)
 
 		// Sleep until retention period has passed for transaction and for another reap cycle to run
 		time.Sleep(15 * time.Second)
@@ -1089,7 +1089,7 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 		// tx should be stored in-memory and moved to errored state
 		status, err := txm.GetTransactionStatus(ctx, txID)
 		require.NoError(t, err)
-		require.Equal(t, commontypes.Failed, status)
+		require.Equal(t, commontypes.Fatal, status)
 	})
 }
 

--- a/pkg/solana/txm/txm_unit_test.go
+++ b/pkg/solana/txm/txm_unit_test.go
@@ -2,6 +2,7 @@ package txm_test
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -46,7 +47,6 @@ func TestTxm_EstimateComputeUnitLimit(t *testing.T) {
 	lggr := logger.Test(t)
 	cfg := config.NewDefault()
 	client := clientmocks.NewReaderWriter(t)
-	require.NoError(t, err)
 	loader := utils.NewLazyLoad(func() (solanaClient.ReaderWriter, error) { return client, nil })
 	txm := solanatxm.NewTxm("localnet", loader, nil, cfg, mkey, lggr)
 
@@ -149,6 +149,94 @@ func TestTxm_EstimateComputeUnitLimit(t *testing.T) {
 		computeUnitLimit, err := txm.EstimateComputeUnitLimit(ctx, tx, "")
 		require.NoError(t, err)
 		require.Equal(t, uint32(1_400_000), computeUnitLimit)
+	})
+}
+
+func TestTxm_ProcessError(t *testing.T) {
+	t.Parallel()
+
+	// setup mock keystore
+	mkey := keyMocks.NewSimpleKeystore(t)
+	// set up txm
+	lggr := logger.Test(t)
+	cfg := config.NewDefault()
+	client := clientmocks.NewReaderWriter(t)
+	loader := utils.NewLazyLoad(func() (solanaClient.ReaderWriter, error) { return client, nil })
+	txm := solanatxm.NewTxm("localnet", loader, nil, cfg, mkey, lggr)
+
+	t.Run("process BlockhashNotFound error", func(t *testing.T) {
+		t.Parallel()
+		err := map[string][]interface{}{
+			"BlockhashNotFound": {
+				0, map[string]int{"Custom": 6003},
+			},
+		}
+		// returns no failure if BlockhashNotFound encountered during simulation
+		txState, errType := txm.ProcessError(solana.Signature{}, err, true)
+		require.Equal(t, solanatxm.NoFailure, errType)
+		require.Equal(t, solanatxm.NotFound, txState) // default enum value
+
+		// returns error if BlockhashNotFound encountered during normal processing
+		txState, errType = txm.ProcessError(solana.Signature{}, err, false)
+		require.Equal(t, solanatxm.TxFailRevert, errType)
+		require.Equal(t, solanatxm.Errored, txState) // default enum value
+	})
+	t.Run("process AlreadyProcessed error", func(t *testing.T) {
+		t.Parallel()
+		err := map[string][]interface{}{
+			"AlreadyProcessed": {
+				0, map[string]int{"Custom": 6003},
+			},
+		}
+		// returns no failure if AlreadyProcessed encountered during simulation
+		txState, errType := txm.ProcessError(solana.Signature{}, err, true)
+		require.Equal(t, solanatxm.NoFailure, errType)
+		require.Equal(t, solanatxm.NotFound, txState) // default enum value
+
+		// returns error if AlreadyProcessed encountered during normal processing
+		txState, errType = txm.ProcessError(solana.Signature{}, err, false)
+		require.Equal(t, solanatxm.TxFailRevert, errType)
+		require.Equal(t, solanatxm.Errored, txState) // default enum value
+	})
+	t.Run("process fatal error cases", func(t *testing.T) {
+		t.Parallel()
+		fatalErrorCases := []string{"InstructionError", "InvalidAccountIndex", "InvalidWritableAccount", "AddressLookupTableNotFound", "InvalidAddressLookupTableData", "InvalidAddressLookupTableIndex", "AccountNotFound", "ProgramAccountNotFound"}
+		for _, errCase := range fatalErrorCases {
+			t.Run(fmt.Sprintf("process %s error", errCase), func(t *testing.T) {
+				t.Parallel()
+				err := map[string][]interface{}{
+					errCase: {
+						0, map[string]int{"Custom": 6003},
+					},
+				}
+				// returns fatal error if InstructionError encountered during simulation
+				txState, errType := txm.ProcessError(solana.Signature{}, err, true)
+				require.Equal(t, solanatxm.TxFailSimRevert, errType)
+				require.Equal(t, solanatxm.FatallyErrored, txState) // default enum value
+
+				// returns fatal error if InstructionError encountered during normal processing
+				txState, errType = txm.ProcessError(solana.Signature{}, err, false)
+				require.Equal(t, solanatxm.TxFailRevert, errType)
+				require.Equal(t, solanatxm.FatallyErrored, txState) // default enum value
+			})
+		}
+	})
+	t.Run("process unknown error", func(t *testing.T) {
+		t.Parallel()
+				err := map[string][]interface{}{
+					"MadeUpError": {
+						0, map[string]int{"Custom": 6003},
+					},
+				}
+				// returns fatal error if InstructionError encountered during simulation
+				txState, errType := txm.ProcessError(solana.Signature{}, err, true)
+				require.Equal(t, solanatxm.TxFailSimOther, errType)
+				require.Equal(t, solanatxm.Errored, txState) // default enum value
+
+				// returns fatal error if InstructionError encountered during normal processing
+				txState, errType = txm.ProcessError(solana.Signature{}, err, false)
+				require.Equal(t, solanatxm.TxFailRevert, errType)
+				require.Equal(t, solanatxm.Errored, txState) // default enum value
 	})
 }
 

--- a/pkg/solana/txm/txm_unit_test.go
+++ b/pkg/solana/txm/txm_unit_test.go
@@ -223,20 +223,20 @@ func TestTxm_ProcessError(t *testing.T) {
 	})
 	t.Run("process unknown error", func(t *testing.T) {
 		t.Parallel()
-				err := map[string][]interface{}{
-					"MadeUpError": {
-						0, map[string]int{"Custom": 6003},
-					},
-				}
-				// returns fatal error if InstructionError encountered during simulation
-				txState, errType := txm.ProcessError(solana.Signature{}, err, true)
-				require.Equal(t, solanatxm.TxFailSimOther, errType)
-				require.Equal(t, solanatxm.Errored, txState) // default enum value
+		err := map[string][]interface{}{
+			"MadeUpError": {
+				0, map[string]int{"Custom": 6003},
+			},
+		}
+		// returns fatal error if InstructionError encountered during simulation
+		txState, errType := txm.ProcessError(solana.Signature{}, err, true)
+		require.Equal(t, solanatxm.TxFailSimOther, errType)
+		require.Equal(t, solanatxm.Errored, txState) // default enum value
 
-				// returns fatal error if InstructionError encountered during normal processing
-				txState, errType = txm.ProcessError(solana.Signature{}, err, false)
-				require.Equal(t, solanatxm.TxFailRevert, errType)
-				require.Equal(t, solanatxm.Errored, txState) // default enum value
+		// returns fatal error if InstructionError encountered during normal processing
+		txState, errType = txm.ProcessError(solana.Signature{}, err, false)
+		require.Equal(t, solanatxm.TxFailRevert, errType)
+		require.Equal(t, solanatxm.Errored, txState) // default enum value
 	})
 }
 


### PR DESCRIPTION
[NONEVM-1018](https://smartcontract-it.atlassian.net/browse/NONEVM-1018)

Add new fatal error cases to prevent the plugin side from retrying transactions that encounter these errors. Retries are likely to fail.

- [InstructionError](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/src/transaction/error.rs#L56)
- [InvalidAccountIndex](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/src/transaction/error.rs#L68)
- [InvalidWritableAccount](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/src/transaction/error.rs#L101C5-L101C27)
- [AddressLookupTableNotFound](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/src/transaction/error.rs#L117)
- [InvalidAddressLookupTableData](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/src/transaction/error.rs#L125)
- [InvalidAddressLookupTableIndex](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/src/transaction/error.rs#L129)
- [AccountNotFound](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/src/transaction/error.rs#L28C5-L28C20)
- [ProgramAccountNotFound](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/src/transaction/error.rs#L32)

Chainlink PR: https://github.com/smartcontractkit/chainlink/pull/15604

[NONEVM-1018]: https://smartcontract-it.atlassian.net/browse/NONEVM-1018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ