### PR TITLE
fix: golangci loopref linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ run:
 linters:
   enable:
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - revive
     - goimports
     - gosec

--- a/integration-tests/smoke/ocr2_test.go
+++ b/integration-tests/smoke/ocr2_test.go
@@ -35,7 +35,6 @@ func TestSolanaOCRV2Smoke(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			_, sg := startOCR2DataFeedsSmokeTest(t, test.name, test.env, config, "")

--- a/integration-tests/soak/ocr2_test.go
+++ b/integration-tests/soak/ocr2_test.go
@@ -35,7 +35,6 @@ func TestSolanaOCRV2Soak(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration-tests/solclient/deployer.go
+++ b/integration-tests/solclient/deployer.go
@@ -503,7 +503,6 @@ func (c *ContractDeployer) DeployAnchorProgramsRemote(contractsDir string, env *
 	log.Debug().Interface("Binaries", contractBinaries).Msg("Program binaries")
 	g := errgroup.Group{}
 	for _, bin := range contractBinaries {
-		bin := bin
 		g.Go(func() error {
 			return c.DeployProgramRemote(bin, env)
 		})
@@ -519,7 +518,6 @@ func (c *ContractDeployer) DeployAnchorProgramsRemoteDocker(baseDir, subDir stri
 	log.Info().Interface("Binaries", contractBinaries).Msg(fmt.Sprintf("Program binaries [%s]", filepath.Join("programs", subDir)))
 	g := errgroup.Group{}
 	for _, bin := range contractBinaries {
-		bin := bin
 		g.Go(func() error {
 			return c.DeployProgramRemoteLocal(filepath.Join(subDir, bin), sol, programIDBuilder)
 		})

--- a/pkg/solana/config_tracker.go
+++ b/pkg/solana/config_tracker.go
@@ -31,7 +31,6 @@ func ConfigFromState(ctx context.Context, state State) (types.ContractConfig, er
 		return types.ContractConfig{}, err
 	}
 	for _, o := range oracles {
-		o := o //  https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable
 		pubKeys = append(pubKeys, o.Signer.Key[:])
 		accounts = append(accounts, types.Account(o.Transmitter.String()))
 	}

--- a/pkg/solana/report_test.go
+++ b/pkg/solana/report_test.go
@@ -143,7 +143,6 @@ func TestMedianFromReport(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := tests.Context(t)
 			var pos []median.ParsedAttributedObservation

--- a/pkg/solana/txm/pendingtx_test.go
+++ b/pkg/solana/txm/pendingtx_test.go
@@ -1304,7 +1304,6 @@ func TestPendingTxContext_ListAllExpiredBroadcastedTxs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			// Initialize a new PendingTxContext
 			ctx := newPendingTxContext()


### PR DESCRIPTION
### Description

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

fixes the following warning 

`level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
`

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
