### PR TITLE
Updated getSeedBytes to handle array seeds

### DIFF
--- a/pkg/solana/chainwriter/testContractIDL.json
+++ b/pkg/solana/chainwriter/testContractIDL.json
@@ -1,1 +1,123 @@
-{"version":"0.1.0","name":"contractReaderInterface","instructions":[{"name":"initialize","accounts":[{"name":"data","isMut":true,"isSigner":false},{"name":"signer","isMut":true,"isSigner":true},{"name":"systemProgram","isMut":false,"isSigner":false}],"args":[{"name":"testIdx","type":"u64"},{"name":"value","type":"u64"}]},{"name":"initializeLookupTable","accounts":[{"name":"writeDataAccount","isMut":true,"isSigner":false,"docs":["PDA for LookupTableDataAccount, derived from seeds and created by the System Program"]},{"name":"admin","isMut":true,"isSigner":true,"docs":["Admin account that pays for PDA creation and signs the transaction"]},{"name":"systemProgram","isMut":false,"isSigner":false,"docs":["System Program required for PDA creation"]}],"args":[{"name":"lookupTable","type":"publicKey"}]}],"accounts":[{"name":"LookupTableDataAccount","type":{"kind":"struct","fields":[{"name":"version","type":"u8"},{"name":"administrator","type":"publicKey"},{"name":"pendingAdministrator","type":"publicKey"},{"name":"lookupTable","type":"publicKey"}]}},{"name":"DataAccount","type":{"kind":"struct","fields":[{"name":"idx","type":"u64"},{"name":"bump","type":"u8"},{"name":"u64Value","type":"u64"},{"name":"u64Slice","type":{"vec":"u64"}}]}}]}
+{
+    "version": "0.1.0",
+    "name": "contractReaderInterface",
+    "instructions": [
+        {
+            "name": "initialize",
+            "accounts": [
+                {
+                    "name": "data",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "signer",
+                    "isMut": true,
+                    "isSigner": true
+                },
+                {
+                    "name": "systemProgram",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "testIdx",
+                    "type": "u64"
+                },
+                {
+                    "name": "value",
+                    "type": "u64"
+                }
+            ]
+        },
+        {
+            "name": "initializeLookupTable",
+            "accounts": [
+                {
+                    "name": "writeDataAccount",
+                    "isMut": true,
+                    "isSigner": false,
+                    "docs": [
+                        "PDA for LookupTableDataAccount, derived from seeds and created by the System Program"
+                    ]
+                },
+                {
+                    "name": "admin",
+                    "isMut": true,
+                    "isSigner": true,
+                    "docs": [
+                        "Admin account that pays for PDA creation and signs the transaction"
+                    ]
+                },
+                {
+                    "name": "systemProgram",
+                    "isMut": false,
+                    "isSigner": false,
+                    "docs": [
+                        "System Program required for PDA creation"
+                    ]
+                }
+            ],
+            "args": [
+                {
+                    "name": "lookupTable",
+                    "type": "publicKey"
+                }
+            ]
+        }
+    ],
+    "accounts": [
+        {
+            "name": "LookupTableDataAccount",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "version",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "administrator",
+                        "type": "publicKey"
+                    },
+                    {
+                        "name": "pendingAdministrator",
+                        "type": "publicKey"
+                    },
+                    {
+                        "name": "lookupTable",
+                        "type": "publicKey"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DataAccount",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "idx",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "bump",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "u64Value",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "u64Slice",
+                        "type": {
+                            "vec": "u64"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### Description
This PR updated the ChainWriter's PDA parsing capabilities to handle the case where a seed resolves to an array. 

This will be necessary for handling CCIP messages which contain multiple token transfers.
<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
