### PR TITLE
Make LP Filter Registration like EVM

### DIFF
--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -40,6 +40,7 @@ type LogPoller interface {
 	Start(context.Context) error
 	Ready() error
 	Close() error
+	HasFilter(context.Context, string) bool
 	RegisterFilter(ctx context.Context, filter logpoller.Filter) error
 	UnregisterFilter(ctx context.Context, name string) error
 	FilteredLogs(context.Context, []query.Expression, query.LimitAndSort, string) ([]logpoller.Log, error)

--- a/pkg/solana/chainreader/account_read_binding.go
+++ b/pkg/solana/chainreader/account_read_binding.go
@@ -30,7 +30,15 @@ type accountReadBinding struct {
 	outputIDLTypeDef         codec.IdlTypeDef
 }
 
-func newAccountReadBinding(namespace, genericName string, isPda bool, pdaPrefix []byte, idl codec.IDL, inputIDLType interface{}, outputIDLTypeDef codec.IdlTypeDef, readDefinition config.ReadDefinition) *accountReadBinding {
+func newAccountReadBinding(
+	namespace, genericName string,
+	isPda bool,
+	pdaPrefix []byte,
+	idl codec.IDL,
+	inputIDLType interface{},
+	outputIDLTypeDef codec.IdlTypeDef,
+	readDefinition config.ReadDefinition,
+) *accountReadBinding {
 	rb := &accountReadBinding{
 		namespace:                namespace,
 		genericName:              genericName,
@@ -52,20 +60,45 @@ func newAccountReadBinding(namespace, genericName string, isPda bool, pdaPrefix 
 
 var _ readBinding = &accountReadBinding{}
 
+func (b *accountReadBinding) SetCodec(codec types.RemoteCodec) {
+	b.codec = codec
+}
+
+func (b *accountReadBinding) SetModifier(commoncodec.Modifier) {}
+
+func (b *accountReadBinding) Register(context.Context) error { return nil }
+
+func (b *accountReadBinding) Unregister(context.Context) error { return nil }
+
+func (b *accountReadBinding) Bind(_ context.Context, address solana.PublicKey) error {
+	b.key = address
+
+	return nil
+}
+
+func (b *accountReadBinding) Unbind(_ context.Context) error {
+	b.key = solana.PublicKey{}
+
+	return nil
+}
+
 func (b *accountReadBinding) GetAddress(ctx context.Context, params any) (solana.PublicKey, error) {
 	// Return the bound key if normal account read
 	if !b.isPda {
 		return b.key, nil
 	}
+
 	// Calculate the public key if PDA account read
 	seedBytes, err := b.buildSeedsSlice(ctx, params)
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("failed build seeds list for PDA calculation: %w", err)
 	}
+
 	key, _, err := solana.FindProgramAddress(seedBytes, b.key)
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("failed find program address for PDA: %w", err)
 	}
+
 	return key, nil
 }
 
@@ -84,16 +117,6 @@ func (b *accountReadBinding) GetIDLInfo() (idl codec.IDL, inputIDLTypeDef interf
 func (b *accountReadBinding) GetAddressResponseHardCoder() *commoncodec.HardCodeModifierConfig {
 	return b.responseAddressHardCoder
 }
-
-func (b *accountReadBinding) SetAddress(key solana.PublicKey) {
-	b.key = key
-}
-
-func (b *accountReadBinding) SetCodec(codec types.RemoteCodec) {
-	b.codec = codec
-}
-
-func (b *accountReadBinding) SetModifier(commoncodec.Modifier) {}
 
 func (b *accountReadBinding) CreateType(forEncoding bool) (any, error) {
 	return b.codec.CreateType(codec.WrapItemType(forEncoding, b.namespace, b.genericName), forEncoding)

--- a/pkg/solana/chainreader/batch.go
+++ b/pkg/solana/chainreader/batch.go
@@ -33,7 +33,7 @@ type MultipleAccountGetter interface {
 }
 
 // doMultiRead aggregate results from multiple PDAs from the same contract into one result.
-func doMultiRead(ctx context.Context, client MultipleAccountGetter, bindings bindingsRegistry, rv readValues, params, returnValue any) error {
+func doMultiRead(ctx context.Context, client MultipleAccountGetter, bdRegistry *bindingsRegistry, rv readValues, params, returnValue any) error {
 	batch := make([]call, len(rv.reads))
 	for idx, r := range rv.reads {
 		batch[idx] = call{
@@ -46,7 +46,7 @@ func doMultiRead(ctx context.Context, client MultipleAccountGetter, bindings bin
 		}
 	}
 
-	results, err := doMethodBatchCall(ctx, client, bindings, batch)
+	results, err := doMethodBatchCall(ctx, client, bdRegistry, batch)
 	if err != nil {
 		return err
 	}
@@ -69,11 +69,11 @@ func doMultiRead(ctx context.Context, client MultipleAccountGetter, bindings bin
 	return nil
 }
 
-func doMethodBatchCall(ctx context.Context, client MultipleAccountGetter, bindingsRegistry bindingsRegistry, batch []call) ([]batchResultWithErr, error) {
+func doMethodBatchCall(ctx context.Context, client MultipleAccountGetter, bdRegistry *bindingsRegistry, batch []call) ([]batchResultWithErr, error) {
 	// Create the list of public keys to fetch
 	keys := make([]solana.PublicKey, len(batch))
 	for idx, batchCall := range batch {
-		rBinding, err := bindingsRegistry.GetReadBinding(batchCall.Namespace, batchCall.ReadName)
+		rBinding, err := bdRegistry.GetReader(batchCall.Namespace, batchCall.ReadName)
 		if err != nil {
 			return nil, fmt.Errorf("%w: read binding not found for contract: %q read: %q: %w", types.ErrInvalidConfig, batchCall.Namespace, batchCall.ReadName, err)
 		}
@@ -107,7 +107,7 @@ func doMethodBatchCall(ctx context.Context, client MultipleAccountGetter, bindin
 			continue
 		}
 
-		rBinding, err := bindingsRegistry.GetReadBinding(results[idx].namespace, results[idx].readName)
+		rBinding, err := bdRegistry.GetReader(results[idx].namespace, results[idx].readName)
 		if err != nil {
 			results[idx].err = err
 

--- a/pkg/solana/chainreader/bindings.go
+++ b/pkg/solana/chainreader/bindings.go
@@ -42,8 +42,22 @@ type readBinding interface {
 
 type addressShareGroup struct {
 	address solana.PublicKey
-	mux     sync.Mutex
+	mux     sync.RWMutex
 	group   []string
+}
+
+func (g *addressShareGroup) getAddress() solana.PublicKey {
+	g.mux.RLock()
+	defer g.mux.RUnlock()
+
+	return g.address
+}
+
+func (g *addressShareGroup) setAddress(addr solana.PublicKey) {
+	g.mux.Lock()
+	defer g.mux.Unlock()
+
+	g.address = addr
 }
 
 type bindingsRegistry struct {
@@ -136,7 +150,14 @@ func (r *bindingsRegistry) GetReaders(namespace string) ([]readBinding, error) {
 	return rBindings.GetReaders()
 }
 
-func (r *bindingsRegistry) Bind(ctx context.Context, reg filterRegistrar, binding types.BoundContract) error {
+// Bind has a side-effect of updating the bound address to a group shared address.
+//
+// DO NOT CHANGE binding from pointer type.
+func (r *bindingsRegistry) Bind(ctx context.Context, reg filterRegistrar, binding *types.BoundContract) error {
+	if binding == nil {
+		return fmt.Errorf("%w: bound contract is nil", types.ErrInvalidType)
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -217,28 +238,26 @@ func (r *bindingsRegistry) getShareGroup(nameSpace string) (*addressShareGroup, 
 	return shareGroup, sharesAddress
 }
 
-func (r *bindingsRegistry) handleAddressSharing(boundContract types.BoundContract) error {
+func (r *bindingsRegistry) handleAddressSharing(boundContract *types.BoundContract) error {
 	shareGroup, isInAGroup := r.getShareGroup(boundContract.Name)
 	if !isInAGroup {
 		return nil
 	}
 
-	shareGroup.mux.Lock()
-	defer shareGroup.mux.Unlock()
-
 	// set shared address to the binding address
-	if shareGroup.address.IsZero() {
+	if shareGroup.getAddress().IsZero() {
 		key, err := solana.PublicKeyFromBase58(boundContract.Address)
 		if err != nil {
 			return err
 		}
 
-		r.addressShareGroups[boundContract.Name].address, shareGroup.address = key, key
-	} else if boundContract.Address != shareGroup.address.String() && boundContract.Address != "" {
-		return fmt.Errorf("namespace: %q shares address: %q with namespaceBindings: %v and cannot be bound with a new address: %s", boundContract.Name, shareGroup.address, shareGroup.group, boundContract.Address)
+		shareGroup.setAddress(key)
+	} else if boundContract.Address != shareGroup.getAddress().String() && boundContract.Address != "" {
+		return fmt.Errorf("namespace: %q shares address: %q with namespaceBindings: %v and cannot be bound with a new address: %s", boundContract.Name, shareGroup.getAddress(), shareGroup.group, boundContract.Address)
 	}
 
-	boundContract.Address = shareGroup.address.String()
+	// side-effect of updating the bound contract address to group-shared address
+	boundContract.Address = shareGroup.getAddress().String()
 
 	return nil
 }

--- a/pkg/solana/chainreader/bindings.go
+++ b/pkg/solana/chainreader/bindings.go
@@ -137,8 +137,12 @@ func (r *bindingsRegistry) GetReaders(namespace string) ([]readBinding, error) {
 }
 
 func (r *bindingsRegistry) Bind(ctx context.Context, reg filterRegistrar, binding types.BoundContract) error {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := r.handleAddressSharing(binding); err != nil {
+		return err
+	}
 
 	namespace, nbsExist := r.namespaceBindings[binding.Name]
 	if !nbsExist {
@@ -150,35 +154,25 @@ func (r *bindingsRegistry) Bind(ctx context.Context, reg filterRegistrar, bindin
 		return err
 	}
 
-	if err := errors.Join(
+	return errors.Join(
 		namespace.Bind(ctx, reg, address),
 		namespace.BindReaders(ctx, address),
-	); err != nil {
-		return err
-	}
-
-	return nil
+	)
 }
 
-func (r *bindingsRegistry) Unbind(ctx context.Context, reg filterRegistrar, bindings []types.BoundContract) error {
+func (r *bindingsRegistry) Unbind(ctx context.Context, reg filterRegistrar, binding types.BoundContract) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	for _, binding := range bindings {
-		namespace, nbsExist := r.namespaceBindings[binding.Name]
-		if !nbsExist {
-			return fmt.Errorf("%w: no namespace named %s", types.ErrInvalidConfig, binding.Name)
-		}
-
-		if err := errors.Join(
-			namespace.Unbind(ctx, reg),
-			namespace.UnbindReaders(ctx),
-		); err != nil {
-			return err
-		}
+	namespace, nbsExist := r.namespaceBindings[binding.Name]
+	if !nbsExist {
+		return fmt.Errorf("%w: no namespace named %s", types.ErrInvalidConfig, binding.Name)
 	}
 
-	return nil
+	return errors.Join(
+		namespace.Unbind(ctx, reg),
+		namespace.UnbindReaders(ctx),
+	)
 }
 
 func (r *bindingsRegistry) CreateType(namespace, readName string, forEncoding bool) (any, error) {
@@ -191,6 +185,9 @@ func (r *bindingsRegistry) CreateType(namespace, readName string, forEncoding bo
 }
 
 func (r *bindingsRegistry) initAddressSharing(addressShareGroups [][]string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	r.addressShareGroups = make(map[string]*addressShareGroup)
 
 	for _, group := range addressShareGroups {
@@ -220,6 +217,32 @@ func (r *bindingsRegistry) getShareGroup(nameSpace string) (*addressShareGroup, 
 	return shareGroup, sharesAddress
 }
 
+func (r *bindingsRegistry) handleAddressSharing(boundContract types.BoundContract) error {
+	shareGroup, isInAGroup := r.getShareGroup(boundContract.Name)
+	if !isInAGroup {
+		return nil
+	}
+
+	shareGroup.mux.Lock()
+	defer shareGroup.mux.Unlock()
+
+	// set shared address to the binding address
+	if shareGroup.address.IsZero() {
+		key, err := solana.PublicKeyFromBase58(boundContract.Address)
+		if err != nil {
+			return err
+		}
+
+		r.addressShareGroups[boundContract.Name].address, shareGroup.address = key, key
+	} else if boundContract.Address != shareGroup.address.String() && boundContract.Address != "" {
+		return fmt.Errorf("namespace: %q shares address: %q with namespaceBindings: %v and cannot be bound with a new address: %s", boundContract.Name, shareGroup.address, shareGroup.group, boundContract.Address)
+	}
+
+	boundContract.Address = shareGroup.address.String()
+
+	return nil
+}
+
 type namespaceBinding struct {
 	// static data
 	name string
@@ -234,6 +257,7 @@ func newNamespaceBinding(namespace string) *namespaceBinding {
 	return &namespaceBinding{
 		name:    namespace,
 		readers: make(map[string]readBinding),
+		bound:   make(map[solana.PublicKey]bool),
 	}
 }
 
@@ -256,9 +280,6 @@ func (b *namespaceBinding) SetModifiers(modifier commoncodec.Modifier) {
 }
 
 func (b *namespaceBinding) Bind(ctx context.Context, reg filterRegistrar, address solana.PublicKey) error {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
 	if b.bindingExists(address) {
 		return nil
 	}
@@ -269,6 +290,9 @@ func (b *namespaceBinding) Bind(ctx context.Context, reg filterRegistrar, addres
 }
 
 func (b *namespaceBinding) BindReaders(ctx context.Context, address solana.PublicKey) error {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
 	var err error
 
 	for _, rb := range b.readers {
@@ -387,28 +411,4 @@ func (b *namespaceBinding) unsetBinding() {
 	defer b.mu.Unlock()
 
 	b.bound = make(map[solana.PublicKey]bool)
-}
-
-func (b *bindingsRegistry) handleAddressSharing(boundContract *types.BoundContract) error {
-	shareGroup, isInAGroup := b.getShareGroup(boundContract.Name)
-	if !isInAGroup {
-		return nil
-	}
-
-	shareGroup.mux.Lock()
-	defer shareGroup.mux.Unlock()
-
-	// set shared address to the binding address
-	if shareGroup.address.IsZero() {
-		key, err := solana.PublicKeyFromBase58(boundContract.Address)
-		if err != nil {
-			return err
-		}
-		b.addressShareGroups[boundContract.Name].address, shareGroup.address = key, key
-	} else if boundContract.Address != shareGroup.address.String() && boundContract.Address != "" {
-		return fmt.Errorf("namespace: %q shares address: %q with namespaceBindings: %v and cannot be bound with a new address: %s", boundContract.Name, shareGroup.address, shareGroup.group, boundContract.Address)
-	}
-
-	boundContract.Address = shareGroup.address.String()
-	return nil
 }

--- a/pkg/solana/chainreader/bindings.go
+++ b/pkg/solana/chainreader/bindings.go
@@ -60,6 +60,13 @@ func (g *addressShareGroup) setAddress(addr solana.PublicKey) {
 	g.address = addr
 }
 
+func (g *addressShareGroup) getGroups() []string {
+	g.mux.RLock()
+	defer g.mux.RUnlock()
+
+	return g.group
+}
+
 type bindingsRegistry struct {
 	mu sync.RWMutex
 	// key is namespace
@@ -229,6 +236,13 @@ func (r *bindingsRegistry) initAddressSharing(addressShareGroups [][]string) err
 	return nil
 }
 
+func (r *bindingsRegistry) GetShares(nameSpace string) (*addressShareGroup, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.getShareGroup(nameSpace)
+}
+
 func (r *bindingsRegistry) getShareGroup(nameSpace string) (*addressShareGroup, bool) {
 	shareGroup, sharesAddress := r.addressShareGroups[nameSpace]
 	if !sharesAddress {
@@ -364,6 +378,9 @@ func (b *namespaceBinding) GetReader(genericName string) (readBinding, error) {
 }
 
 func (b *namespaceBinding) GetReaders() ([]readBinding, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
 	allBindings := make([]readBinding, len(b.readers))
 
 	var idx int

--- a/pkg/solana/chainreader/bindings.go
+++ b/pkg/solana/chainreader/bindings.go
@@ -2,6 +2,7 @@ package chainreader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -13,31 +14,31 @@ import (
 
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller"
 )
 
+type filterRegistrar interface {
+	HasFilter(context.Context, string) bool
+	RegisterFilter(context.Context, logpoller.Filter) error
+	UnregisterFilter(ctx context.Context, name string) error
+}
+
 type readBinding interface {
+	Bind(context.Context, solana.PublicKey) error
+	Unbind(context.Context) error
 	GetAddress(context.Context, any) (solana.PublicKey, error)
 	GetGenericName() string
 	GetReadDefinition() config.ReadDefinition
 	GetIDLInfo() (idl codec.IDL, inputIDLTypeDef interface{}, outputIDLTypeDef codec.IdlTypeDef)
 	GetAddressResponseHardCoder() *commoncodec.HardCodeModifierConfig
-	SetAddress(solana.PublicKey)
 	SetCodec(types.RemoteCodec)
 	SetModifier(commoncodec.Modifier)
+	Register(context.Context) error
+	Unregister(context.Context) error
 	CreateType(bool) (any, error)
 	Decode(context.Context, []byte, any) error
 	QueryKey(context.Context, query.KeyFilter, query.LimitAndSort, any) ([]types.Sequence, error)
 }
-
-type bindingsRegistry struct {
-	// key is namespace
-	namespaceBindings map[string]readNameBindings
-	// key is namespace
-	addressShareGroups map[string]*addressShareGroup
-}
-
-// key is read name
-type readNameBindings map[string]readBinding
 
 type addressShareGroup struct {
 	address solana.PublicKey
@@ -45,38 +46,143 @@ type addressShareGroup struct {
 	group   []string
 }
 
-func (b *bindingsRegistry) AddReadBinding(namespace, readName string, rBinding readBinding) {
-	if _, nbsExists := b.namespaceBindings[namespace]; !nbsExists {
-		b.namespaceBindings[namespace] = readNameBindings{}
-	}
-
-	b.namespaceBindings[namespace][readName] = rBinding
+type bindingsRegistry struct {
+	mu sync.RWMutex
+	// key is namespace
+	namespaceBindings map[string]*namespaceBinding
+	// key is namespace
+	addressShareGroups map[string]*addressShareGroup
 }
 
-func (b *bindingsRegistry) GetReadBinding(namespace, readName string) (readBinding, error) {
-	rBindings, err := b.GetReadBindings(namespace)
-	if err != nil {
-		return nil, err
+func newBindingsRegistry() *bindingsRegistry {
+	return &bindingsRegistry{
+		namespaceBindings: make(map[string]*namespaceBinding),
 	}
-
-	rBinding, rBindingExists := rBindings[readName]
-	if !rBindingExists {
-		return nil, fmt.Errorf("%w: no read binding exists for namespace: %q read: %q", types.ErrInvalidConfig, namespace, readName)
-	}
-
-	return rBinding, nil
 }
 
-func (b *bindingsRegistry) GetReadBindings(namespace string) (readNameBindings, error) {
-	rBindings, nameSpaceExists := b.namespaceBindings[namespace]
+func (r *bindingsRegistry) SetCodecs(codec types.RemoteCodec) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, nbs := range r.namespaceBindings {
+		nbs.SetCodecs(codec)
+	}
+}
+
+func (r *bindingsRegistry) SetModifiers(modifier commoncodec.Modifier) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, nbs := range r.namespaceBindings {
+		nbs.SetModifiers(modifier)
+	}
+}
+
+func (r *bindingsRegistry) RegisterAll(ctx context.Context) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, nbs := range r.namespaceBindings {
+		if err := nbs.RegisterReaders(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *bindingsRegistry) UnregisterAll(ctx context.Context) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, nbs := range r.namespaceBindings {
+		if err := nbs.UnregisterReaders(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *bindingsRegistry) AddReader(namespace, genericName string, reader readBinding) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, nbsExists := r.namespaceBindings[namespace]; !nbsExists {
+		r.namespaceBindings[namespace] = newNamespaceBinding(namespace)
+	}
+
+	r.namespaceBindings[namespace].AddReader(genericName, reader)
+}
+
+func (r *bindingsRegistry) GetReader(namespace, genericName string) (readBinding, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	binding, nbsExists := r.namespaceBindings[namespace]
+	if !nbsExists {
+		return nil, fmt.Errorf("%w: no read binding exists for %s", types.ErrInvalidConfig, namespace)
+	}
+
+	return binding.GetReader(genericName)
+}
+
+func (r *bindingsRegistry) GetReaders(namespace string) ([]readBinding, error) {
+	rBindings, nameSpaceExists := r.namespaceBindings[namespace]
 	if !nameSpaceExists {
 		return nil, fmt.Errorf("%w: no read binding exists for namespace: %q", types.ErrInvalidConfig, namespace)
 	}
-	return rBindings, nil
+
+	return rBindings.GetReaders()
 }
 
-func (b *bindingsRegistry) CreateType(namespace, readName string, forEncoding bool) (any, error) {
-	rBinding, err := b.GetReadBinding(namespace, readName)
+func (r *bindingsRegistry) Bind(ctx context.Context, reg filterRegistrar, binding types.BoundContract) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	namespace, nbsExist := r.namespaceBindings[binding.Name]
+	if !nbsExist {
+		return fmt.Errorf("%w: no namespace named %s", types.ErrInvalidConfig, binding.Name)
+	}
+
+	address, err := solana.PublicKeyFromBase58(binding.Address)
+	if err != nil {
+		return err
+	}
+
+	if err := errors.Join(
+		namespace.Bind(ctx, reg, address),
+		namespace.BindReaders(ctx, address),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *bindingsRegistry) Unbind(ctx context.Context, reg filterRegistrar, bindings []types.BoundContract) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, binding := range bindings {
+		namespace, nbsExist := r.namespaceBindings[binding.Name]
+		if !nbsExist {
+			return fmt.Errorf("%w: no namespace named %s", types.ErrInvalidConfig, binding.Name)
+		}
+
+		if err := errors.Join(
+			namespace.Unbind(ctx, reg),
+			namespace.UnbindReaders(ctx),
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *bindingsRegistry) CreateType(namespace, readName string, forEncoding bool) (any, error) {
+	rBinding, err := r.GetReader(namespace, readName)
 	if err != nil {
 		return nil, err
 	}
@@ -84,46 +190,203 @@ func (b *bindingsRegistry) CreateType(namespace, readName string, forEncoding bo
 	return rBinding.CreateType(forEncoding)
 }
 
-func (b *bindingsRegistry) Bind(boundContract *types.BoundContract) error {
-	if boundContract == nil {
-		return fmt.Errorf("%w: bound contract is nil", types.ErrInvalidType)
-	}
+func (r *bindingsRegistry) initAddressSharing(addressShareGroups [][]string) error {
+	r.addressShareGroups = make(map[string]*addressShareGroup)
 
-	if err := b.handleAddressSharing(boundContract); err != nil {
-		return err
-	}
+	for _, group := range addressShareGroups {
+		shareGroup := &addressShareGroup{
+			address: solana.PublicKey{},
+			group:   group,
+		}
 
-	rBindings, nameSpaceExists := b.namespaceBindings[boundContract.Name]
-	if !nameSpaceExists {
-		return fmt.Errorf("%w: no namespace named: %q", types.ErrInvalidConfig, boundContract.Name)
-	}
+		for _, namespace := range group {
+			if _, alreadySharesAddress := r.addressShareGroups[namespace]; alreadySharesAddress {
+				return fmt.Errorf("namespace %q can't share address with two different groups", namespace)
+			}
 
-	key, err := solana.PublicKeyFromBase58(boundContract.Address)
-	if err != nil {
-		return fmt.Errorf("%w: failed to parse address: %q for contract %q", types.ErrInvalidConfig, boundContract.Address, boundContract.Name)
-	}
-
-	for _, rBinding := range rBindings {
-		rBinding.SetAddress(key)
+			r.addressShareGroups[namespace] = shareGroup
+		}
 	}
 
 	return nil
 }
 
-func (b *bindingsRegistry) SetCodecs(codec types.RemoteCodec) {
-	for _, nbs := range b.namespaceBindings {
-		for _, rb := range nbs {
-			rb.SetCodec(codec)
-		}
+func (r *bindingsRegistry) getShareGroup(nameSpace string) (*addressShareGroup, bool) {
+	shareGroup, sharesAddress := r.addressShareGroups[nameSpace]
+	if !sharesAddress {
+		return nil, false
+	}
+
+	return shareGroup, sharesAddress
+}
+
+type namespaceBinding struct {
+	// static data
+	name string
+
+	// dynamic thread-safe data
+	mu      sync.RWMutex
+	readers map[string]readBinding
+	bound   map[solana.PublicKey]bool
+}
+
+func newNamespaceBinding(namespace string) *namespaceBinding {
+	return &namespaceBinding{
+		name:    namespace,
+		readers: make(map[string]readBinding),
 	}
 }
 
-func (b *bindingsRegistry) SetModifiers(modifier commoncodec.Modifier) {
-	for _, nbs := range b.namespaceBindings {
-		for _, rb := range nbs {
-			rb.SetModifier(modifier)
+func (b *namespaceBinding) SetCodecs(codec types.RemoteCodec) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for _, rb := range b.readers {
+		rb.SetCodec(codec)
+	}
+}
+
+func (b *namespaceBinding) SetModifiers(modifier commoncodec.Modifier) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for _, rb := range b.readers {
+		rb.SetModifier(modifier)
+	}
+}
+
+func (b *namespaceBinding) Bind(ctx context.Context, reg filterRegistrar, address solana.PublicKey) error {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.bindingExists(address) {
+		return nil
+	}
+
+	b.setBinding(address)
+
+	return nil
+}
+
+func (b *namespaceBinding) BindReaders(ctx context.Context, address solana.PublicKey) error {
+	var err error
+
+	for _, rb := range b.readers {
+		err = errors.Join(err, rb.Bind(ctx, address))
+	}
+
+	return nil
+}
+
+func (b *namespaceBinding) Unbind(ctx context.Context, reg filterRegistrar) error {
+	if !b.isBound() {
+		return nil
+	}
+
+	b.unsetBinding()
+
+	return nil
+}
+
+func (b *namespaceBinding) UnbindReaders(ctx context.Context) error {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	var err error
+
+	for _, reader := range b.readers {
+		err = errors.Join(reader.Unbind(ctx))
+	}
+
+	return err
+}
+
+func (b *namespaceBinding) AddReader(genericName string, reader readBinding) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.readers[genericName] = reader
+}
+
+func (b *namespaceBinding) GetReader(genericName string) (readBinding, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	rbs, rbsExists := b.readers[genericName]
+	if !rbsExists {
+		return nil, fmt.Errorf("%w: no read binding exists for %s", types.ErrInvalidConfig, genericName)
+	}
+
+	return rbs, nil
+}
+
+func (b *namespaceBinding) GetReaders() ([]readBinding, error) {
+	allBindings := make([]readBinding, len(b.readers))
+
+	var idx int
+
+	for _, rBinding := range b.readers {
+		allBindings[idx] = rBinding
+		idx++
+	}
+
+	return allBindings, nil
+}
+
+func (b *namespaceBinding) RegisterReaders(ctx context.Context) error {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for _, reader := range b.readers {
+		if err := reader.Register(ctx); err != nil {
+			return err
 		}
 	}
+
+	return nil
+}
+
+func (b *namespaceBinding) UnregisterReaders(ctx context.Context) error {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for _, reader := range b.readers {
+		if err := reader.Unregister(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *namespaceBinding) isBound() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return len(b.bound) > 0
+}
+
+func (b *namespaceBinding) bindingExists(address solana.PublicKey) bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	bound, exists := b.bound[address]
+
+	return exists && bound
+}
+
+func (b *namespaceBinding) setBinding(address solana.PublicKey) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.bound[address] = true
+}
+
+func (b *namespaceBinding) unsetBinding() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.bound = make(map[solana.PublicKey]bool)
 }
 
 func (b *bindingsRegistry) handleAddressSharing(boundContract *types.BoundContract) error {
@@ -147,33 +410,5 @@ func (b *bindingsRegistry) handleAddressSharing(boundContract *types.BoundContra
 	}
 
 	boundContract.Address = shareGroup.address.String()
-	return nil
-}
-
-func (b *bindingsRegistry) getShareGroup(nameSpace string) (*addressShareGroup, bool) {
-	shareGroup, sharesAddress := b.addressShareGroups[nameSpace]
-	if !sharesAddress {
-		return nil, false
-	}
-
-	return shareGroup, sharesAddress
-}
-
-func (b *bindingsRegistry) initAddressSharing(addressShareGroups [][]string) error {
-	b.addressShareGroups = make(map[string]*addressShareGroup)
-	for _, group := range addressShareGroups {
-		shareGroup := &addressShareGroup{
-			address: solana.PublicKey{},
-			group:   group,
-		}
-
-		for _, namespace := range group {
-			if _, alreadySharesAddress := b.addressShareGroups[namespace]; alreadySharesAddress {
-				return fmt.Errorf("namespace %q can't share address with two different groups", namespace)
-			}
-			b.addressShareGroups[namespace] = shareGroup
-		}
-	}
-
 	return nil
 }

--- a/pkg/solana/chainreader/bindings_test.go
+++ b/pkg/solana/chainreader/bindings_test.go
@@ -24,10 +24,10 @@ func TestBindings_CreateType(t *testing.T) {
 		t.Parallel()
 
 		expected := 8
-		bdRegistry := bindingsRegistry{namespaceBindings: make(map[string]readNameBindings)}
+		bdRegistry := newBindingsRegistry()
 		binding := new(mockBinding)
-		bdRegistry.AddReadBinding("A", "B", binding)
 
+		bdRegistry.AddReader("A", "B", binding)
 		binding.On("CreateType", mock.Anything).Return(expected, nil)
 
 		returned, err := bdRegistry.CreateType("A", "B", true)
@@ -39,8 +39,7 @@ func TestBindings_CreateType(t *testing.T) {
 	t.Run("returns error when binding does not exist", func(t *testing.T) {
 		t.Parallel()
 
-		bdRegistry := bindingsRegistry{namespaceBindings: make(map[string]readNameBindings)}
-
+		bdRegistry := newBindingsRegistry()
 		_, err := bdRegistry.CreateType("A", "B", true)
 
 		require.ErrorIs(t, err, types.ErrInvalidConfig)
@@ -50,6 +49,16 @@ func TestBindings_CreateType(t *testing.T) {
 type mockBinding struct {
 	mock.Mock
 }
+
+func (_m *mockBinding) Bind(_ context.Context, _ solana.PublicKey) error { return nil }
+
+func (_m *mockBinding) Unbind(_ context.Context) error { return nil }
+
+func (_m *mockBinding) SetCodec(_ types.RemoteCodec) {}
+
+func (_m *mockBinding) Register(_ context.Context) error { return nil }
+
+func (_m *mockBinding) Unregister(_ context.Context) error { return nil }
 
 func (_m *mockBinding) GetAddress(_ context.Context, _ any) (solana.PublicKey, error) {
 	return solana.PublicKey{}, nil
@@ -70,10 +79,6 @@ func (_m *mockBinding) GetIDLInfo() (idl codec.IDL, inputIDLTypeDef interface{},
 func (_m *mockBinding) GetAddressResponseHardCoder() *commoncodec.HardCodeModifierConfig {
 	return &commoncodec.HardCodeModifierConfig{}
 }
-
-func (_m *mockBinding) SetAddress(_ solana.PublicKey) {}
-
-func (_m *mockBinding) SetCodec(_ types.RemoteCodec) {}
 
 func (_m *mockBinding) SetModifier(a commoncodec.Modifier) {
 	_m.Called(a)

--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -643,12 +643,13 @@ func toLPFilter(
 	eventIdl codec.EventIDLTypes,
 ) logpoller.Filter {
 	return logpoller.Filter{
-		EventName:   name,
-		EventSig:    logpoller.NewEventSignatureFromName(name),
-		EventIdl:    logpoller.EventIdl(eventIdl),
-		SubkeyPaths: subKeyPaths,
-		Retention:   conf.GetRetention(),
-		MaxLogsKept: conf.GetMaxLogsKept(),
+		EventName:     name,
+		EventSig:      logpoller.NewEventSignatureFromName(name),
+		StartingBlock: conf.GetStartingBlock(),
+		EventIdl:      logpoller.EventIdl(eventIdl),
+		SubkeyPaths:   subKeyPaths,
+		Retention:     conf.GetRetention(),
+		MaxLogsKept:   conf.GetMaxLogsKept(),
 	}
 }
 

--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -335,10 +335,10 @@ func (s *ContractReaderService) Bind(ctx context.Context, bindings []types.Bound
 		s.lookup.bindAddressForContract(bindings[idx].Name, bindings[idx].Address)
 
 		// also bind with an empty address so that we can look up the contract without providing address when calling CR methods
-		if sg, isInAShareGroup := s.bdRegistry.getShareGroup(bindings[idx].Name); isInAShareGroup {
+		if sg, isInAShareGroup := s.bdRegistry.GetShares(bindings[idx].Name); isInAShareGroup {
 			s.lookup.bindAddressForContract(bindings[idx].Name, "")
 
-			for _, namespace := range sg.group {
+			for _, namespace := range sg.getGroups() {
 				if err := s.addAddressResponseHardCoderModifier(namespace, bindings[idx].Address); err != nil {
 					return fmt.Errorf("failed to add address response hard coder modifier for contract: %q, : %w", namespace, err)
 				}

--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -8,9 +8,11 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
 	commoncodec "github.com/smartcontractkit/chainlink-common/pkg/codec"
@@ -30,7 +32,9 @@ import (
 type EventsReader interface {
 	Start(ctx context.Context) error
 	Ready() error
+	HasFilter(context.Context, string) bool
 	RegisterFilter(context.Context, logpoller.Filter) error
+	UnregisterFilter(ctx context.Context, name string) error
 	FilteredLogs(context.Context, []query.Expression, query.LimitAndSort, string) ([]logpoller.Log, error)
 }
 
@@ -48,11 +52,11 @@ type ContractReaderService struct {
 	reader EventsReader
 
 	// internal values
-	bdRegistry bindingsRegistry
-	lookup     *lookup
-	parsed     *codec.ParsedTypes
-	codec      types.RemoteCodec
-	filters    []logpoller.Filter
+	bdRegistry    *bindingsRegistry
+	lookup        *lookup
+	parsed        *codec.ParsedTypes
+	codec         types.RemoteCodec
+	shouldStartLP bool
 
 	// service state management
 	wg sync.WaitGroup
@@ -72,19 +76,15 @@ func NewContractReaderService(
 	reader EventsReader,
 ) (*ContractReaderService, error) {
 	svc := &ContractReaderService{
-		lggr:   logger.Named(lggr, ServiceName),
-		client: dataReader,
-		bdRegistry: bindingsRegistry{
-			namespaceBindings:  make(map[string]readNameBindings),
-			addressShareGroups: make(map[string]*addressShareGroup),
-		},
-		lookup: newLookup(),
+		lggr:       logger.Named(lggr, ServiceName),
+		client:     dataReader,
+		bdRegistry: newBindingsRegistry(),
+		lookup:     newLookup(),
 		parsed: &codec.ParsedTypes{
 			EncoderDefs: map[string]codec.Entry{},
 			DecoderDefs: map[string]codec.Entry{},
 		},
-		filters: []logpoller.Filter{},
-		reader:  reader,
+		reader: reader,
 	}
 
 	if err := svc.bdRegistry.initAddressSharing(cfg.AddressShareGroups); err != nil {
@@ -104,6 +104,7 @@ func NewContractReaderService(
 
 	svc.bdRegistry.SetCodecs(svcCodec)
 	svc.bdRegistry.SetModifiers(svc.parsed.Modifiers)
+
 	return svc, nil
 }
 
@@ -117,26 +118,23 @@ func (s *ContractReaderService) Name() string {
 // and error.
 func (s *ContractReaderService) Start(ctx context.Context) error {
 	return s.StartOnce(ServiceName, func() error {
-		if len(s.filters) == 0 {
+		if !s.shouldStartLP {
 			// No dependency on EventReader
 			return nil
 		}
+
 		if s.reader.Ready() != nil {
 			// Start EventReader if it hasn't already been
 			// Lazily starting it here rather than earlier, since nodes running only ordinary DF jobs don't need it
 			err := s.reader.Start(ctx)
 			if err != nil &&
 				!strings.Contains(err.Error(), "has already been started") { // in case another thread calls Start() after Ready() returns
-				return fmt.Errorf("%d event filters defined in ChainReader config, but unable to start event reader: %w", len(s.filters), err)
+				return fmt.Errorf("event filters are defined in ChainReader config, but unable to start event reader: %w", err)
 			}
 		}
+
 		// registering filters needs a context so we should be able to use the start function context.
-		for _, filter := range s.filters {
-			if err := s.reader.RegisterFilter(ctx, filter); err != nil {
-				return err
-			}
-		}
-		return nil
+		return s.bdRegistry.RegisterAll(ctx)
 	})
 }
 
@@ -146,7 +144,10 @@ func (s *ContractReaderService) Close() error {
 	return s.StopOnce(ServiceName, func() error {
 		s.wg.Wait()
 
-		return nil
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		return s.bdRegistry.UnregisterAll(ctx)
 	})
 }
 
@@ -282,24 +283,9 @@ func (s *ContractReaderService) BatchGetLatestValues(ctx context.Context, reques
 	return result, nil
 }
 
-func populateResultFromLookup(
-	idxLookup map[types.BoundContract]map[int]int,
-	output types.BatchGetLatestValuesResult,
-	results []batchResultWithErr,
-) {
-	for bound, idxs := range idxLookup {
-		for reqIdx, callIdx := range idxs {
-			res := types.BatchReadResult{ReadName: results[callIdx].readName}
-			res.SetResult(results[callIdx].returnVal, results[callIdx].err)
-
-			output[bound][reqIdx] = res
-		}
-	}
-}
-
 // QueryKey implements the types.ContractReader interface.
 func (s *ContractReaderService) QueryKey(ctx context.Context, contract types.BoundContract, filter query.KeyFilter, limitAndSort query.LimitAndSort, sequenceDataType any) ([]types.Sequence, error) {
-	binding, err := s.bdRegistry.GetReadBinding(contract.Name, filter.Key)
+	binding, err := s.bdRegistry.GetReader(contract.Name, filter.Key)
 	if err != nil {
 		return nil, err
 	}
@@ -337,21 +323,24 @@ func (s *ContractReaderService) QueryKey(ctx context.Context, contract types.Bou
 
 // Bind implements the types.ContractReader interface and allows new contract namespaceBindings to be added
 // to the service.
-func (s *ContractReaderService) Bind(_ context.Context, bindings []types.BoundContract) error {
+func (s *ContractReaderService) Bind(ctx context.Context, bindings []types.BoundContract) error {
 	for i := range bindings {
-		if err := s.bdRegistry.Bind(&bindings[i]); err != nil {
+		if err := s.bdRegistry.Bind(ctx, s.reader, bindings[i]); err != nil {
 			return err
 		}
 
 		s.lookup.bindAddressForContract(bindings[i].Name, bindings[i].Address)
+
 		// also bind with an empty address so that we can look up the contract without providing address when calling CR methods
 		if sg, isInAShareGroup := s.bdRegistry.getShareGroup(bindings[i].Name); isInAShareGroup {
 			s.lookup.bindAddressForContract(bindings[i].Name, "")
+
 			for _, namespace := range sg.group {
 				if err := s.addAddressResponseHardCoderModifier(namespace, bindings[i].Address); err != nil {
 					return fmt.Errorf("failed to add address response hard coder modifier for contract: %q, : %w", namespace, err)
 				}
 			}
+
 			return nil
 		}
 
@@ -364,12 +353,9 @@ func (s *ContractReaderService) Bind(_ context.Context, bindings []types.BoundCo
 
 // Unbind implements the types.ContractReader interface and allows existing contract namespaceBindings to be removed
 // from the service.
-func (s *ContractReaderService) Unbind(_ context.Context, bindings []types.BoundContract) error {
-	for _, binding := range bindings {
-		s.lookup.unbindAddressForContract(binding.Name, binding.Address)
-	}
-
-	return nil
+func (s *ContractReaderService) Unbind(ctx context.Context, bindings []types.BoundContract) error {
+	// TODO: unbind is incomplete
+	return s.bdRegistry.Unbind(ctx, s.reader, bindings)
 }
 
 // CreateContractType implements the ContractTypeProvider interface and allows the chain reader
@@ -426,20 +412,10 @@ func (s *ContractReaderService) initNamespace(namespaces map[string]config.Chain
 					return err
 				}
 			case config.Event:
-				idlDef, err := codec.FindDefinitionFromIDL(codec.ChainConfigTypeEventDef, read.ChainSpecificName, nameSpaceDef.IDL)
-				if err != nil {
-					return err
-				}
-
-				eventIDlDef, isOk := idlDef.(codec.IdlEvent)
-				if !isOk {
-					return fmt.Errorf("unexpected type %T from IDL definition for event read: %q, with chainSpecificName: %q, of type: %q", eventIDlDef, genericName, read.ChainSpecificName, read.ReadType)
-				}
-
-				if err = s.addEventRead(
+				if err := s.addEventRead(
+					nameSpaceDef.PollingFilter,
 					namespace, genericName,
-					nameSpaceDef.ContractAddress,
-					nameSpaceDef.IDL, eventIDlDef,
+					nameSpaceDef.IDL,
 					read,
 					s.reader,
 				); err != nil {
@@ -477,8 +453,9 @@ func (s *ContractReaderService) addAccountRead(namespace string, genericName str
 		return err
 	}
 
-	s.bdRegistry.AddReadBinding(namespace, genericName, newAccountReadBinding(namespace, genericName, isPDA, readDefinition.PDADefinition.Prefix, idl, inputIDLDef, outputIDLDef, readDefinition))
+	s.bdRegistry.AddReader(namespace, genericName, newAccountReadBinding(namespace, genericName, isPDA, readDefinition.PDADefinition.Prefix, idl, inputIDLDef, outputIDLDef, readDefinition))
 	s.lookup.addReadNameForContract(namespace, genericName, reads)
+
 	return nil
 }
 
@@ -523,12 +500,13 @@ func (s *ContractReaderService) addMultiAccountReadToCodec(namespace string, rea
 			return nil, fmt.Errorf("failed to add read to multi read %q: %w", mr.ChainSpecificName, err)
 		}
 
-		s.bdRegistry.AddReadBinding(namespace, genericName, newAccountReadBinding(namespace, genericName, isPDA, mr.PDADefinition.Prefix, idl, inputIDLDef, accountIDLDef, readDefinition))
+		s.bdRegistry.AddReader(namespace, genericName, newAccountReadBinding(namespace, genericName, isPDA, mr.PDADefinition.Prefix, idl, inputIDLDef, accountIDLDef, readDefinition))
 		reads = append(reads, read{
 			readName:  genericName,
 			useParams: readDefinition.MultiReader.ReuseParams,
 		})
 	}
+
 	return reads, nil
 }
 
@@ -538,7 +516,7 @@ func (s *ContractReaderService) addAddressResponseHardCoderModifier(namespace st
 		return fmt.Errorf("failed to parse address: %q", addressToHardCode)
 	}
 
-	rBindings, err := s.bdRegistry.GetReadBindings(namespace)
+	rBindings, err := s.bdRegistry.GetReaders(namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get read bindings : %w", err)
 	}
@@ -578,58 +556,128 @@ func (s *ContractReaderService) addAddressResponseHardCoderModifier(namespace st
 }
 
 func (s *ContractReaderService) addEventRead(
+	common *config.PollingFilter,
 	namespace, genericName string,
-	contractAddress solana.PublicKey,
 	idl codec.IDL,
-	eventIdl codec.IdlEvent,
 	readDefinition config.ReadDefinition,
 	events EventsReader,
 ) error {
-	mappedTuples := make(map[string]uint64)
-	subKeys := [4][]string{}
+	if readDefinition.EventDefinitions == nil {
+		return fmt.Errorf("%w: event definitions missing", types.ErrInvalidConfig)
+	}
 
-	applyIndexedFieldTuple(mappedTuples, subKeys, readDefinition.IndexedField0, 0)
-	applyIndexedFieldTuple(mappedTuples, subKeys, readDefinition.IndexedField1, 1)
-	applyIndexedFieldTuple(mappedTuples, subKeys, readDefinition.IndexedField2, 2)
-	applyIndexedFieldTuple(mappedTuples, subKeys, readDefinition.IndexedField3, 3)
+	conf := readDefinition.EventDefinitions
 
-	filter := toLPFilter(readDefinition.PollingFilter, contractAddress, subKeys[:],
-		codec.EventIDLTypes{Event: eventIdl, Types: idl.Types})
+	idlDef, err := codec.FindDefinitionFromIDL(codec.ChainConfigTypeEventDef, readDefinition.ChainSpecificName, idl)
+	if err != nil {
+		return err
+	}
 
-	s.filters = append(s.filters, filter)
-	s.bdRegistry.AddReadBinding(namespace, genericName, newEventReadBinding(
+	pf := setPollingFilterOverrides(common, conf.PollingFilter)
+
+	eventIdl, isOk := idlDef.(codec.IdlEvent)
+	if !isOk {
+		return fmt.Errorf(
+			"unexpected type from IDL definition for event read: %q, with chainSpecificName: %q, of type: %q",
+			genericName, readDefinition.ChainSpecificName, readDefinition.ReadType,
+		)
+	}
+
+	subkeys := newIndexedSubkeys()
+
+	applyIndexedFieldTuple(subkeys, conf.IndexedField0, 0)
+	applyIndexedFieldTuple(subkeys, conf.IndexedField1, 1)
+	applyIndexedFieldTuple(subkeys, conf.IndexedField2, 2)
+	applyIndexedFieldTuple(subkeys, conf.IndexedField3, 3)
+
+	reader := newEventReadBinding(
 		namespace,
 		genericName,
-		mappedTuples,
+		subkeys,
 		events,
-		filter.EventSig,
 		readDefinition,
-	))
+		pf,
+	)
+
+	s.shouldStartLP = true
+	reader.SetFilter(toLPFilter(readDefinition.ChainSpecificName, pf, subkeys.subKeys[:], codec.EventIDLTypes{Event: eventIdl, Types: idl.Types}))
+
+	s.bdRegistry.AddReader(namespace, genericName, reader)
 
 	return nil
 }
 
+func populateResultFromLookup(
+	idxLookup map[types.BoundContract]map[int]int,
+	output types.BatchGetLatestValuesResult,
+	results []batchResultWithErr,
+) {
+	for bound, idxs := range idxLookup {
+		for reqIdx, callIdx := range idxs {
+			res := types.BatchReadResult{ReadName: results[callIdx].readName}
+			res.SetResult(results[callIdx].returnVal, results[callIdx].err)
+
+			output[bound][reqIdx] = res
+		}
+	}
+}
+
 func toLPFilter(
-	f *config.PollingFilter,
-	address solana.PublicKey,
+	name string,
+	conf config.PollingFilter,
 	subKeyPaths [][]string,
 	eventIdl codec.EventIDLTypes,
 ) logpoller.Filter {
 	return logpoller.Filter{
-		Address:     logpoller.PublicKey(address),
-		EventName:   f.EventName,
-		EventSig:    logpoller.NewEventSignatureFromName(f.EventName),
+		EventName:   name,
+		EventSig:    logpoller.NewEventSignatureFromName(name),
 		EventIdl:    logpoller.EventIdl(eventIdl),
 		SubkeyPaths: subKeyPaths,
-		Retention:   f.Retention,
-		MaxLogsKept: f.MaxLogsKept,
+		Retention:   conf.GetRetention(),
+		MaxLogsKept: conf.GetMaxLogsKept(),
 	}
 }
 
-func applyIndexedFieldTuple(lookup map[string]uint64, subKeys [4][]string, conf *config.IndexedField, idx uint64) {
+// injectAddressModifier injects AddressModifier into OutputModifications.
+// This is necessary because AddressModifier cannot be serialized and must be applied at runtime.
+func injectAddressModifier(inputModifications, outputModifications commoncodec.ModifiersConfig) {
+	for i, modConfig := range inputModifications {
+		if addrModifierConfig, ok := modConfig.(*commoncodec.AddressBytesToStringModifierConfig); ok {
+			addrModifierConfig.Modifier = codec.SolanaAddressModifier{}
+			outputModifications[i] = addrModifierConfig
+		}
+	}
+
+	for i, modConfig := range outputModifications {
+		if addrModifierConfig, ok := modConfig.(*commoncodec.AddressBytesToStringModifierConfig); ok {
+			addrModifierConfig.Modifier = codec.SolanaAddressModifier{}
+			outputModifications[i] = addrModifierConfig
+		}
+	}
+}
+
+type accountDataReader struct {
+	client *rpc.Client
+}
+
+func NewAccountDataReader(client *rpc.Client) *accountDataReader {
+	return &accountDataReader{client: client}
+}
+
+func (r *accountDataReader) ReadAll(ctx context.Context, pk solana.PublicKey, opts *rpc.GetAccountInfoOpts) ([]byte, error) {
+	result, err := r.client.GetAccountInfoWithOpts(ctx, pk, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	bts := result.Value.Data.GetBinary()
+
+	return bts, nil
+}
+
+func applyIndexedFieldTuple(subkeys *indexedSubkeys, conf *config.IndexedField, idx uint64) {
 	if conf != nil {
-		lookup[conf.OffChainPath] = idx
-		subKeys[idx] = strings.Split(conf.OnChainPath, ".")
+		subkeys.addForIndex(conf.OffChainPath, conf.OnChainPath, idx)
 	}
 }
 
@@ -781,4 +829,31 @@ func (s *ContractReaderService) getPDAsForGetTokenPrices(params any, values read
 		pdaAddresses = append(pdaAddresses, pdaAddress)
 	}
 	return pdaAddresses, nil
+}
+
+func setPollingFilterOverrides(common *config.PollingFilter, overrides ...*config.PollingFilter) config.PollingFilter {
+	final := reflect.New(reflect.TypeOf(common).Elem())
+	valOfF := final.Elem()
+	allOverrides := append([]*config.PollingFilter{common}, overrides...)
+
+	for _, override := range allOverrides {
+		valOfO := reflect.Indirect(reflect.ValueOf(override))
+		for idx := range valOfF.Type().NumField() {
+			name := valOfO.Type().Field(idx).Name
+			field := valOfF.FieldByName(name)
+			valOfFieldO := valOfO.FieldByName(name)
+
+			if valOfFieldO.IsZero() {
+				continue
+			}
+
+			if field.CanSet() {
+				newVal := reflect.New(field.Type().Elem())
+				newVal.Elem().Set(valOfO.FieldByName(name).Elem())
+				field.Set(newVal)
+			}
+		}
+	}
+
+	return final.Elem().Interface().(config.PollingFilter)
 }

--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -321,22 +321,25 @@ func (s *ContractReaderService) QueryKey(ctx context.Context, contract types.Bou
 	return sequenceOfValues, nil
 }
 
-// Bind implements the types.ContractReader interface and allows new contract namespaceBindings to be added
-// to the service.
+// Bind implements the types.ContractReader interface and allows new contract namespaceBindings to be added to the
+// service.
+//
+// Bind has a side-effect of updating a binding with a shared address if the bound contract has been configured to be
+// part of a share group.
 func (s *ContractReaderService) Bind(ctx context.Context, bindings []types.BoundContract) error {
-	for i := range bindings {
-		if err := s.bdRegistry.Bind(ctx, s.reader, bindings[i]); err != nil {
+	for idx := range bindings {
+		if err := s.bdRegistry.Bind(ctx, s.reader, &bindings[idx]); err != nil {
 			return err
 		}
 
-		s.lookup.bindAddressForContract(bindings[i].Name, bindings[i].Address)
+		s.lookup.bindAddressForContract(bindings[idx].Name, bindings[idx].Address)
 
 		// also bind with an empty address so that we can look up the contract without providing address when calling CR methods
-		if sg, isInAShareGroup := s.bdRegistry.getShareGroup(bindings[i].Name); isInAShareGroup {
-			s.lookup.bindAddressForContract(bindings[i].Name, "")
+		if sg, isInAShareGroup := s.bdRegistry.getShareGroup(bindings[idx].Name); isInAShareGroup {
+			s.lookup.bindAddressForContract(bindings[idx].Name, "")
 
 			for _, namespace := range sg.group {
-				if err := s.addAddressResponseHardCoderModifier(namespace, bindings[i].Address); err != nil {
+				if err := s.addAddressResponseHardCoderModifier(namespace, bindings[idx].Address); err != nil {
 					return fmt.Errorf("failed to add address response hard coder modifier for contract: %q, : %w", namespace, err)
 				}
 			}
@@ -344,8 +347,8 @@ func (s *ContractReaderService) Bind(ctx context.Context, bindings []types.Bound
 			return nil
 		}
 
-		if err := s.addAddressResponseHardCoderModifier(bindings[i].Name, bindings[i].Address); err != nil {
-			return fmt.Errorf("failed to add address response hard coder modifier for contract: %q, : %w", bindings[i].Name, err)
+		if err := s.addAddressResponseHardCoderModifier(bindings[idx].Name, bindings[idx].Address); err != nil {
+			return fmt.Errorf("failed to add address response hard coder modifier for contract: %q, : %w", bindings[idx].Name, err)
 		}
 	}
 
@@ -830,6 +833,10 @@ func setPollingFilterOverrides(common *config.PollingFilter, overrides ...*confi
 	allOverrides := append([]*config.PollingFilter{common}, overrides...)
 
 	for _, override := range allOverrides {
+		if override == nil {
+			continue
+		}
+
 		valOfO := reflect.Indirect(reflect.ValueOf(override))
 		for idx := range valOfF.Type().NumField() {
 			name := valOfO.Type().Field(idx).Name

--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -348,14 +348,25 @@ func (s *ContractReaderService) Bind(ctx context.Context, bindings []types.Bound
 			return fmt.Errorf("failed to add address response hard coder modifier for contract: %q, : %w", bindings[i].Name, err)
 		}
 	}
+
 	return nil
 }
 
 // Unbind implements the types.ContractReader interface and allows existing contract namespaceBindings to be removed
 // from the service.
 func (s *ContractReaderService) Unbind(ctx context.Context, bindings []types.BoundContract) error {
-	// TODO: unbind is incomplete
-	return s.bdRegistry.Unbind(ctx, s.reader, bindings)
+	for i := range bindings {
+		if err := s.bdRegistry.Unbind(ctx, s.reader, bindings[i]); err != nil {
+			return err
+		}
+
+		s.lookup.unbindAddressForContract(bindings[i].Name, bindings[i].Address)
+
+		// also unbind an empty address if a share group exists
+		s.lookup.unbindAddressForContract(bindings[i].Name, "")
+	}
+
+	return nil
 }
 
 // CreateContractType implements the ContractTypeProvider interface and allows the chain reader
@@ -635,24 +646,6 @@ func toLPFilter(
 		SubkeyPaths: subKeyPaths,
 		Retention:   conf.GetRetention(),
 		MaxLogsKept: conf.GetMaxLogsKept(),
-	}
-}
-
-// injectAddressModifier injects AddressModifier into OutputModifications.
-// This is necessary because AddressModifier cannot be serialized and must be applied at runtime.
-func injectAddressModifier(inputModifications, outputModifications commoncodec.ModifiersConfig) {
-	for i, modConfig := range inputModifications {
-		if addrModifierConfig, ok := modConfig.(*commoncodec.AddressBytesToStringModifierConfig); ok {
-			addrModifierConfig.Modifier = codec.SolanaAddressModifier{}
-			outputModifications[i] = addrModifierConfig
-		}
-	}
-
-	for i, modConfig := range outputModifications {
-		if addrModifierConfig, ok := modConfig.(*commoncodec.AddressBytesToStringModifierConfig); ok {
-			addrModifierConfig.Modifier = codec.SolanaAddressModifier{}
-			outputModifications[i] = addrModifierConfig
-		}
 	}
 }
 

--- a/pkg/solana/chainreader/chain_reader_test.go
+++ b/pkg/solana/chainreader/chain_reader_test.go
@@ -116,7 +116,13 @@ func TestSolanaChainReaderService_Start(t *testing.T) {
 	eventReadDef := config.ReadDefinition{
 		ChainSpecificName: "myEvent",
 		ReadType:          config.Event,
-		PollingFilter:     &config.PollingFilter{EventName: "myEventSig.........."},
+		EventDefinitions: &config.EventDefinitions{
+			IndexedField0: &config.IndexedField{
+				OffChainPath: "A.B",
+				OnChainPath:  "A.B",
+			},
+			PollingFilter: &config.PollingFilter{},
+		},
 	}
 
 	testCases := []struct {
@@ -149,7 +155,6 @@ func TestSolanaChainReaderService_Start(t *testing.T) {
 									Fields: &[]codec.IdlField{}}}},
 							Events: []codec.IdlEvent{{Name: "myEvent", Fields: []codec.IdlEventField{{Name: "a", Type: boolType}}}},
 						},
-						ContractAddress: pk,
 						Reads: map[string]config.ReadDefinition{
 							"myRead": tt.ReadDef},
 					},
@@ -174,6 +179,9 @@ func TestSolanaChainReaderService_Start(t *testing.T) {
 			}())
 			er.On("Start", mock.Anything).Maybe().Return(tt.StartError)
 			er.On("RegisterFilter", mock.Anything, mock.Anything).Maybe().Return(tt.RegisterFilterError)
+
+			require.NoError(t, svc.Bind(ctx, []types.BoundContract{{Address: pk.String(), Name: "myChainReader"}}))
+
 			err = svc.Start(ctx)
 			if tt.ExpectError {
 				assert.Error(t, err)

--- a/pkg/solana/chainreader/chain_reader_test.go
+++ b/pkg/solana/chainreader/chain_reader_test.go
@@ -178,6 +178,7 @@ func TestSolanaChainReaderService_Start(t *testing.T) {
 				return service.ErrNotStarted
 			}())
 			er.On("Start", mock.Anything).Maybe().Return(tt.StartError)
+			er.On("HasFilter", mock.Anything, mock.Anything).Return(false).Maybe()
 			er.On("RegisterFilter", mock.Anything, mock.Anything).Maybe().Return(tt.RegisterFilterError)
 
 			require.NoError(t, svc.Bind(ctx, []types.BoundContract{{Address: pk.String(), Name: "myChainReader"}}))

--- a/pkg/solana/chainreader/event_read_binding.go
+++ b/pkg/solana/chainreader/event_read_binding.go
@@ -101,11 +101,7 @@ func (b *eventReadBinding) Unbind(ctx context.Context) error {
 
 	b.unsetBinding()
 
-	if err := b.Unregister(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return b.Unregister(ctx)
 }
 
 func (b *eventReadBinding) Register(ctx context.Context) error {

--- a/pkg/solana/chainreader/event_read_binding.go
+++ b/pkg/solana/chainreader/event_read_binding.go
@@ -5,46 +5,60 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/google/uuid"
 
 	commoncodec "github.com/smartcontractkit/chainlink-common/pkg/codec"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
-
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller"
 )
 
 type eventReadBinding struct {
+	// dependencies
+	reader   EventsReader
+	remapper remapHelper
+	codec    types.RemoteCodec
+	modifier commoncodec.Modifier
+	conf     config.PollingFilter
+	// filter in eventReadBinding is to be used as an override for lp filter defined in the namespace binding.
+	// If filter is nil, this event should be registered with the lp filter defined in the namespace binding.
+	filter *syncedFilter
+
+	// static data
 	namespace, genericName string
-	codec                  types.RemoteCodec
-	modifier               commoncodec.Modifier
-	key                    solana.PublicKey
-	remapper               remapHelper
-	indexedSubKeys         map[string]uint64
-	reader                 EventsReader
 	eventSig               [logpoller.EventSignatureLength]byte
+	indexedSubKeys         *indexedSubkeys
 	readDefinition         config.ReadDefinition
+
+	// thread protected fields
+	mu             sync.RWMutex
+	key            solana.PublicKey
+	bound          bool
+	registerCalled bool
 }
 
 func newEventReadBinding(
 	namespace, genericName string,
-	indexedSubKeys map[string]uint64,
+	indexedSubKeys *indexedSubkeys,
 	reader EventsReader,
-	eventSig [logpoller.EventSignatureLength]byte,
 	readDefinition config.ReadDefinition,
+	conf config.PollingFilter,
 ) *eventReadBinding {
 	binding := &eventReadBinding{
+		filter:         newSyncedFilter(),
 		namespace:      namespace,
 		genericName:    genericName,
 		indexedSubKeys: indexedSubKeys,
 		reader:         reader,
-		eventSig:       eventSig,
 		readDefinition: readDefinition,
+		conf:           conf,
 	}
 
 	binding.remapper = remapHelper{binding.remapPrimitive}
@@ -52,7 +66,85 @@ func newEventReadBinding(
 	return binding
 }
 
+func (b *eventReadBinding) Bind(ctx context.Context, address solana.PublicKey) error {
+	if b.isBound() {
+		// we are changing contract address reference, so we need to unregister old filter if it exists
+		if err := b.Unregister(ctx); err != nil {
+			return err
+		}
+	}
+
+	// filter isn't required here because the event can also be polled for by the contractBinding common filter.
+	if b.filter != nil {
+		b.filter.SetName(fmt.Sprintf("%s.%s.%s", b.namespace, b.genericName, uuid.NewString()))
+		b.filter.SetAddress(address)
+	}
+
+	b.setBinding(address)
+
+	if b.registered() {
+		return b.Register(ctx)
+	}
+
+	return nil
+}
+
+func (b *eventReadBinding) Unbind(ctx context.Context) error {
+	if !b.isBound() {
+		return nil
+	}
+
+	if b.filter != nil {
+		b.filter.SetAddress(solana.PublicKey{})
+		b.filter.SetName("")
+	}
+
+	b.unsetBinding()
+
+	if err := b.Unregister(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *eventReadBinding) Register(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.filter == nil {
+		return nil
+	}
+
+	b.registerCalled = true
+
+	// can't be true before filters params are set so there is no race with a bad filter outcome
+	if !b.bound {
+		return nil
+	}
+
+	return b.filter.Register(ctx, b.reader)
+}
+
+func (b *eventReadBinding) Unregister(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.filter == nil {
+		return nil
+	}
+
+	if !b.bound {
+		return nil
+	}
+
+	return b.filter.Unregister(ctx, b.reader)
+}
+
 func (b *eventReadBinding) GetAddress(_ context.Context, _ any) (solana.PublicKey, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
 	return b.key, nil
 }
 
@@ -72,16 +164,20 @@ func (b *eventReadBinding) GetAddressResponseHardCoder() *commoncodec.HardCodeMo
 	return nil
 }
 
-func (b *eventReadBinding) SetAddress(key solana.PublicKey) {
-	b.key = key
-}
-
 func (b *eventReadBinding) SetCodec(codec types.RemoteCodec) {
 	b.codec = codec
 }
 
 func (b *eventReadBinding) SetModifier(modifier commoncodec.Modifier) {
 	b.modifier = modifier
+}
+
+func (b *eventReadBinding) SetFilter(filter logpoller.Filter) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.filter.SetFilter(filter)
+	b.eventSig = filter.EventSig
 }
 
 func (b *eventReadBinding) CreateType(forEncoding bool) (any, error) {
@@ -155,7 +251,7 @@ func (b *eventReadBinding) remapPrimitive(expression query.Expression) (query.Ex
 }
 
 func (b *eventReadBinding) encodeComparator(comparator *primitives.Comparator) (query.Expression, error) {
-	subKeyIndex, ok := b.indexedSubKeys[comparator.Name]
+	subKeyIndex, ok := b.indexedSubKeys.indexForKey(comparator.Name)
 	if !ok {
 		return query.Expression{}, fmt.Errorf("%w: unknown indexed subkey mapping %s", types.ErrInvalidConfig, comparator.Name)
 	}
@@ -222,6 +318,36 @@ func (b *eventReadBinding) decodeLog(ctx context.Context, log *logpoller.Log, in
 	return nil
 }
 
+func (b *eventReadBinding) isBound() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return b.bound
+}
+
+func (b *eventReadBinding) setBinding(binding solana.PublicKey) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.key = binding
+	b.bound = true
+}
+
+func (b *eventReadBinding) unsetBinding() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.key = solana.PublicKey{}
+	b.bound = false
+}
+
+func (b *eventReadBinding) registered() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return b.registerCalled
+}
+
 type remapHelper struct {
 	primitive func(query.Expression) (query.Expression, error)
 }
@@ -261,4 +387,26 @@ func (r remapHelper) remapExpression(key string, expression query.Expression) (q
 	}
 
 	return r.primitive(expression)
+}
+
+type indexedSubkeys struct {
+	lookup  map[string]uint64
+	subKeys [4][]string
+}
+
+func newIndexedSubkeys() *indexedSubkeys {
+	return &indexedSubkeys{
+		lookup: make(map[string]uint64),
+	}
+}
+
+func (k *indexedSubkeys) addForIndex(offChainPath, onChainPath string, idx uint64) {
+	k.lookup[offChainPath] = idx
+	k.subKeys[idx] = strings.Split(onChainPath, ".")
+}
+
+func (k *indexedSubkeys) indexForKey(key string) (uint64, bool) {
+	idx, ok := k.lookup[key]
+
+	return idx, ok
 }

--- a/pkg/solana/chainreader/filter.go
+++ b/pkg/solana/chainreader/filter.go
@@ -87,19 +87,6 @@ func (r *syncedFilter) AddressSet() bool {
 	return r.addressSet
 }
 
-func (r *syncedFilter) HasIndexedSubkeys() bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	for _, path := range r.filter.SubkeyPaths {
-		if len(path) > 0 {
-			return true
-		}
-	}
-
-	return false
-}
-
 type FilterError struct {
 	Err    error
 	Action string

--- a/pkg/solana/chainreader/filter.go
+++ b/pkg/solana/chainreader/filter.go
@@ -1,0 +1,115 @@
+package chainreader
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller"
+)
+
+type syncedFilter struct {
+	// internal state properties
+	mu         sync.RWMutex
+	addressSet bool
+	filter     logpoller.Filter
+}
+
+func newSyncedFilter() *syncedFilter {
+	return &syncedFilter{}
+}
+
+func (r *syncedFilter) Register(ctx context.Context, registrar filterRegistrar) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if !registrar.HasFilter(ctx, r.filter.Name) {
+		if err := registrar.RegisterFilter(ctx, r.filter); err != nil {
+			return FilterError{
+				Err:    fmt.Errorf("%w: %s", types.ErrInternal, err.Error()),
+				Action: "register",
+				Filter: r.filter,
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *syncedFilter) Unregister(ctx context.Context, registrar filterRegistrar) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if !registrar.HasFilter(ctx, r.filter.Name) {
+		return nil
+	}
+
+	if err := registrar.UnregisterFilter(ctx, r.filter.Name); err != nil {
+		return FilterError{
+			Err:    fmt.Errorf("%w: %s", types.ErrInternal, err.Error()),
+			Action: "unregister",
+			Filter: r.filter,
+		}
+	}
+
+	return nil
+}
+
+func (r *syncedFilter) SetFilter(filter logpoller.Filter) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.filter = filter
+}
+
+func (r *syncedFilter) SetName(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.filter.Name = name
+}
+
+func (r *syncedFilter) SetAddress(address solana.PublicKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.addressSet = true
+	r.filter.Address = logpoller.PublicKey(address)
+}
+
+func (r *syncedFilter) AddressSet() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.addressSet
+}
+
+func (r *syncedFilter) HasIndexedSubkeys() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, path := range r.filter.SubkeyPaths {
+		if len(path) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+type FilterError struct {
+	Err    error
+	Action string
+	Filter logpoller.Filter
+}
+
+func (e FilterError) Error() string {
+	return fmt.Sprintf("[logpoller filter error] action: %s; err: %s; filter: %+v;", e.Action, e.Err.Error(), e.Filter)
+}
+
+func (e FilterError) Unwrap() error {
+	return e.Err
+}

--- a/pkg/solana/chainreader/mocks/events_reader.go
+++ b/pkg/solana/chainreader/mocks/events_reader.go
@@ -85,6 +85,53 @@ func (_c *EventsReader_FilteredLogs_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// HasFilter provides a mock function with given fields: _a0, _a1
+func (_m *EventsReader) HasFilter(_a0 context.Context, _a1 string) bool {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasFilter")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// EventsReader_HasFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasFilter'
+type EventsReader_HasFilter_Call struct {
+	*mock.Call
+}
+
+// HasFilter is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 string
+func (_e *EventsReader_Expecter) HasFilter(_a0 interface{}, _a1 interface{}) *EventsReader_HasFilter_Call {
+	return &EventsReader_HasFilter_Call{Call: _e.mock.On("HasFilter", _a0, _a1)}
+}
+
+func (_c *EventsReader_HasFilter_Call) Run(run func(_a0 context.Context, _a1 string)) *EventsReader_HasFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *EventsReader_HasFilter_Call) Return(_a0 bool) *EventsReader_HasFilter_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *EventsReader_HasFilter_Call) RunAndReturn(run func(context.Context, string) bool) *EventsReader_HasFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Ready provides a mock function with given fields:
 func (_m *EventsReader) Ready() error {
 	ret := _m.Called()
@@ -219,6 +266,53 @@ func (_c *EventsReader_Start_Call) Return(_a0 error) *EventsReader_Start_Call {
 }
 
 func (_c *EventsReader_Start_Call) RunAndReturn(run func(context.Context) error) *EventsReader_Start_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UnregisterFilter provides a mock function with given fields: ctx, name
+func (_m *EventsReader) UnregisterFilter(ctx context.Context, name string) error {
+	ret := _m.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UnregisterFilter")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// EventsReader_UnregisterFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UnregisterFilter'
+type EventsReader_UnregisterFilter_Call struct {
+	*mock.Call
+}
+
+// UnregisterFilter is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *EventsReader_Expecter) UnregisterFilter(ctx interface{}, name interface{}) *EventsReader_UnregisterFilter_Call {
+	return &EventsReader_UnregisterFilter_Call{Call: _e.mock.On("UnregisterFilter", ctx, name)}
+}
+
+func (_c *EventsReader_UnregisterFilter_Call) Run(run func(ctx context.Context, name string)) *EventsReader_UnregisterFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *EventsReader_UnregisterFilter_Call) Return(_a0 error) *EventsReader_UnregisterFilter_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *EventsReader_UnregisterFilter_Call) RunAndReturn(run func(context.Context, string) error) *EventsReader_UnregisterFilter_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/solana/config/chain_reader.go
+++ b/pkg/solana/config/chain_reader.go
@@ -5,13 +5,37 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
-
 	commoncodec "github.com/smartcontractkit/chainlink-common/pkg/codec"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
 )
+
+const (
+	DefaultLogPollerRetention = 24 * time.Hour
+	DefaultMaxLogsKept        = 0
+)
+
+type PollingFilter struct {
+	Retention   *time.Duration `json:"retention,omitempty"`   // maximum amount of time to retain logs
+	MaxLogsKept *int64         `json:"maxLogsKept,omitempty"` // maximum number of logs to retain ( 0 = unlimited )
+}
+
+func (f PollingFilter) GetRetention() time.Duration {
+	if f.Retention == nil {
+		return DefaultLogPollerRetention
+	}
+
+	return *f.Retention
+}
+
+func (f PollingFilter) GetMaxLogsKept() int64 {
+	if f.MaxLogsKept == nil {
+		return DefaultMaxLogsKept
+	}
+
+	return *f.MaxLogsKept
+}
 
 type ContractReader struct {
 	Namespaces map[string]ChainContractReader `json:"namespaces"`
@@ -24,11 +48,20 @@ type ContractReader struct {
 }
 
 type ChainContractReader struct {
-	codec.IDL       `json:"anchorIDL"`
-	ContractAddress solana.PublicKey `json:"contractAddress"`
+	codec.IDL      `json:"anchorIDL"`
+	*PollingFilter `json:"pollingFilter,omitempty"`
 	// Reads key is the off-chain name for this read.
 	Reads map[string]ReadDefinition `json:"reads"`
-	// TODO ContractPollingFilter same as EVM?
+}
+
+type EventDefinitions struct {
+	IndexedField0 *IndexedField `json:"indexedField0"`
+	IndexedField1 *IndexedField `json:"indexedField1"`
+	IndexedField2 *IndexedField `json:"indexedField2"`
+	IndexedField3 *IndexedField `json:"indexedField3"`
+	// PollingFilter should be defined on a contract level in ContractPollingFilter, unless event needs to override the
+	// contract level filter options.
+	*PollingFilter `json:"pollingFilter,omitempty"`
 }
 
 type MultiReader struct {
@@ -46,14 +79,13 @@ type ReadDefinition struct {
 	OutputModifications commoncodec.ModifiersConfig `json:"outputModifications,omitempty"`
 	PDADefinition       codec.PDATypeDef            `json:"pdaDefinition,omitempty"` // Only used for PDA account reads
 	MultiReader         *MultiReader                `json:"multiReader,omitempty"`
-	IndexedField0       *IndexedField               `json:"indexedField0"`
-	IndexedField1       *IndexedField               `json:"indexedField1"`
-	IndexedField2       *IndexedField               `json:"indexedField2"`
-	IndexedField3       *IndexedField               `json:"indexedField3"`
+	EventDefinitions    *EventDefinitions           `json:"eventDefinitions,omitempty"`
 	// ResponseAddressHardCoder hardcodes the address of the contract into the defined field in the response.
 	ResponseAddressHardCoder *commoncodec.HardCodeModifierConfig `json:"responseAddressHardCoder,omitempty"`
-	// This will create a log poller filter for this event.
-	*PollingFilter `json:"pollingFilter,omitempty"`
+}
+
+func (d ReadDefinition) HasPollingFilter() bool {
+	return d.EventDefinitions != nil && d.EventDefinitions.PollingFilter != nil
 }
 
 type ReadType int
@@ -144,10 +176,4 @@ func (c *ChainContractReader) UnmarshalJSON(bytes []byte) error {
 	}
 
 	return nil
-}
-
-type PollingFilter struct {
-	EventName   string        `json:"eventName"`
-	Retention   time.Duration `json:"retention"`   // maximum amount of time to retain logs
-	MaxLogsKept int64         `json:"maxLogsKept"` // maximum number of logs to retain ( 0 = unlimited )
 }

--- a/pkg/solana/config/chain_reader.go
+++ b/pkg/solana/config/chain_reader.go
@@ -12,13 +12,15 @@ import (
 )
 
 const (
-	DefaultLogPollerRetention = 24 * time.Hour
+	DefaultLogPollerRetention = 30 * 24 * time.Hour
 	DefaultMaxLogsKept        = 0
+	DefaultStartingBlock      = 0
 )
 
 type PollingFilter struct {
-	Retention   *time.Duration `json:"retention,omitempty"`   // maximum amount of time to retain logs
-	MaxLogsKept *int64         `json:"maxLogsKept,omitempty"` // maximum number of logs to retain ( 0 = unlimited )
+	Retention     *time.Duration `json:"retention,omitempty"`     // maximum amount of time to retain logs
+	MaxLogsKept   *int64         `json:"maxLogsKept,omitempty"`   // maximum number of logs to retain ( 0 = unlimited )
+	StartingBlock *int64         `json:"startingBlock,omitempty"` // which block to start looking for logs
 }
 
 func (f PollingFilter) GetRetention() time.Duration {
@@ -35,6 +37,14 @@ func (f PollingFilter) GetMaxLogsKept() int64 {
 	}
 
 	return *f.MaxLogsKept
+}
+
+func (f PollingFilter) GetStartingBlock() int64 {
+	if f.StartingBlock == nil {
+		return DefaultStartingBlock
+	}
+
+	return *f.StartingBlock
 }
 
 type ContractReader struct {

--- a/pkg/solana/logpoller/filters.go
+++ b/pkg/solana/logpoller/filters.go
@@ -81,6 +81,15 @@ func (fl *filters) PruneFilters(ctx context.Context) error {
 	return nil
 }
 
+func (fl *filters) HasFilter(ctx context.Context, name string) bool {
+	exists, err := fl.orm.HasFilter(ctx, name)
+	if err != nil {
+		return false
+	}
+
+	return exists
+}
+
 // RegisterFilter persists provided filter and ensures that any log emitted by a contract with filter.Address
 // that matches filter.EventSig signature will be captured starting from filter.StartingBlock.
 // The filter may be unregistered later by filter.Name.

--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -24,6 +24,7 @@ var (
 
 type ORM interface {
 	ChainID() string
+	HasFilter(ctx context.Context, name string) (bool, error)
 	InsertFilter(ctx context.Context, filter Filter) (id int64, err error)
 	SelectFilters(ctx context.Context) ([]Filter, error)
 	DeleteFilters(ctx context.Context, filters map[int64]Filter) error
@@ -40,6 +41,7 @@ type logsLoader interface {
 }
 
 type filtersI interface {
+	HasFilter(ctx context.Context, name string) bool
 	RegisterFilter(ctx context.Context, filter Filter) error
 	UnregisterFilter(ctx context.Context, name string) error
 	LoadFilters(ctx context.Context) error
@@ -185,6 +187,13 @@ func (lp *Service) Process(ctx context.Context, programEvent ProgramEvent) (err 
 	}
 
 	return lp.orm.InsertLogs(ctx, logs)
+}
+
+func (lp *Service) HasFilter(ctx context.Context, name string) bool {
+	ctx, cancel := lp.eng.Ctx(ctx)
+	defer cancel()
+
+	return lp.filters.HasFilter(ctx, name)
 }
 
 // RegisterFilter - refer to filters.RegisterFilter for details.

--- a/pkg/solana/logpoller/mock_filters.go
+++ b/pkg/solana/logpoller/mock_filters.go
@@ -190,6 +190,53 @@ func (_c *mockFilters_GetFiltersToBackfill_Call) RunAndReturn(run func() []Filte
 	return _c
 }
 
+// HasFilter provides a mock function with given fields: ctx, name
+func (_m *mockFilters) HasFilter(ctx context.Context, name string) bool {
+	ret := _m.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasFilter")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, name)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// mockFilters_HasFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasFilter'
+type mockFilters_HasFilter_Call struct {
+	*mock.Call
+}
+
+// HasFilter is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *mockFilters_Expecter) HasFilter(ctx interface{}, name interface{}) *mockFilters_HasFilter_Call {
+	return &mockFilters_HasFilter_Call{Call: _e.mock.On("HasFilter", ctx, name)}
+}
+
+func (_c *mockFilters_HasFilter_Call) Run(run func(ctx context.Context, name string)) *mockFilters_HasFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *mockFilters_HasFilter_Call) Return(_a0 bool) *mockFilters_HasFilter_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *mockFilters_HasFilter_Call) RunAndReturn(run func(context.Context, string) bool) *mockFilters_HasFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IncrementSeqNum provides a mock function with given fields: filterID
 func (_m *mockFilters) IncrementSeqNum(filterID int64) int64 {
 	ret := _m.Called(filterID)

--- a/pkg/solana/logpoller/mock_orm.go
+++ b/pkg/solana/logpoller/mock_orm.go
@@ -231,6 +231,63 @@ func (_c *MockORM_GetLatestBlock_Call) RunAndReturn(run func(context.Context) (i
 	return _c
 }
 
+// HasFilter provides a mock function with given fields: ctx, name
+func (_m *MockORM) HasFilter(ctx context.Context, name string) (bool, error) {
+	ret := _m.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasFilter")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, name)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockORM_HasFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasFilter'
+type MockORM_HasFilter_Call struct {
+	*mock.Call
+}
+
+// HasFilter is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *MockORM_Expecter) HasFilter(ctx interface{}, name interface{}) *MockORM_HasFilter_Call {
+	return &MockORM_HasFilter_Call{Call: _e.mock.On("HasFilter", ctx, name)}
+}
+
+func (_c *MockORM_HasFilter_Call) Run(run func(ctx context.Context, name string)) *MockORM_HasFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockORM_HasFilter_Call) Return(_a0 bool, _a1 error) *MockORM_HasFilter_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockORM_HasFilter_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *MockORM_HasFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // InsertFilter provides a mock function with given fields: ctx, filter
 func (_m *MockORM) InsertFilter(ctx context.Context, filter Filter) (int64, error) {
 	ret := _m.Called(ctx, filter)

--- a/pkg/solana/logpoller/orm.go
+++ b/pkg/solana/logpoller/orm.go
@@ -38,6 +38,29 @@ func (o *DSORM) Transact(ctx context.Context, fn func(*DSORM) error) (err error)
 // new returns a NewORM like o, but backed by ds.
 func (o *DSORM) new(ds sqlutil.DataSource) *DSORM { return NewORM(o.chainID, ds, o.lggr) }
 
+func (o *DSORM) HasFilter(ctx context.Context, name string) (bool, error) {
+	args, err := newQueryArgs(o.chainID).withField("name", name).toArgs()
+	if err != nil {
+		return false, err
+	}
+
+	query := `
+		SELECT id FROM solana.log_poller_filters
+			WHERE is_deleted = false AND chain_id = :chain_id AND name = :name LIMIT 1`
+
+	query, sqlArgs, err := o.ds.BindNamed(query, args)
+	if err != nil {
+		return false, err
+	}
+
+	var id int64
+	if err = o.ds.GetContext(ctx, &id, query, sqlArgs...); err != nil {
+		return false, err
+	}
+
+	return id >= 0, nil
+}
+
 // InsertFilter is idempotent.
 //
 // Each address/event pair must have a unique job id, so it may be removed when the job is deleted.

--- a/pkg/solana/logpoller/orm_test.go
+++ b/pkg/solana/logpoller/orm_test.go
@@ -84,6 +84,12 @@ func TestLogPollerFilters(t *testing.T) {
 				dbFilter, err := orm.GetFilterByID(ctx, id)
 				require.NoError(t, err)
 				require.Equal(t, filter, dbFilter)
+
+				exists, err := orm.HasFilter(ctx, dbFilter.Name)
+
+				require.NoError(t, err)
+				require.True(t, exists)
+
 				dbFilters, err := orm.SelectFilters(ctx)
 				require.NoError(t, err)
 				i := slices.IndexFunc(dbFilters, func(f Filter) bool {


### PR DESCRIPTION
### Description

Align LogPoller filter registration logic to be similar to EVM. Filters are checked and registered on `ContractReader` startup and unregistered on close.