### PR TITLE
Improve Solana address codec modifier to handle all valid base58 keys

### DIFF
--- a/pkg/solana/codec/byte_string_modifier.go
+++ b/pkg/solana/codec/byte_string_modifier.go
@@ -22,13 +22,17 @@ func (s SolanaAddressModifier) EncodeAddress(bytes []byte) (string, error) {
 
 // DecodeAddress decodes a Base58-encoded Solana address into a 32-byte array.
 func (s SolanaAddressModifier) DecodeAddress(str string) ([]byte, error) {
-	if len(str) != 44 {
-		return nil, fmt.Errorf("%w: got length %d, expected 44 for address %s", commontypes.ErrInvalidType, len(str), str)
-	}
-
 	pubkey, err := solana.PublicKeyFromBase58(str)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to decode Base58 address: %s", commontypes.ErrInvalidType, err)
+	}
+
+	if pubkey.IsZero() {
+		return nil, fmt.Errorf("%w: zero-value address", commontypes.ErrInvalidType)
+	}
+
+	if !pubkey.IsOnCurve() {
+		return nil, fmt.Errorf("%w: address %q with length of %d is not on the ed25519 curve", commontypes.ErrInvalidType, str, len(str))
 	}
 
 	return pubkey.Bytes(), nil

--- a/pkg/solana/codec/byte_string_modifier_test.go
+++ b/pkg/solana/codec/byte_string_modifier_test.go
@@ -51,6 +51,19 @@ func TestSolanaAddressModifier(t *testing.T) {
 		assert.Contains(t, err.Error(), commontypes.ErrInvalidType.Error())
 	})
 
+	t.Run("DecodeAddress returns error for address under 32 chars", func(t *testing.T) {
+		// < than 32 chars
+		_, err := modifier.DecodeAddress("1111111111111111111111111111111")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), commontypes.ErrInvalidType.Error())
+	})
+
+	t.Run("DecodeAddress returns error for valid length address not on the ed25519 curve", func(t *testing.T) {
+		_, err := modifier.DecodeAddress("AddressLookupTab1e11111111111111111111111111")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), commontypes.ErrInvalidType.Error())
+	})
+
 	t.Run("Length returns 32 for Solana addresses", func(t *testing.T) {
 		assert.Equal(t, solana.PublicKeyLength, modifier.Length())
 	})


### PR DESCRIPTION
### Description

Solana codec address modifier only handled base58 encoded addresses of size 44, which doesn’t cover all valid addresses. 

This PR fixes address size handling and adds an additonal zero address check and an ed25519 curve check for addresses of valid size.