### PR TITLE
retract v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -162,3 +162,5 @@ replace (
 
 	github.com/sourcegraph/sourcegraph/lib => github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240822153003-c864f15af264
 )
+
+retract v1.1.0 // tag moved - checksum mismatch


### PR DESCRIPTION
When the tooling attempts to use `v1.1.0`, a checksum mismatch is often encountered. The tag must have been moved after publishing and being cached in the sumdb. Using newer versions does not prevent encountering this problematic version. It must be `retract`ed: https://go.dev/ref/mod#go-mod-file-retract

We will have to publish a new version in order for the tooling to recognize this retraction.