### PR TITLE
Fix chainreader query keys test on Solana

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/pelletier/go-toml/v2 v2.2.0
 	github.com/prometheus/client_golang v1.17.0
-	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241127162636-07aa781ee1f4
+	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241210192653-a9c706f99e83
 	github.com/smartcontractkit/libocr v0.0.0-20241007185508-adbe57025f12
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/smartcontractkit/chainlink-common v0.3.1-0.20241127162636-07aa781ee1f4 h1:atCZ1jol7a+tdtgU/wNqXgliBun5H7BjGBicGL8Tj6o=
-github.com/smartcontractkit/chainlink-common v0.3.1-0.20241127162636-07aa781ee1f4/go.mod h1:bQktEJf7sJ0U3SmIcXvbGUox7SmXcnSEZ4kUbT8R5Nk=
+github.com/smartcontractkit/chainlink-common v0.3.1-0.20241210192653-a9c706f99e83 h1:NjrU7KOn3Tk+C6QFo9tQBqeotPKytpBwhn/J1s+yiiY=
+github.com/smartcontractkit/chainlink-common v0.3.1-0.20241210192653-a9c706f99e83/go.mod h1:bQktEJf7sJ0U3SmIcXvbGUox7SmXcnSEZ4kUbT8R5Nk=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 h1:12ijqMM9tvYVEm+nR826WsrNi6zCKpwBhuApq127wHs=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7/go.mod h1:FX7/bVdoep147QQhsOPkYsPEXhGZjeYx6lBSaSXtZOA=
 github.com/smartcontractkit/libocr v0.0.0-20241007185508-adbe57025f12 h1:NzZGjaqez21I3DU7objl3xExTH4fxYvzTqar8DC6360=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/rs/zerolog v1.33.0
-	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241127162636-07aa781ee1f4
+	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241211150015-a9658ae0e214
 	github.com/smartcontractkit/chainlink-solana v1.1.1-0.20241204153209-c3a71b0eef99
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.18
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1427,8 +1427,8 @@ github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgB
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241204015713-8956bb614e9e h1:GnM6ZWV6vlk2+n6c6o+v/R1LtXzBGVVx7r37nt/h6Uc=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241204015713-8956bb614e9e/go.mod h1:80vGBbOfertJig0xFKsRfm+i17FkjdKkk1dAaGE45Os=
-github.com/smartcontractkit/chainlink-common v0.3.1-0.20241127162636-07aa781ee1f4 h1:atCZ1jol7a+tdtgU/wNqXgliBun5H7BjGBicGL8Tj6o=
-github.com/smartcontractkit/chainlink-common v0.3.1-0.20241127162636-07aa781ee1f4/go.mod h1:bQktEJf7sJ0U3SmIcXvbGUox7SmXcnSEZ4kUbT8R5Nk=
+github.com/smartcontractkit/chainlink-common v0.3.1-0.20241211150015-a9658ae0e214 h1:608GWud0heM/7HuW67PRO7uLOcIYh0YqZaLqhGXl33w=
+github.com/smartcontractkit/chainlink-common v0.3.1-0.20241211150015-a9658ae0e214/go.mod h1:bQktEJf7sJ0U3SmIcXvbGUox7SmXcnSEZ4kUbT8R5Nk=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e h1:PRoeby6ZlTuTkv2f+7tVU4+zboTfRzI+beECynF4JQ0=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e/go.mod h1:mUh5/woemsVaHgTorA080hrYmO3syBCmPdnWc/5dOqk=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241202141438-a90db35252db h1:N1RH1hSr2ACzOFc9hkCcjE8pRBTdcU3p8nsTJByaLes=

--- a/pkg/solana/chainreader/chain_reader_test.go
+++ b/pkg/solana/chainreader/chain_reader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"math/big"
 	"os"
 	"strconv"
@@ -679,6 +680,11 @@ func (r *wrappedTestChainReader) QueryKey(_ context.Context, _ types.BoundContra
 	return nil, nil
 }
 
+func (r *wrappedTestChainReader) QueryKeys(_ context.Context, _ []types.ContractKeyFilter, _ query.LimitAndSort) (iter.Seq2[string, types.Sequence], error) {
+	r.test.Skip("QueryKeys is not yet supported in Solana")
+	return nil, nil
+}
+
 func (r *wrappedTestChainReader) Bind(ctx context.Context, bindings []types.BoundContract) error {
 	return r.service.Bind(ctx, bindings)
 }
@@ -921,5 +927,10 @@ func (s *skipEventsChainReader) BatchGetLatestValues(_ context.Context, _ types.
 
 func (s *skipEventsChainReader) QueryKey(_ context.Context, _ types.BoundContract, _ query.KeyFilter, _ query.LimitAndSort, _ any) ([]types.Sequence, error) {
 	s.t.Skip("QueryKey is not yet supported in Solana")
+	return nil, nil
+}
+
+func (s *skipEventsChainReader) QueryKeys(_ context.Context, _ []types.ContractKeyFilter, _ query.LimitAndSort) (iter.Seq2[string, types.Sequence], error) {
+	s.t.Skip("QueryKeys is not yet supported in Solana")
 	return nil, nil
 }


### PR DESCRIPTION
Bump chainlink-common and implement missing method in chainreader, so that chainlink-common CI stops failing
```
2024-12-11T15:47:19.2409838Z         --- FAIL: TestSolanaChainReaderService_ReaderInterface/Solana_on_loop/QueryKeys (0.01s)
2024-12-11T15:47:19.2411124Z             --- FAIL: TestSolanaChainReaderService_ReaderInterface/Solana_on_loop/QueryKeys/Solana_on_loop (0.01s)
2024-12-11T15:47:19.2412772Z                 --- SKIP: TestSolanaChainReaderService_ReaderInterface/Solana_on_loop/QueryKeys/Solana_on_loop/QueryKeys_returns_sequence_data_properly_for_two_event_types (0.00s)
2024-12-11T15:47:19.2414564Z                 --- FAIL: TestSolanaChainReaderService_ReaderInterface/Solana_on_loop/QueryKeys/Solana_on_loop/QueryKeys_returns_not_found_if_sequence_never_happened (0.00s)
2024-12-11T15:47:19.2416432Z                 --- SKIP: TestSolanaChainReaderService_ReaderInterface/Solana_on_loop/QueryKeys/Solana_on_loop/QueryKeys_returns_sequence_data_properly_as_values.Value (0.00s)
2024-12-11T15:47:19.2418186Z                 --- SKIP: TestSolanaChainReaderService_ReaderInterface/Solana_on_loop/QueryKeys/Solana_on_loop/QueryKeys_can_filter_data_with_value_comparator (0.00s)
2024-12-11T15:47:19.2419903Z                 --- SKIP: TestSolanaChainReaderService_ReaderInterface/Solana_on_loop/QueryKeys/Solana_on_loop/QueryKeys_can_limit_results_with_cursor (0.00s)
```

https://github.com/smartcontractkit/chainlink-common/actions/runs/12279038508/job/34265006534?pr=966