### PR TITLE
Fixed issues and aligned ChainReader and ChainWriter implementations

### DIFF
--- a/pkg/solana/chainreader/account_read_binding.go
+++ b/pkg/solana/chainreader/account_read_binding.go
@@ -20,10 +20,10 @@ type accountReadBinding struct {
 	codec                  types.RemoteCodec
 	key                    solana.PublicKey
 	isPda                  bool   // flag to signify whether or not the account read is for a PDA
-	prefix                 string // only used for PDA public key calculation
+	prefix                 []byte // only used for PDA public key calculation
 }
 
-func newAccountReadBinding(namespace, genericName, prefix string, isPda bool) *accountReadBinding {
+func newAccountReadBinding(namespace, genericName string, prefix []byte, isPda bool) *accountReadBinding {
 	return &accountReadBinding{
 		namespace:   namespace,
 		genericName: genericName,
@@ -73,7 +73,7 @@ func (b *accountReadBinding) Decode(ctx context.Context, bts []byte, outVal any)
 func (b *accountReadBinding) buildSeedsSlice(ctx context.Context, params any) ([][]byte, error) {
 	flattenedSeeds := make([]byte, 0, solana.MaxSeeds*solana.MaxSeedLength)
 	// Append the static prefix string first
-	flattenedSeeds = append(flattenedSeeds, []byte(b.prefix)...)
+	flattenedSeeds = append(flattenedSeeds, b.prefix...)
 	// Encode the seeds provided in the params
 	encodedParamSeeds, err := b.codec.Encode(ctx, params, codec.WrapItemType(true, b.namespace, b.genericName))
 	if err != nil {

--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -21,6 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/utils"
 )
 
 type EventsReader interface {
@@ -311,7 +312,7 @@ func (s *ContractReaderService) addCodecDef(forEncoding bool, namespace, generic
 func (s *ContractReaderService) init(namespaces map[string]config.ChainContractReader) error {
 	for namespace, nameSpaceDef := range namespaces {
 		for genericName, read := range nameSpaceDef.Reads {
-			injectAddressModifier(read.InputModifications, read.OutputModifications)
+			utils.InjectAddressModifier(read.InputModifications, read.OutputModifications)
 
 			switch read.ReadType {
 			case config.Account:
@@ -369,12 +370,12 @@ func (s *ContractReaderService) addAccountRead(namespace string, genericName str
 	)
 
 	// Create PDA read binding if PDA prefix or seeds configs are populated
-	if len(readDefinition.PDADefiniton.Prefix) > 0 || len(readDefinition.PDADefiniton.Seeds) > 0 {
+	if readDefinition.PDADefiniton.Prefix != nil || len(readDefinition.PDADefiniton.Seeds) > 0 {
 		inputAccountIDLDef = readDefinition.PDADefiniton
 		reader = newAccountReadBinding(namespace, genericName, readDefinition.PDADefiniton.Prefix, true)
 	} else {
 		inputAccountIDLDef = codec.NilIdlTypeDefTy
-		reader = newAccountReadBinding(namespace, genericName, "", false)
+		reader = newAccountReadBinding(namespace, genericName, nil, false)
 	}
 	if err := s.addCodecDef(true, namespace, genericName, idl, inputAccountIDLDef, readDefinition.InputModifications); err != nil {
 		return err
@@ -413,24 +414,6 @@ func (s *ContractReaderService) addEventRead(
 	))
 
 	return nil
-}
-
-// injectAddressModifier injects AddressModifier into OutputModifications.
-// This is necessary because AddressModifier cannot be serialized and must be applied at runtime.
-func injectAddressModifier(inputModifications, outputModifications commoncodec.ModifiersConfig) {
-	for i, modConfig := range inputModifications {
-		if addrModifierConfig, ok := modConfig.(*commoncodec.AddressBytesToStringModifierConfig); ok {
-			addrModifierConfig.Modifier = codec.SolanaAddressModifier{}
-			outputModifications[i] = addrModifierConfig
-		}
-	}
-
-	for i, modConfig := range outputModifications {
-		if addrModifierConfig, ok := modConfig.(*commoncodec.AddressBytesToStringModifierConfig); ok {
-			addrModifierConfig.Modifier = codec.SolanaAddressModifier{}
-			outputModifications[i] = addrModifierConfig
-		}
-	}
 }
 
 type accountDataReader struct {

--- a/pkg/solana/chainreader/chain_reader_test.go
+++ b/pkg/solana/chainreader/chain_reader_test.go
@@ -274,7 +274,7 @@ func TestSolanaChainReaderService_GetLatestValue(t *testing.T) {
 		programID := solana.NewWallet().PublicKey()
 		pubKey := solana.NewWallet().PublicKey()
 		uint64Seed := uint64(5)
-		prefixString := "Prefix"
+		prefixBytes := []byte("Prefix")
 
 		readDef := config.ReadDefinition{
 			ChainSpecificName: testutils.TestStructWithNestedStruct,
@@ -294,7 +294,7 @@ func TestSolanaChainReaderService_GetLatestValue(t *testing.T) {
 			{
 				name: "happy path",
 				pdaDefinition: codec.PDATypeDef{
-					Prefix: prefixString,
+					Prefix: prefixBytes,
 					Seeds: []codec.PDASeed{
 						{
 							Name: "PubKey",
@@ -306,7 +306,7 @@ func TestSolanaChainReaderService_GetLatestValue(t *testing.T) {
 						},
 					},
 				},
-				expected: mustFindProgramAddress(t, programID, [][]byte{[]byte(prefixString), pubKey.Bytes(), go_binary.LittleEndian.AppendUint64([]byte{}, uint64Seed)}),
+				expected: mustFindProgramAddress(t, programID, [][]byte{prefixBytes, pubKey.Bytes(), go_binary.LittleEndian.AppendUint64([]byte{}, uint64Seed)}),
 				params: map[string]any{
 					"PubKey":     pubKey,
 					"Uint64Seed": uint64Seed,
@@ -315,7 +315,7 @@ func TestSolanaChainReaderService_GetLatestValue(t *testing.T) {
 			{
 				name: "with modifier and random field",
 				pdaDefinition: codec.PDATypeDef{
-					Prefix: prefixString,
+					Prefix: prefixBytes,
 					Seeds: []codec.PDASeed{
 						{
 							Name: "PubKey",
@@ -330,7 +330,7 @@ func TestSolanaChainReaderService_GetLatestValue(t *testing.T) {
 				inputModifier: codeccommon.ModifiersConfig{
 					&codeccommon.RenameModifierConfig{Fields: map[string]string{"PubKey": "PublicKey"}},
 				},
-				expected: mustFindProgramAddress(t, programID, [][]byte{[]byte(prefixString), pubKey.Bytes(), go_binary.LittleEndian.AppendUint64([]byte{}, uint64Seed)}),
+				expected: mustFindProgramAddress(t, programID, [][]byte{prefixBytes, pubKey.Bytes(), go_binary.LittleEndian.AppendUint64([]byte{}, uint64Seed)}),
 				params: map[string]any{
 					"PublicKey":   pubKey,
 					"randomField": "randomValue", // unused field should be ignored by the codec
@@ -340,15 +340,15 @@ func TestSolanaChainReaderService_GetLatestValue(t *testing.T) {
 			{
 				name: "only prefix",
 				pdaDefinition: codec.PDATypeDef{
-					Prefix: prefixString,
+					Prefix: prefixBytes,
 				},
-				expected: mustFindProgramAddress(t, programID, [][]byte{[]byte(prefixString)}),
+				expected: mustFindProgramAddress(t, programID, [][]byte{prefixBytes}),
 				params:   nil,
 			},
 			{
 				name: "no prefix",
 				pdaDefinition: codec.PDATypeDef{
-					Prefix: "",
+					Prefix: nil,
 					Seeds: []codec.PDASeed{
 						{
 							Name: "PubKey",
@@ -369,7 +369,7 @@ func TestSolanaChainReaderService_GetLatestValue(t *testing.T) {
 			{
 				name: "public key seed provided as bytes",
 				pdaDefinition: codec.PDATypeDef{
-					Prefix: prefixString,
+					Prefix: prefixBytes,
 					Seeds: []codec.PDASeed{
 						{
 							Name: "PubKey",
@@ -377,7 +377,7 @@ func TestSolanaChainReaderService_GetLatestValue(t *testing.T) {
 						},
 					},
 				},
-				expected: mustFindProgramAddress(t, programID, [][]byte{[]byte(prefixString), pubKey.Bytes()}),
+				expected: mustFindProgramAddress(t, programID, [][]byte{prefixBytes, pubKey.Bytes()}),
 				params: map[string]any{
 					"PubKey": pubKey.Bytes(),
 				},
@@ -424,12 +424,12 @@ func TestSolanaChainReaderService_GetLatestValue(t *testing.T) {
 	})
 
 	t.Run("PDA account read errors if missing param", func(t *testing.T) {
-		prefixString := "Prefix"
+		prefixBytes := []byte("Prefix")
 		readDef := config.ReadDefinition{
 			ChainSpecificName: testutils.TestStructWithNestedStruct,
 			ReadType:          config.Account,
 			PDADefiniton: codec.PDATypeDef{
-				Prefix: prefixString,
+				Prefix: prefixBytes,
 				Seeds: []codec.PDASeed{
 					{
 						Name: "PubKey",

--- a/pkg/solana/chainwriter/chain_writer.go
+++ b/pkg/solana/chainwriter/chain_writer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/fees"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/txm"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/utils"
 )
 
 const ServiceName = "SolanaChainWriter"
@@ -91,6 +92,7 @@ func (s *SolanaChainWriterService) parsePrograms(config ChainWriterConfig) error
 			return fmt.Errorf("failed to unmarshal IDL for program: %s, error: %w", program, err)
 		}
 		for method, methodConfig := range programConfig.Methods {
+			utils.InjectAddressModifier(methodConfig.InputModifications, nil)
 			idlDef, err := codec.FindDefinitionFromIDL(codec.ChainConfigTypeInstructionDef, methodConfig.ChainSpecificName, idl)
 			if err != nil {
 				return err

--- a/pkg/solana/codec/anchoridl.go
+++ b/pkg/solana/codec/anchoridl.go
@@ -160,7 +160,7 @@ type IdlField struct {
 // PDA is a struct that does not correlate to an official IDL type
 // It is needed to encode seeds to calculate the address for PDA account reads
 type PDATypeDef struct {
-	Prefix string    `json:"prefix,omitempty"`
+	Prefix []byte    `json:"prefix,omitempty"`
 	Seeds  []PDASeed `json:"seeds,omitempty"`
 }
 

--- a/pkg/solana/utils/utils.go
+++ b/pkg/solana/utils/utils.go
@@ -12,6 +12,9 @@ import (
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/require"
 
+	commoncodec "github.com/smartcontractkit/chainlink-common/pkg/codec"
+
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/internal"
 )
 
@@ -88,4 +91,22 @@ func sendTransaction(ctx context.Context, rpcClient *rpc.Client, t *testing.T, i
 	})
 	require.NoError(t, err)
 	return txres
+}
+
+// InjectAddressModifier injects AddressModifier into InputModifications and OutputModifications.
+// This is necessary because AddressModifier cannot be serialized and must be applied at runtime.
+func InjectAddressModifier(inputModifications, outputModifications commoncodec.ModifiersConfig) {
+	for i, modConfig := range inputModifications {
+		if addrModifierConfig, ok := modConfig.(*commoncodec.AddressBytesToStringModifierConfig); ok {
+			addrModifierConfig.Modifier = codec.SolanaAddressModifier{}
+			inputModifications[i] = addrModifierConfig
+		}
+	}
+
+	for i, modConfig := range outputModifications {
+		if addrModifierConfig, ok := modConfig.(*commoncodec.AddressBytesToStringModifierConfig); ok {
+			addrModifierConfig.Modifier = codec.SolanaAddressModifier{}
+			outputModifications[i] = addrModifierConfig
+		}
+	}
 }


### PR DESCRIPTION
- Fixed the `InjectAddressModifier` method to properly set the Solana `AddressBytesToStringModifierConfig` in the input modifications
- Applied the `InjectAddressModifier` method to the ChainWriter initialization
- Updated the PDA prefix seed in ChainReader to be `[]byte` instead of `string` to align better with ChainWriter and make interface tests easier