### PR TITLE
Bump actions/cache version

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
       run: echo "path=./${{ inputs.go-module-file }}" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: actions/cache@v4
       name: Cache Go Modules
       with:
         path: |
@@ -51,7 +51,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
 
-    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: actions/cache@v4
       if: ${{ inputs.only-modules == 'false' }}
       name: Cache Go Build Outputs
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: cache docker build image
       id: cache-image
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4
       with:
         path: contracts/docker-build.tar
         key: ${{ runner.os }}-docker-pnpm-build-${{ needs.get_projectserum_version.outputs.projectserum_version }}-${{ hashFiles('**/Cargo.lock') }}
@@ -47,18 +47,18 @@ jobs:
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: Cache cargo target dir
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4
       with:
         path: contracts/target
         key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
     - name: Cache hello-world target dir
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4
       with:
         path: contracts/examples/hello-world/target
         key: ${{ runner.os }}-v2-cargo-build-target-hello-world-${{ hashFiles('**/Cargo.lock') }}
     - name: cache docker build image
       id: cache-image
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4
       with:
         path: contracts/docker-build.tar
         key: ${{ runner.os }}-docker-pnpm-build-${{ needs.get_projectserum_version.outputs.projectserum_version }}-${{ hashFiles('**/Cargo.lock') }}
@@ -92,13 +92,13 @@ jobs:
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: Cache cargo target dir
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4
       with:
         path: contracts/target
         key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
     - name: cache docker build image
       id: cache-image
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4
       with:
         path: contracts/docker-build.tar
         key: ${{ runner.os }}-docker-pnpm-build-${{ needs.get_projectserum_version.outputs.projectserum_version }}-${{ hashFiles('**/Cargo.lock') }}
@@ -133,14 +133,14 @@ jobs:
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
 
       - name: Cache cargo target dir
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@v4
         with:
           path: contracts/target
           key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: cache docker build image
         id: cache-image
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@v4
         with:
           fail-on-cache-miss: true
           path: contracts/docker-build.tar


### PR DESCRIPTION
### Description
Need to bump github actions/cache to latest due to this deprecation notice https://github.com/actions/cache/discussions/1510
Closed because of duplicate: https://github.com/smartcontractkit/chainlink-solana/pull/1064
<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
