### PR TITLE
pkg/solana: expand HealthReport

### DIFF
--- a/pkg/solana/client/multinode/multi_node.go
+++ b/pkg/solana/client/multinode/multi_node.go
@@ -86,6 +86,10 @@ func NewMultiNode[
 	return c
 }
 
+func (c *MultiNode[CHAIN_ID, RPC]) Name() string {
+	return c.lggr.Name()
+}
+
 func (c *MultiNode[CHAIN_ID, RPC]) ChainID() CHAIN_ID {
 	return c.chainID
 }

--- a/pkg/solana/client/multinode/transaction_sender.go
+++ b/pkg/solana/client/multinode/transaction_sender.go
@@ -72,6 +72,10 @@ type TransactionSender[TX any, RESULT SendTxResult, CHAIN_ID ID, RPC SendTxRPCCl
 	chStop services.StopChan
 }
 
+func (txSender *TransactionSender[TX, RESULT, CHAIN_ID, RPC]) Name() string {
+	return txSender.lggr.Name()
+}
+
 // SendTransaction - broadcasts transaction to all the send-only and primary nodes in MultiNode.
 // A returned nil or error does not guarantee that the transaction will or won't be included. Additional checks must be
 // performed to determine the final state.


### PR DESCRIPTION
Add `BalanceMonitor`, `MultiNode`, and `TransactionSender` to `Chain.HealthReport()`. Also nest them under the `Chain` logger, since their lifecycles are managed by `chain`.