### PR TITLE
Added bitmap location parsing for IsWritable and IsSignable on AccountLookups

### DIFF
--- a/integration-tests/relayinterface/lookups_test.go
+++ b/integration-tests/relayinterface/lookups_test.go
@@ -23,6 +23,7 @@ import (
 
 type InnerAccountArgs struct {
 	Accounts []*solana.AccountMeta
+	Bitmap   uint64
 }
 
 type TestAccountArgs struct {
@@ -132,27 +133,29 @@ func TestAccountLookups(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("AccountLookup works with MetaBool lookups", func(t *testing.T) {
+	t.Run("AccountLookup works with MetaBool bitmap lookups", func(t *testing.T) {
 		accounts := [3]*solana.AccountMeta{}
 
 		for i := 0; i < 3; i++ {
 			accounts[i] = &solana.AccountMeta{
 				PublicKey:  chainwriter.GetRandomPubKey(t),
-				IsSigner:   i%2 == 0,
-				IsWritable: (i+1)%2 == 0,
+				IsSigner:   (i)%2 == 0,
+				IsWritable: (i)%2 == 0,
 			}
 		}
 
 		lookupConfig := chainwriter.AccountLookup{
 			Name:       "InvalidAccount",
 			Location:   "Inner.Accounts.PublicKey",
-			IsSigner:   chainwriter.MetaBool{Location: "Inner.Accounts.IsSigner"},
-			IsWritable: chainwriter.MetaBool{Location: "Inner.Accounts.IsWritable"},
+			IsSigner:   chainwriter.MetaBool{BitmapLocation: "Inner.Bitmap"},
+			IsWritable: chainwriter.MetaBool{BitmapLocation: "Inner.Bitmap"},
 		}
 
 		args := TestAccountArgs{
 			Inner: InnerAccountArgs{
 				Accounts: accounts[:],
+				// should be 101... so {true, false, true}
+				Bitmap: 5,
 			},
 		}
 
@@ -164,41 +167,10 @@ func TestAccountLookups(t *testing.T) {
 		}
 	})
 
-	t.Run("AccountLookup works with MetaBool lookups when a meta field is missing", func(t *testing.T) {
-		accounts := [3]*solana.AccountMeta{}
-
-		for i := 0; i < 3; i++ {
-			accounts[i] = &solana.AccountMeta{
-				PublicKey:  chainwriter.GetRandomPubKey(t),
-				IsWritable: true,
-			}
-		}
-
-		lookupConfig := chainwriter.AccountLookup{
-			Name:       "InvalidAccount",
-			Location:   "Inner.Accounts.PublicKey",
-			IsSigner:   chainwriter.MetaBool{Location: "Inner.Accounts.IsSigner"},
-			IsWritable: chainwriter.MetaBool{Location: "Inner.Accounts.IsWritable"},
-		}
-
-		args := TestAccountArgs{
-			Inner: InnerAccountArgs{
-				Accounts: accounts[:],
-			},
-		}
-
-		result, err := lookupConfig.Resolve(ctx, args, nil, nil)
-		require.NoError(t, err)
-
-		for i, meta := range result {
-			require.Equal(t, accounts[i], meta)
-		}
-	})
-
-	t.Run("AccountLookup works with MetaBool lookups in a different location", func(t *testing.T) {
+	t.Run("AccountLookup fails with MetaBool due to an invalid number of bitmaps", func(t *testing.T) {
 		type TestAccountArgsExtended struct {
-			Inner        InnerAccountArgs
-			ExternalBool bool
+			Inner   InnerAccountArgs
+			Bitmaps []uint64
 		}
 
 		accounts := [3]*solana.AccountMeta{}
@@ -214,60 +186,22 @@ func TestAccountLookups(t *testing.T) {
 		lookupConfig := chainwriter.AccountLookup{
 			Name:       "InvalidAccount",
 			Location:   "Inner.Accounts.PublicKey",
-			IsSigner:   chainwriter.MetaBool{Location: "ExternalBool"},
-			IsWritable: chainwriter.MetaBool{Location: "ExternalBool"},
+			IsSigner:   chainwriter.MetaBool{BitmapLocation: "Bitmaps"},
+			IsWritable: chainwriter.MetaBool{BitmapLocation: "Bitmaps"},
 		}
 
 		args := TestAccountArgsExtended{
 			Inner: InnerAccountArgs{
 				Accounts: accounts[:],
 			},
-			ExternalBool: true,
-		}
-
-		result, err := lookupConfig.Resolve(ctx, args, nil, nil)
-		require.NoError(t, err)
-
-		for i, meta := range result {
-			require.Equal(t, accounts[i], meta)
-		}
-	})
-
-	t.Run("AccountLookup fails with MetaBool due to an invalid number of Meta lookups", func(t *testing.T) {
-		type TestAccountArgsExtended struct {
-			Inner         InnerAccountArgs
-			ExternalBools []bool
-		}
-
-		accounts := [3]*solana.AccountMeta{}
-
-		for i := 0; i < 3; i++ {
-			accounts[i] = &solana.AccountMeta{
-				PublicKey:  chainwriter.GetRandomPubKey(t),
-				IsWritable: true,
-				IsSigner:   true,
-			}
-		}
-
-		lookupConfig := chainwriter.AccountLookup{
-			Name:       "InvalidAccount",
-			Location:   "Inner.Accounts.PublicKey",
-			IsSigner:   chainwriter.MetaBool{Location: "ExternalBools"},
-			IsWritable: chainwriter.MetaBool{Location: "ExternalBools"},
-		}
-
-		args := TestAccountArgsExtended{
-			Inner: InnerAccountArgs{
-				Accounts: accounts[:],
-			},
-			ExternalBools: []bool{true, true},
+			Bitmaps: []uint64{5, 3},
 		}
 
 		_, err := lookupConfig.Resolve(ctx, args, nil, nil)
-		require.Contains(t, err.Error(), "boolean array length 2 doesn't match pubkey count 3 for location")
+		require.Contains(t, err.Error(), "bitmap value is not a single value")
 	})
 
-	t.Run("AccountLookup fails with MetaBool with an Invalid Location", func(t *testing.T) {
+	t.Run("AccountLookup fails with MetaBool with an Invalid BitmapLocation", func(t *testing.T) {
 		accounts := [3]*solana.AccountMeta{}
 
 		for i := 0; i < 3; i++ {
@@ -280,8 +214,8 @@ func TestAccountLookups(t *testing.T) {
 		lookupConfig := chainwriter.AccountLookup{
 			Name:       "InvalidAccount",
 			Location:   "Inner.Accounts.PublicKey",
-			IsSigner:   chainwriter.MetaBool{Location: "Invalid.IsSigner"},
-			IsWritable: chainwriter.MetaBool{Location: "Invalid.IsWritable"},
+			IsSigner:   chainwriter.MetaBool{BitmapLocation: "Invalid.Bitmap"},
+			IsWritable: chainwriter.MetaBool{BitmapLocation: "Invalid.Bitmap"},
 		}
 
 		args := TestAccountArgs{
@@ -291,10 +225,10 @@ func TestAccountLookups(t *testing.T) {
 		}
 
 		_, err := lookupConfig.Resolve(ctx, args, nil, nil)
-		require.Contains(t, err.Error(), "error reading bools from location")
+		require.Contains(t, err.Error(), "error reading bitmap from location")
 	})
 
-	t.Run("AccountLookup fails when MetaBool is an invalid type", func(t *testing.T) {
+	t.Run("AccountLookup fails when MetaBool Bitmap is an invalid type", func(t *testing.T) {
 		accounts := [3]*solana.AccountMeta{}
 
 		for i := 0; i < 3; i++ {
@@ -307,8 +241,8 @@ func TestAccountLookups(t *testing.T) {
 		lookupConfig := chainwriter.AccountLookup{
 			Name:       "InvalidAccount",
 			Location:   "Inner.Accounts.PublicKey",
-			IsSigner:   chainwriter.MetaBool{Location: "Inner"},
-			IsWritable: chainwriter.MetaBool{Location: "Inner"},
+			IsSigner:   chainwriter.MetaBool{BitmapLocation: "Inner"},
+			IsWritable: chainwriter.MetaBool{BitmapLocation: "Inner"},
 		}
 
 		args := TestAccountArgs{

--- a/integration-tests/relayinterface/lookups_test.go
+++ b/integration-tests/relayinterface/lookups_test.go
@@ -21,6 +21,14 @@ import (
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/utils"
 )
 
+type InnerAccountArgs struct {
+	Accounts []*solana.AccountMeta
+}
+
+type TestAccountArgs struct {
+	Inner InnerAccountArgs
+}
+
 func TestAccountContant(t *testing.T) {
 	t.Run("AccountConstant resolves valid address", func(t *testing.T) {
 		expectedAddr := chainwriter.GetRandomPubKey(t)
@@ -62,8 +70,8 @@ func TestAccountLookups(t *testing.T) {
 		lookupConfig := chainwriter.AccountLookup{
 			Name:       "TestAccount",
 			Location:   "Inner.Address",
-			IsSigner:   true,
-			IsWritable: true,
+			IsSigner:   chainwriter.MetaBool{Value: true},
+			IsWritable: chainwriter.MetaBool{Value: true},
 		}
 		result, err := lookupConfig.Resolve(ctx, testArgs, nil, nil)
 		require.NoError(t, err)
@@ -96,8 +104,8 @@ func TestAccountLookups(t *testing.T) {
 		lookupConfig := chainwriter.AccountLookup{
 			Name:       "TestAccount",
 			Location:   "Inner.Address",
-			IsSigner:   true,
-			IsWritable: true,
+			IsSigner:   chainwriter.MetaBool{Value: true},
+			IsWritable: chainwriter.MetaBool{Value: true},
 		}
 		result, err := lookupConfig.Resolve(ctx, testArgs, nil, nil)
 		require.NoError(t, err)
@@ -117,11 +125,200 @@ func TestAccountLookups(t *testing.T) {
 		lookupConfig := chainwriter.AccountLookup{
 			Name:       "InvalidAccount",
 			Location:   "Invalid.Directory",
-			IsSigner:   true,
-			IsWritable: true,
+			IsSigner:   chainwriter.MetaBool{Value: true},
+			IsWritable: chainwriter.MetaBool{Value: true},
 		}
 		_, err := lookupConfig.Resolve(ctx, testArgs, nil, nil)
 		require.Error(t, err)
+	})
+
+	t.Run("AccountLookup works with MetaBool lookups", func(t *testing.T) {
+		accounts := [3]*solana.AccountMeta{}
+
+		for i := 0; i < 3; i++ {
+			accounts[i] = &solana.AccountMeta{
+				PublicKey:  chainwriter.GetRandomPubKey(t),
+				IsSigner:   i%2 == 0,
+				IsWritable: (i+1)%2 == 0,
+			}
+		}
+
+		lookupConfig := chainwriter.AccountLookup{
+			Name:       "InvalidAccount",
+			Location:   "Inner.Accounts.PublicKey",
+			IsSigner:   chainwriter.MetaBool{Location: "Inner.Accounts.IsSigner"},
+			IsWritable: chainwriter.MetaBool{Location: "Inner.Accounts.IsWritable"},
+		}
+
+		args := TestAccountArgs{
+			Inner: InnerAccountArgs{
+				Accounts: accounts[:],
+			},
+		}
+
+		result, err := lookupConfig.Resolve(ctx, args, nil, nil)
+		require.NoError(t, err)
+
+		for i, meta := range result {
+			require.Equal(t, accounts[i], meta)
+		}
+	})
+
+	t.Run("AccountLookup works with MetaBool lookups when a meta field is missing", func(t *testing.T) {
+		accounts := [3]*solana.AccountMeta{}
+
+		for i := 0; i < 3; i++ {
+			accounts[i] = &solana.AccountMeta{
+				PublicKey:  chainwriter.GetRandomPubKey(t),
+				IsWritable: true,
+			}
+		}
+
+		lookupConfig := chainwriter.AccountLookup{
+			Name:       "InvalidAccount",
+			Location:   "Inner.Accounts.PublicKey",
+			IsSigner:   chainwriter.MetaBool{Location: "Inner.Accounts.IsSigner"},
+			IsWritable: chainwriter.MetaBool{Location: "Inner.Accounts.IsWritable"},
+		}
+
+		args := TestAccountArgs{
+			Inner: InnerAccountArgs{
+				Accounts: accounts[:],
+			},
+		}
+
+		result, err := lookupConfig.Resolve(ctx, args, nil, nil)
+		require.NoError(t, err)
+
+		for i, meta := range result {
+			require.Equal(t, accounts[i], meta)
+		}
+	})
+
+	t.Run("AccountLookup works with MetaBool lookups in a different location", func(t *testing.T) {
+		type TestAccountArgsExtended struct {
+			Inner        InnerAccountArgs
+			ExternalBool bool
+		}
+
+		accounts := [3]*solana.AccountMeta{}
+
+		for i := 0; i < 3; i++ {
+			accounts[i] = &solana.AccountMeta{
+				PublicKey:  chainwriter.GetRandomPubKey(t),
+				IsWritable: true,
+				IsSigner:   true,
+			}
+		}
+
+		lookupConfig := chainwriter.AccountLookup{
+			Name:       "InvalidAccount",
+			Location:   "Inner.Accounts.PublicKey",
+			IsSigner:   chainwriter.MetaBool{Location: "ExternalBool"},
+			IsWritable: chainwriter.MetaBool{Location: "ExternalBool"},
+		}
+
+		args := TestAccountArgsExtended{
+			Inner: InnerAccountArgs{
+				Accounts: accounts[:],
+			},
+			ExternalBool: true,
+		}
+
+		result, err := lookupConfig.Resolve(ctx, args, nil, nil)
+		require.NoError(t, err)
+
+		for i, meta := range result {
+			require.Equal(t, accounts[i], meta)
+		}
+	})
+
+	t.Run("AccountLookup fails with MetaBool due to an invalid number of Meta lookups", func(t *testing.T) {
+		type TestAccountArgsExtended struct {
+			Inner         InnerAccountArgs
+			ExternalBools []bool
+		}
+
+		accounts := [3]*solana.AccountMeta{}
+
+		for i := 0; i < 3; i++ {
+			accounts[i] = &solana.AccountMeta{
+				PublicKey:  chainwriter.GetRandomPubKey(t),
+				IsWritable: true,
+				IsSigner:   true,
+			}
+		}
+
+		lookupConfig := chainwriter.AccountLookup{
+			Name:       "InvalidAccount",
+			Location:   "Inner.Accounts.PublicKey",
+			IsSigner:   chainwriter.MetaBool{Location: "ExternalBools"},
+			IsWritable: chainwriter.MetaBool{Location: "ExternalBools"},
+		}
+
+		args := TestAccountArgsExtended{
+			Inner: InnerAccountArgs{
+				Accounts: accounts[:],
+			},
+			ExternalBools: []bool{true, true},
+		}
+
+		_, err := lookupConfig.Resolve(ctx, args, nil, nil)
+		require.Contains(t, err.Error(), "boolean array length 2 doesn't match pubkey count 3 for location")
+	})
+
+	t.Run("AccountLookup fails with MetaBool with an Invalid Location", func(t *testing.T) {
+		accounts := [3]*solana.AccountMeta{}
+
+		for i := 0; i < 3; i++ {
+			accounts[i] = &solana.AccountMeta{
+				PublicKey:  chainwriter.GetRandomPubKey(t),
+				IsWritable: true,
+			}
+		}
+
+		lookupConfig := chainwriter.AccountLookup{
+			Name:       "InvalidAccount",
+			Location:   "Inner.Accounts.PublicKey",
+			IsSigner:   chainwriter.MetaBool{Location: "Invalid.IsSigner"},
+			IsWritable: chainwriter.MetaBool{Location: "Invalid.IsWritable"},
+		}
+
+		args := TestAccountArgs{
+			Inner: InnerAccountArgs{
+				Accounts: accounts[:],
+			},
+		}
+
+		_, err := lookupConfig.Resolve(ctx, args, nil, nil)
+		require.Contains(t, err.Error(), "error reading bools from location")
+	})
+
+	t.Run("AccountLookup fails when MetaBool is an invalid type", func(t *testing.T) {
+		accounts := [3]*solana.AccountMeta{}
+
+		for i := 0; i < 3; i++ {
+			accounts[i] = &solana.AccountMeta{
+				PublicKey:  chainwriter.GetRandomPubKey(t),
+				IsWritable: true,
+			}
+		}
+
+		lookupConfig := chainwriter.AccountLookup{
+			Name:       "InvalidAccount",
+			Location:   "Inner.Accounts.PublicKey",
+			IsSigner:   chainwriter.MetaBool{Location: "Inner"},
+			IsWritable: chainwriter.MetaBool{Location: "Inner"},
+		}
+
+		args := TestAccountArgs{
+			Inner: InnerAccountArgs{
+				Accounts: accounts[:],
+			},
+		}
+
+		_, err := lookupConfig.Resolve(ctx, args, nil, nil)
+		require.Contains(t, err.Error(), "invalid value format at path")
 	})
 }
 
@@ -435,7 +632,7 @@ func TestLookupTables(t *testing.T) {
 					Accounts: chainwriter.AccountLookup{
 						Name:     "TestLookupTable",
 						Location: "Inner.Address",
-						IsSigner: true,
+						IsSigner: chainwriter.MetaBool{Value: true},
 					},
 				},
 			},

--- a/pkg/solana/chainwriter/ccip_example_config.go
+++ b/pkg/solana/chainwriter/ccip_example_config.go
@@ -104,8 +104,8 @@ func TestConfig() {
 			AccountLookup{
 				Name:       "TokenAccount",
 				Location:   "Message.TokenAmounts.DestTokenAddress",
-				IsSigner:   false,
-				IsWritable: false,
+				IsSigner:   MetaBool{Value: false},
+				IsWritable: MetaBool{Value: false},
 			},
 			// PDA Account Lookup - Based on an account lookup and an address lookup
 			PDALookups{
@@ -116,16 +116,16 @@ func TestConfig() {
 				PublicKey: AccountLookup{
 					Name:       "TokenAccount",
 					Location:   "Message.TokenAmounts.DestTokenAddress",
-					IsSigner:   false,
-					IsWritable: false,
+					IsSigner:   MetaBool{Value: false},
+					IsWritable: MetaBool{Value: false},
 				},
 				// The seed is the receiver address.
 				Seeds: []Seed{
 					{Dynamic: AccountLookup{
 						Name:       "Receiver",
 						Location:   "Message.Receiver",
-						IsSigner:   false,
-						IsWritable: false,
+						IsSigner:   MetaBool{Value: false},
+						IsWritable: MetaBool{Value: false},
 					}},
 				},
 			},

--- a/pkg/solana/chainwriter/chain_writer_test.go
+++ b/pkg/solana/chainwriter/chain_writer_test.go
@@ -128,8 +128,8 @@ func TestChainWriter_GetAddresses(t *testing.T) {
 			chainwriter.AccountLookup{
 				Name:       "LookupTable",
 				Location:   "LookupTable",
-				IsSigner:   accountLookupMeta.IsSigner,
-				IsWritable: accountLookupMeta.IsWritable,
+				IsSigner:   chainwriter.MetaBool{Value: accountLookupMeta.IsSigner},
+				IsWritable: chainwriter.MetaBool{Value: accountLookupMeta.IsWritable},
 			},
 			chainwriter.PDALookups{
 				Name:      "DataAccountPDA",
@@ -463,8 +463,8 @@ func TestChainWriter_SubmitTransaction(t *testing.T) {
 							chainwriter.AccountLookup{
 								Name:       "LookupTable",
 								Location:   "LookupTable",
-								IsSigner:   false,
-								IsWritable: false,
+								IsSigner:   chainwriter.MetaBool{Value: false},
+								IsWritable: chainwriter.MetaBool{Value: false},
 							},
 							chainwriter.PDALookups{
 								Name:      "DataAccountPDA",

--- a/pkg/solana/chainwriter/helpers.go
+++ b/pkg/solana/chainwriter/helpers.go
@@ -51,8 +51,14 @@ func GetValuesAtLocation(args any, location string) ([][]byte, error) {
 			buf := make([]byte, 8)
 			binary.LittleEndian.PutUint64(buf, num)
 			vals = append(vals, buf)
+		} else if boolean, ok := value.(bool); ok {
+			if boolean {
+				vals = append(vals, []byte{0x01})
+			} else {
+				vals = append(vals, []byte{0x00})
+			}
 		} else {
-			return nil, fmt.Errorf("invalid value format at path: %s", location)
+			return nil, fmt.Errorf("invalid value format at path: %s, type: %s", location, reflect.TypeOf(value).String())
 		}
 	}
 

--- a/pkg/solana/chainwriter/helpers.go
+++ b/pkg/solana/chainwriter/helpers.go
@@ -51,12 +51,6 @@ func GetValuesAtLocation(args any, location string) ([][]byte, error) {
 			buf := make([]byte, 8)
 			binary.LittleEndian.PutUint64(buf, num)
 			vals = append(vals, buf)
-		} else if boolean, ok := value.(bool); ok {
-			if boolean {
-				vals = append(vals, []byte{0x01})
-			} else {
-				vals = append(vals, []byte{0x00})
-			}
 		} else {
 			return nil, fmt.Errorf("invalid value format at path: %s, type: %s", location, reflect.TypeOf(value).String())
 		}

--- a/pkg/solana/chainwriter/lookups.go
+++ b/pkg/solana/chainwriter/lookups.go
@@ -27,10 +27,16 @@ type AccountConstant struct {
 
 // AccountLookup dynamically derives an account address from args using a specified location path.
 type AccountLookup struct {
-	Name       string
-	Location   string
-	IsSigner   bool
-	IsWritable bool
+	Name     string
+	Location string
+	// IsSigner and IsWritable can either be a constant bool or a location to a bool
+	IsSigner   MetaBool
+	IsWritable MetaBool
+}
+
+type MetaBool struct {
+	Value    bool
+	Location string
 }
 
 type Seed struct {
@@ -89,21 +95,73 @@ func (ac AccountConstant) Resolve(_ context.Context, _ any, _ map[string]map[str
 	}, nil
 }
 
-func (al AccountLookup) Resolve(_ context.Context, args any, _ map[string]map[string][]*solana.AccountMeta, _ client.Reader) ([]*solana.AccountMeta, error) {
+func (al AccountLookup) Resolve(
+	_ context.Context,
+	args any,
+	_ map[string]map[string][]*solana.AccountMeta,
+	_ client.Reader,
+) ([]*solana.AccountMeta, error) {
 	derivedValues, err := GetValuesAtLocation(args, al.Location)
 	if err != nil {
-		return nil, fmt.Errorf("error getting account from lookup: %w", err)
+		return nil, fmt.Errorf("error getting account from '%s': %w", al.Location, err)
 	}
 
 	var metas []*solana.AccountMeta
-	for _, address := range derivedValues {
+	for i, address := range derivedValues {
+		// Resolve isSigner for this particular pubkey
+		isSigner, err := resolveMetaBool(al.IsSigner, args, i, len(derivedValues))
+		if err != nil {
+			return nil, err
+		}
+
+		// Resolve isWritable
+		isWritable, err := resolveMetaBool(al.IsWritable, args, i, len(derivedValues))
+		if err != nil {
+			return nil, err
+		}
+
 		metas = append(metas, &solana.AccountMeta{
 			PublicKey:  solana.PublicKeyFromBytes(address),
-			IsSigner:   al.IsSigner,
-			IsWritable: al.IsWritable,
+			IsSigner:   isSigner,
+			IsWritable: isWritable,
 		})
 	}
+
 	return metas, nil
+}
+
+func resolveMetaBool(mb MetaBool, args any, pubkeyIndex, pubkeysCount int) (bool, error) {
+	if mb.Location == "" {
+		return mb.Value, nil
+	}
+
+	boolVals, err := GetValuesAtLocation(args, mb.Location)
+	if err != nil {
+		return false, fmt.Errorf("error reading bools from location '%s': %w", mb.Location, err)
+	}
+
+	if len(boolVals) == 0 {
+		return false, fmt.Errorf("no boolean found at location '%s'", mb.Location)
+	}
+
+	// boolVals should always equal the number of pubkeys or 1
+	if len(boolVals) != pubkeysCount && len(boolVals) != 1 {
+		return false, fmt.Errorf(
+			"boolean array length %d doesn't match pubkey count %d for location '%s'",
+			len(boolVals), pubkeysCount, mb.Location,
+		)
+	}
+
+	// a single boolean value is valid to apply to all pubkeys
+	data := boolVals[0]
+
+	if len(boolVals) > 1 {
+		data = boolVals[pubkeyIndex]
+	}
+	if len(data) == 0 {
+		return false, fmt.Errorf("missing data for boolean at index %d in location '%s'", pubkeyIndex, mb.Location)
+	}
+	return data[0] != 0, nil
 }
 
 func (alt AccountsFromLookupTable) Resolve(_ context.Context, _ any, derivedTableMap map[string]map[string][]*solana.AccountMeta, _ client.Reader) ([]*solana.AccountMeta, error) {

--- a/pkg/solana/chainwriter/lookups.go
+++ b/pkg/solana/chainwriter/lookups.go
@@ -2,6 +2,7 @@ package chainwriter
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"reflect"
 
@@ -29,14 +30,14 @@ type AccountConstant struct {
 type AccountLookup struct {
 	Name     string
 	Location string
-	// IsSigner and IsWritable can either be a constant bool or a location to a bool
+	// IsSigner and IsWritable can either be a constant bool or a location to a bitmap which decides the bools
 	IsSigner   MetaBool
 	IsWritable MetaBool
 }
 
 type MetaBool struct {
-	Value    bool
-	Location string
+	Value          bool
+	BitmapLocation string
 }
 
 type Seed struct {
@@ -107,18 +108,22 @@ func (al AccountLookup) Resolve(
 	}
 
 	var metas []*solana.AccountMeta
+	signerIndexes, err := resolveBitMap(al.IsSigner, args, len(derivedValues))
+	if err != nil {
+		return nil, err
+	}
+
+	writerIndexes, err := resolveBitMap(al.IsWritable, args, len(derivedValues))
+	if err != nil {
+		return nil, err
+	}
+
 	for i, address := range derivedValues {
 		// Resolve isSigner for this particular pubkey
-		isSigner, err := resolveMetaBool(al.IsSigner, args, i, len(derivedValues))
-		if err != nil {
-			return nil, err
-		}
+		isSigner := signerIndexes[i]
 
 		// Resolve isWritable
-		isWritable, err := resolveMetaBool(al.IsWritable, args, i, len(derivedValues))
-		if err != nil {
-			return nil, err
-		}
+		isWritable := writerIndexes[i]
 
 		metas = append(metas, &solana.AccountMeta{
 			PublicKey:  solana.PublicKeyFromBytes(address),
@@ -130,38 +135,30 @@ func (al AccountLookup) Resolve(
 	return metas, nil
 }
 
-func resolveMetaBool(mb MetaBool, args any, pubkeyIndex, pubkeysCount int) (bool, error) {
-	if mb.Location == "" {
-		return mb.Value, nil
+func resolveBitMap(mb MetaBool, args any, length int) ([]bool, error) {
+	result := make([]bool, length)
+	if mb.BitmapLocation == "" {
+		for i := 0; i < length; i++ {
+			result[i] = mb.Value
+		}
+		return result, nil
 	}
 
-	boolVals, err := GetValuesAtLocation(args, mb.Location)
+	bitmapVals, err := GetValuesAtLocation(args, mb.BitmapLocation)
 	if err != nil {
-		return false, fmt.Errorf("error reading bools from location '%s': %w", mb.Location, err)
+		return []bool{}, fmt.Errorf("error reading bitmap from location '%s': %w", mb.BitmapLocation, err)
 	}
 
-	if len(boolVals) == 0 {
-		return false, fmt.Errorf("no boolean found at location '%s'", mb.Location)
+	if len(bitmapVals) != 1 {
+		return []bool{}, fmt.Errorf("bitmap value is not a single value: %v, length: %d", bitmapVals, len(bitmapVals))
 	}
 
-	// boolVals should always equal the number of pubkeys or 1
-	if len(boolVals) != pubkeysCount && len(boolVals) != 1 {
-		return false, fmt.Errorf(
-			"boolean array length %d doesn't match pubkey count %d for location '%s'",
-			len(boolVals), pubkeysCount, mb.Location,
-		)
+	bitmapInt := binary.LittleEndian.Uint64(bitmapVals[0])
+	for i := 0; i < length; i++ {
+		result[i] = bitmapInt&(1<<i) > 0
 	}
 
-	// a single boolean value is valid to apply to all pubkeys
-	data := boolVals[0]
-
-	if len(boolVals) > 1 {
-		data = boolVals[pubkeyIndex]
-	}
-	if len(data) == 0 {
-		return false, fmt.Errorf("missing data for boolean at index %d in location '%s'", pubkeyIndex, mb.Location)
-	}
-	return data[0] != 0, nil
+	return result, nil
 }
 
 func (alt AccountsFromLookupTable) Resolve(_ context.Context, _ any, derivedTableMap map[string]map[string][]*solana.AccountMeta, _ client.Reader) ([]*solana.AccountMeta, error) {


### PR DESCRIPTION
### Description

This PR updates `AccountLookup`s to be able to search for `AccountMeta` values based on a provided Bitmap. This is needed for CCIP messaging `ExtraArgs` which will contain a bitmap for which accounts are writable.
<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->

- https://github.com/smartcontractkit/chainlink-solana/pull/1009