### PR TITLE
Address sharing

### DIFF
--- a/integration-tests/relayinterface/chain_components_test.go
+++ b/integration-tests/relayinterface/chain_components_test.go
@@ -240,6 +240,31 @@ func RunContractReaderInLoopTests[T WrappedTestingT[T]](t T, it ChainComponentsI
 			},
 		},
 		{
+			Name: ContractReaderGetLatestValueUsingMultiReader,
+			Test: func(t T) {
+				cr := it.GetContractReader(t)
+				bindings := it.GetBindings(t)
+				ctx := tests.Context(t)
+
+				bound := BindingsByName(bindings, AnyContractName)[0]
+
+				require.NoError(t, cr.Bind(ctx, bindings))
+
+				type MultiReadResult struct {
+					A uint8
+					B int16
+					U string
+					V bool
+				}
+
+				mRR := MultiReadResult{}
+				require.NoError(t, cr.GetLatestValue(ctx, bound.ReadIdentifier(MultiRead), primitives.Unconfirmed, nil, &mRR))
+
+				expectedMRR := MultiReadResult{A: 1, B: 2, U: "Hello", V: true}
+				require.Equal(t, expectedMRR, mRR)
+			},
+		},
+		{
 			Name: ContractReaderGetLatestValueUsingMultiReaderWithParmsReuse,
 			Test: func(t T) {
 				cr := it.GetContractReader(t)

--- a/integration-tests/relayinterface/chain_components_test.go
+++ b/integration-tests/relayinterface/chain_components_test.go
@@ -198,9 +198,10 @@ func RunContractReaderTests[T WrappedTestingT[T]](t T, it *SolanaChainComponents
 
 // GetLatestValue method
 const (
-	ContractReaderGetLatestValueUsingMultiReader               = "Get latest value using multi reader"
-	ContractReaderGetLatestValueUsingMultiReaderWithParmsReuse = "Get latest value using multi reader with params reuse"
-	ContractReaderGetLatestValueGetTokenPrices                 = "Get latest value handles get token prices edge case"
+	ContractReaderGetLatestValueUsingMultiReader                 = "Get latest value using multi reader"
+	ContractReaderGetLatestValueWithAddressHardcodedIntoResponse = "Get latest value with AddressHardcoded into response"
+	ContractReaderGetLatestValueUsingMultiReaderWithParmsReuse   = "Get latest value using multi reader with params reuse"
+	ContractReaderGetLatestValueGetTokenPrices                   = "Get latest value handles get token prices edge case"
 )
 
 type TimestampedUnixBig struct {
@@ -212,27 +213,29 @@ func RunContractReaderInLoopTests[T WrappedTestingT[T]](t T, it ChainComponentsI
 	//RunContractReaderInterfaceTests(t, it, false, true)
 	testCases := []Testcase[T]{
 		{
-			Name: ContractReaderGetLatestValueUsingMultiReader,
+			Name: ContractReaderGetLatestValueWithAddressHardcodedIntoResponse,
 			Test: func(t T) {
 				cr := it.GetContractReader(t)
 				bindings := it.GetBindings(t)
 				ctx := tests.Context(t)
 
 				bound := BindingsByName(bindings, AnyContractName)[0]
-
 				require.NoError(t, cr.Bind(ctx, bindings))
 
+				boundAddress, err := solana.PublicKeyFromBase58(bound.Address)
+				require.NoError(t, err)
+
 				type MultiReadResult struct {
-					A uint8
-					B int16
-					U string
-					V bool
+					A              uint8
+					B              int16
+					SharedAddress  []byte
+					AddressToShare []byte
 				}
 
 				mRR := MultiReadResult{}
-				require.NoError(t, cr.GetLatestValue(ctx, bound.ReadIdentifier(MultiRead), primitives.Unconfirmed, nil, &mRR))
+				require.NoError(t, cr.GetLatestValue(ctx, bound.ReadIdentifier(ReadWithAddressHardCodedIntoResponse), primitives.Unconfirmed, nil, &mRR))
 
-				expectedMRR := MultiReadResult{A: 1, B: 2, U: "Hello", V: true}
+				expectedMRR := MultiReadResult{A: 1, B: 2, SharedAddress: boundAddress.Bytes(), AddressToShare: boundAddress.Bytes()}
 				require.Equal(t, expectedMRR, mRR)
 			},
 		},
@@ -603,9 +606,10 @@ func (h *helper) runInitialize(
 }
 
 const (
-	MultiRead                = "MultiRead"
-	MultiReadWithParamsReuse = "MultiReadWithParamsReuse"
-	GetTokenPrices           = "GetTokenPrices"
+	MultiRead                            = "MultiRead"
+	ReadWithAddressHardCodedIntoResponse = "ReadWithAddressHardCodedIntoResponse"
+	MultiReadWithParamsReuse             = "MultiReadWithParamsReuse"
+	GetTokenPrices                       = "GetTokenPrices"
 )
 
 func (it *SolanaChainComponentsInterfaceTester[T]) buildContractReaderConfig(t T) config.ContractReader {
@@ -631,11 +635,43 @@ func (it *SolanaChainComponentsInterfaceTester[T]) buildContractReaderConfig(t T
 			MethodReturningUint64: uint64ReadDef,
 		},
 	}
+
+	readWithAddressHardCodedIntoResponseDef := config.ReadDefinition{
+		ChainSpecificName: "MultiRead1",
+		ReadType:          config.Account,
+		PDADefinition: codec.PDATypeDef{
+			Prefix: []byte("multi_read1"),
+		},
+		ResponseAddressHardCoder: &commoncodec.HardCodeModifierConfig{
+			// placeholder values, whatever is put as value gets replaced with a solana pub key anyway
+			OffChainValues: map[string]any{
+				"SharedAddress":  solana.PublicKey{},
+				"AddressToShare": solana.PublicKey{},
+			},
+		},
+		OutputModifications: commoncodec.ModifiersConfig{
+			&commoncodec.HardCodeModifierConfig{
+				OffChainValues: map[string]any{"U": "", "V": false},
+			},
+		},
+	}
+
+	multiReadDef := readWithAddressHardCodedIntoResponseDef
+	multiReadDef.ResponseAddressHardCoder = nil
+	multiReadDef.MultiReader = &config.MultiReader{
+		Reads: []config.ReadDefinition{{
+			ChainSpecificName: "MultiRead2",
+			PDADefinition:     codec.PDATypeDef{Prefix: []byte("multi_read2")},
+			ReadType:          config.Account,
+		}},
+	}
+
 	return config.ContractReader{
 		Namespaces: map[string]config.ChainContractReader{
 			AnyContractName: {
 				IDL: mustUnmarshalIDL(t, string(it.Helper.GetPrimaryIDL(t))),
 				Reads: map[string]config.ReadDefinition{
+					ReadWithAddressHardCodedIntoResponse: readWithAddressHardCodedIntoResponseDef,
 					GetTokenPrices: {
 						ChainSpecificName: "BillingTokenConfigWrapper",
 						PDADefinition: codec.PDATypeDef{
@@ -664,25 +700,7 @@ func (it *SolanaChainComponentsInterfaceTester[T]) buildContractReaderConfig(t T
 						},
 						ReadType: config.Account,
 					},
-					MultiRead: {
-						ChainSpecificName: "MultiRead1",
-						PDADefinition: codec.PDATypeDef{
-							Prefix: []byte("multi_read1"),
-						},
-						OutputModifications: commoncodec.ModifiersConfig{
-							&commoncodec.HardCodeModifierConfig{
-								OffChainValues: map[string]any{"U": "", "V": false},
-							},
-						},
-						MultiReader: &config.MultiReader{Reads: []config.ReadDefinition{
-							{
-								ChainSpecificName: "MultiRead2",
-								PDADefinition:     codec.PDATypeDef{Prefix: []byte("multi_read2")},
-								ReadType:          config.Account,
-							},
-						}},
-						ReadType: config.Account,
-					},
+					MultiRead: multiReadDef,
 					MultiReadWithParamsReuse: {
 						ChainSpecificName: "MultiRead3",
 						PDADefinition: codec.PDATypeDef{

--- a/pkg/solana/chainreader/account_read_binding.go
+++ b/pkg/solana/chainreader/account_read_binding.go
@@ -11,38 +11,46 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
+
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
 )
 
 // accountReadBinding provides decoding and reading Solana Account data using a defined codec.
 type accountReadBinding struct {
-	namespace, genericName string
-	codec                  types.RemoteCodec
-	key                    solana.PublicKey
-	isPda                  bool   // flag to signify whether or not the account read is for a PDA
-	prefix                 []byte // only used for PDA public key calculation
+	namespace, genericName   string
+	codec                    types.RemoteCodec
+	key                      solana.PublicKey
+	isPda                    bool   // flag to signify whether or not the account read is for a PDA
+	prefix                   []byte // only used for PDA public key calculation
+	responseAddressHardCoder *commoncodec.HardCodeModifierConfig
+	readDefinition           config.ReadDefinition
+	idl                      codec.IDL
+	inputIDLType             interface{}
+	outputIDLTypeDef         codec.IdlTypeDef
 }
 
-func newAccountReadBinding(namespace, genericName string, prefix []byte, isPda bool) *accountReadBinding {
-	return &accountReadBinding{
-		namespace:   namespace,
-		genericName: genericName,
-		prefix:      prefix,
-		isPda:       isPda,
+func newAccountReadBinding(namespace, genericName string, isPda bool, idl codec.IDL, inputIDLType interface{}, outputIDLTypeDef codec.IdlTypeDef, readDefinition config.ReadDefinition) *accountReadBinding {
+	rb := &accountReadBinding{
+		namespace:                namespace,
+		genericName:              genericName,
+		prefix:                   readDefinition.PDADefinition.Prefix,
+		isPda:                    isPda,
+		readDefinition:           readDefinition,
+		idl:                      idl,
+		inputIDLType:             inputIDLType,
+		outputIDLTypeDef:         outputIDLTypeDef,
+		responseAddressHardCoder: nil,
 	}
+
+	if readDefinition.ResponseAddressHardCoder != nil {
+		rb.responseAddressHardCoder = readDefinition.ResponseAddressHardCoder
+	}
+
+	return rb
 }
 
 var _ readBinding = &accountReadBinding{}
-
-func (b *accountReadBinding) SetCodec(codec types.RemoteCodec) {
-	b.codec = codec
-}
-
-func (b *accountReadBinding) SetModifier(commoncodec.Modifier) {}
-
-func (b *accountReadBinding) SetAddress(key solana.PublicKey) {
-	b.key = key
-}
 
 func (b *accountReadBinding) GetAddress(ctx context.Context, params any) (solana.PublicKey, error) {
 	// Return the bound key if normal account read
@@ -61,12 +69,42 @@ func (b *accountReadBinding) GetAddress(ctx context.Context, params any) (solana
 	return key, nil
 }
 
+func (b *accountReadBinding) GetGenericName() string {
+	return b.genericName
+}
+
+func (b *accountReadBinding) GetReadDefinition() config.ReadDefinition {
+	return b.readDefinition
+}
+
+func (b *accountReadBinding) GetIDLInfo() (idl codec.IDL, inputIDLTypeDef interface{}, outputIDLTypeDef codec.IdlTypeDef) {
+	return b.idl, b.inputIDLType, b.outputIDLTypeDef
+}
+
+func (b *accountReadBinding) GetAddressResponseHardCoder() *commoncodec.HardCodeModifierConfig {
+	return b.responseAddressHardCoder
+}
+
+func (b *accountReadBinding) SetAddress(key solana.PublicKey) {
+	b.key = key
+}
+
+func (b *accountReadBinding) SetCodec(codec types.RemoteCodec) {
+	b.codec = codec
+}
+
+func (b *accountReadBinding) SetModifier(commoncodec.Modifier) {}
+
 func (b *accountReadBinding) CreateType(forEncoding bool) (any, error) {
 	return b.codec.CreateType(codec.WrapItemType(forEncoding, b.namespace, b.genericName), forEncoding)
 }
 
 func (b *accountReadBinding) Decode(ctx context.Context, bts []byte, outVal any) error {
 	return b.codec.Decode(ctx, bts, outVal, codec.WrapItemType(false, b.namespace, b.genericName))
+}
+
+func (b *accountReadBinding) QueryKey(_ context.Context, _ query.KeyFilter, _ query.LimitAndSort, _ any) ([]types.Sequence, error) {
+	return nil, errors.New("unimplemented")
 }
 
 // buildSeedsSlice encodes and builds the seedslist to calculate the PDA public key
@@ -103,8 +141,4 @@ func (b *accountReadBinding) buildSeedsSlice(ctx context.Context, params any) ([
 		seedByteArray = append(seedByteArray, flattenedSeeds[startIdx:endIdx])
 	}
 	return seedByteArray, nil
-}
-
-func (b *accountReadBinding) QueryKey(_ context.Context, _ query.KeyFilter, _ query.LimitAndSort, _ any) ([]types.Sequence, error) {
-	return nil, errors.New("unimplemented")
 }

--- a/pkg/solana/chainreader/bindings.go
+++ b/pkg/solana/chainreader/bindings.go
@@ -10,11 +10,18 @@ import (
 	commoncodec "github.com/smartcontractkit/chainlink-common/pkg/codec"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
+
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 )
 
 type readBinding interface {
-	SetAddress(solana.PublicKey)
 	GetAddress(context.Context, any) (solana.PublicKey, error)
+	GetGenericName() string
+	GetReadDefinition() config.ReadDefinition
+	GetIDLInfo() (idl codec.IDL, inputIDLTypeDef interface{}, outputIDLTypeDef codec.IdlTypeDef)
+	GetAddressResponseHardCoder() *commoncodec.HardCodeModifierConfig
+	SetAddress(solana.PublicKey)
 	SetCodec(types.RemoteCodec)
 	SetModifier(commoncodec.Modifier)
 	CreateType(bool) (any, error)
@@ -47,9 +54,9 @@ func (b *bindingsRegistry) AddReadBinding(namespace, readName string, rBinding r
 }
 
 func (b *bindingsRegistry) GetReadBinding(namespace, readName string) (readBinding, error) {
-	rBindings, nameSpaceExists := b.namespaceBindings[namespace]
-	if !nameSpaceExists {
-		return nil, fmt.Errorf("%w: no read binding exists for namespace: %q", types.ErrInvalidConfig, namespace)
+	rBindings, err := b.GetReadBindings(namespace)
+	if err != nil {
+		return nil, err
 	}
 
 	rBinding, rBindingExists := rBindings[readName]
@@ -58,6 +65,14 @@ func (b *bindingsRegistry) GetReadBinding(namespace, readName string) (readBindi
 	}
 
 	return rBinding, nil
+}
+
+func (b *bindingsRegistry) GetReadBindings(namespace string) (readNameBindings, error) {
+	rBindings, nameSpaceExists := b.namespaceBindings[namespace]
+	if !nameSpaceExists {
+		return nil, fmt.Errorf("%w: no read binding exists for namespace: %q", types.ErrInvalidConfig, namespace)
+	}
+	return rBindings, nil
 }
 
 func (b *bindingsRegistry) CreateType(namespace, readName string, forEncoding bool) (any, error) {
@@ -112,7 +127,7 @@ func (b *bindingsRegistry) SetModifiers(modifier commoncodec.Modifier) {
 }
 
 func (b *bindingsRegistry) handleAddressSharing(boundContract *types.BoundContract) error {
-	shareGroup, isInAGroup := b.getShareGroup(*boundContract)
+	shareGroup, isInAGroup := b.getShareGroup(boundContract.Name)
 	if !isInAGroup {
 		return nil
 	}
@@ -135,8 +150,8 @@ func (b *bindingsRegistry) handleAddressSharing(boundContract *types.BoundContra
 	return nil
 }
 
-func (b *bindingsRegistry) getShareGroup(boundContract types.BoundContract) (*addressShareGroup, bool) {
-	shareGroup, sharesAddress := b.addressShareGroups[boundContract.Name]
+func (b *bindingsRegistry) getShareGroup(nameSpace string) (*addressShareGroup, bool) {
+	shareGroup, sharesAddress := b.addressShareGroups[nameSpace]
 	if !sharesAddress {
 		return nil, false
 	}

--- a/pkg/solana/chainreader/bindings_test.go
+++ b/pkg/solana/chainreader/bindings_test.go
@@ -12,6 +12,9 @@ import (
 	commoncodec "github.com/smartcontractkit/chainlink-common/pkg/codec"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
+
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 )
 
 func TestBindings_CreateType(t *testing.T) {
@@ -48,13 +51,29 @@ type mockBinding struct {
 	mock.Mock
 }
 
-func (_m *mockBinding) SetCodec(_ types.RemoteCodec) {}
-
-func (_m *mockBinding) SetAddress(_ solana.PublicKey) {}
-
 func (_m *mockBinding) GetAddress(_ context.Context, _ any) (solana.PublicKey, error) {
 	return solana.PublicKey{}, nil
 }
+
+func (_m *mockBinding) GetGenericName() string {
+	return ""
+}
+
+func (_m *mockBinding) GetReadDefinition() config.ReadDefinition {
+	return config.ReadDefinition{}
+}
+
+func (_m *mockBinding) GetIDLInfo() (idl codec.IDL, inputIDLTypeDef interface{}, outputIDLTypeDef codec.IdlTypeDef) {
+	return codec.IDL{}, codec.IdlTypeDef{}, codec.IdlTypeDef{}
+}
+
+func (_m *mockBinding) GetAddressResponseHardCoder() *commoncodec.HardCodeModifierConfig {
+	return &commoncodec.HardCodeModifierConfig{}
+}
+
+func (_m *mockBinding) SetAddress(_ solana.PublicKey) {}
+
+func (_m *mockBinding) SetCodec(_ types.RemoteCodec) {}
 
 func (_m *mockBinding) SetModifier(a commoncodec.Modifier) {
 	_m.Called(a)

--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -298,11 +298,20 @@ func (s *ContractReaderService) Bind(_ context.Context, bindings []types.BoundCo
 
 		s.lookup.bindAddressForContract(bindings[i].Name, bindings[i].Address)
 		// also bind with an empty address so that we can look up the contract without providing address when calling CR methods
-		if _, isInAShareGroup := s.bdRegistry.getShareGroup(bindings[i]); isInAShareGroup {
+		if sg, isInAShareGroup := s.bdRegistry.getShareGroup(bindings[i].Name); isInAShareGroup {
 			s.lookup.bindAddressForContract(bindings[i].Name, "")
+			for _, namespace := range sg.group {
+				if err := s.addAddressResponseHardCoderModifier(namespace, bindings[i].Address); err != nil {
+					return fmt.Errorf("failed to add address response hard coder modifier for contract: %q, : %w", namespace, err)
+				}
+			}
+			return nil
+		}
+
+		if err := s.addAddressResponseHardCoderModifier(bindings[i].Name, bindings[i].Address); err != nil {
+			return fmt.Errorf("failed to add address response hard coder modifier for contract: %q, : %w", bindings[i].Name, err)
 		}
 	}
-
 	return nil
 }
 
@@ -331,7 +340,7 @@ func (s *ContractReaderService) CreateContractType(readIdentifier string, forEnc
 	return s.bdRegistry.CreateType(values.contract, values.reads[0].readName, forEncoding)
 }
 
-func (s *ContractReaderService) addCodecDef(forEncoding bool, namespace, genericName string, idl codec.IDL, idlDefinition interface{}, modCfg commoncodec.ModifiersConfig) error {
+func (s *ContractReaderService) addCodecDef(parsed *codec.ParsedTypes, forEncoding bool, namespace, genericName string, idl codec.IDL, idlDefinition interface{}, modCfg commoncodec.ModifiersConfig) error {
 	mod, err := modCfg.ToModifier(codec.DecoderHooks...)
 	if err != nil {
 		return err
@@ -343,9 +352,9 @@ func (s *ContractReaderService) addCodecDef(forEncoding bool, namespace, generic
 	}
 
 	if forEncoding {
-		s.parsed.EncoderDefs[codec.WrapItemType(true, namespace, genericName)] = cEntry
+		parsed.EncoderDefs[codec.WrapItemType(true, namespace, genericName)] = cEntry
 	} else {
-		s.parsed.DecoderDefs[codec.WrapItemType(false, namespace, genericName)] = cEntry
+		parsed.DecoderDefs[codec.WrapItemType(false, namespace, genericName)] = cEntry
 	}
 	return nil
 }
@@ -398,7 +407,7 @@ func (s *ContractReaderService) initNamespace(namespaces map[string]config.Chain
 	return nil
 }
 
-func (s *ContractReaderService) addAccountRead(namespace string, genericName string, idl codec.IDL, idlType codec.IdlTypeDef, readDefinition config.ReadDefinition) error {
+func (s *ContractReaderService) addAccountRead(namespace string, genericName string, idl codec.IDL, outputIDLDef codec.IdlTypeDef, readDefinition config.ReadDefinition) error {
 	reads := []read{{readName: genericName, useParams: true}}
 	if readDefinition.MultiReader != nil {
 		multiRead, err := s.addMultiAccountReadToCodec(namespace, readDefinition, idl)
@@ -408,38 +417,30 @@ func (s *ContractReaderService) addAccountRead(namespace string, genericName str
 		reads = append(reads, multiRead...)
 	}
 
-	if err := s.addAccountReadToCodec(namespace, genericName, idl, idlType, readDefinition); err != nil {
+	var inputIDLDef interface{} = codec.NilIdlTypeDefTy
+	isPDA := false
+
+	// Create PDA read binding if PDA prefix or seeds configs are populated
+	if readDefinition.PDADefinition.Prefix != nil || len(readDefinition.PDADefinition.Seeds) > 0 {
+		inputIDLDef = readDefinition.PDADefinition
+		isPDA = true
+	}
+
+	if err := s.addAccountReadToCodec(s.parsed, namespace, genericName, idl, inputIDLDef, outputIDLDef, readDefinition); err != nil {
 		return err
 	}
 
+	s.bdRegistry.AddReadBinding(namespace, genericName, newAccountReadBinding(namespace, genericName, isPDA, idl, inputIDLDef, outputIDLDef, readDefinition))
 	s.lookup.addReadNameForContract(namespace, genericName, reads)
 	return nil
 }
 
-func (s *ContractReaderService) addAccountReadToCodec(namespace string, genericName string, idl codec.IDL, idlType codec.IdlTypeDef, readDefinition config.ReadDefinition) error {
-	var (
-		reader             readBinding
-		inputAccountIDLDef interface{}
-	)
-
-	if err := s.addCodecDef(false, namespace, genericName, idl, idlType, readDefinition.OutputModifications); err != nil {
+func (s *ContractReaderService) addAccountReadToCodec(parsed *codec.ParsedTypes, namespace string, genericName string, idl codec.IDL, inputIDLDef interface{}, outputIDLDef codec.IdlTypeDef, readDefinition config.ReadDefinition) error {
+	if err := s.addCodecDef(parsed, true, namespace, genericName, idl, inputIDLDef, readDefinition.InputModifications); err != nil {
 		return err
 	}
 
-	// Create PDA read binding if PDA prefix or seeds configs are populated
-	if readDefinition.PDADefinition.Prefix != nil || len(readDefinition.PDADefinition.Seeds) > 0 {
-		inputAccountIDLDef = readDefinition.PDADefinition
-		reader = newAccountReadBinding(namespace, genericName, readDefinition.PDADefinition.Prefix, true)
-	} else {
-		inputAccountIDLDef = codec.NilIdlTypeDefTy
-		reader = newAccountReadBinding(namespace, genericName, nil, false)
-	}
-	if err := s.addCodecDef(true, namespace, genericName, idl, inputAccountIDLDef, readDefinition.InputModifications); err != nil {
-		return err
-	}
-
-	s.bdRegistry.AddReadBinding(namespace, genericName, reader)
-	return nil
+	return s.addCodecDef(parsed, false, namespace, genericName, idl, outputIDLDef, readDefinition.OutputModifications)
 }
 
 func (s *ContractReaderService) addMultiAccountReadToCodec(namespace string, readDefinition config.ReadDefinition, idl codec.IDL) ([]read, error) {
@@ -459,19 +460,74 @@ func (s *ContractReaderService) addMultiAccountReadToCodec(namespace string, rea
 			return nil, fmt.Errorf("unexpected type %T from IDL definition for account read with chainSpecificName: %q, of type: %q", accountIDLDef, mr.ChainSpecificName, mr.ReadType)
 		}
 
+		var inputIDLDef interface{} = codec.NilIdlTypeDefTy
+		isPDA := false
+
+		// Create PDA read binding if PDA prefix or seeds configs are populated
+		if readDefinition.PDADefinition.Prefix != nil || len(readDefinition.PDADefinition.Seeds) > 0 {
+			inputIDLDef = readDefinition.PDADefinition
+			isPDA = true
+		}
+
 		// multi read defs don't have a generic name as they are accessed from the parent read which does have a generic name.
 		// generic name is used everywhere, so add a prefix to avoid potential collision with generic names of other reads.
 		genericName := "multiread-" + mr.ChainSpecificName
-		if err = s.addAccountReadToCodec(namespace, genericName, idl, accountIDLDef, mr); err != nil {
+		if err = s.addAccountReadToCodec(s.parsed, namespace, genericName, idl, inputIDLDef, accountIDLDef, mr); err != nil {
 			return nil, fmt.Errorf("failed to add read to multi read %q: %w", mr.ChainSpecificName, err)
 		}
 
+		s.bdRegistry.AddReadBinding(namespace, genericName, newAccountReadBinding(namespace, genericName, isPDA, idl, inputIDLDef, accountIDLDef, readDefinition))
 		reads = append(reads, read{
 			readName:  genericName,
 			useParams: readDefinition.MultiReader.ReuseParams,
 		})
 	}
 	return reads, nil
+}
+
+func (s *ContractReaderService) addAddressResponseHardCoderModifier(namespace string, addressToHardCode string) error {
+	address, err := solana.PublicKeyFromBase58(addressToHardCode)
+	if err != nil {
+		return fmt.Errorf("failed to parse address: %q", addressToHardCode)
+	}
+
+	rBindings, err := s.bdRegistry.GetReadBindings(namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get read bindings : %w", err)
+	}
+
+	for _, rb := range rBindings {
+		if addressResponseHardCoder := rb.GetAddressResponseHardCoder(); addressResponseHardCoder != nil {
+			hardCoder := rb.GetAddressResponseHardCoder()
+			if hardCoder == nil {
+				continue
+			}
+
+			for k := range hardCoder.OffChainValues {
+				hardCoder.OffChainValues[k] = address
+			}
+
+			idl, inputIDlType, outputIDLType := rb.GetIDLInfo()
+			parsed := &codec.ParsedTypes{
+				EncoderDefs: map[string]codec.Entry{},
+				DecoderDefs: map[string]codec.Entry{},
+			}
+
+			readDef := rb.GetReadDefinition()
+			readDef.OutputModifications = append(readDef.OutputModifications, hardCoder)
+			if err = s.addAccountReadToCodec(parsed, namespace, rb.GetGenericName(), idl, inputIDlType, outputIDLType, readDef); err != nil {
+				return fmt.Errorf("failed to set codec with address response hardcoder for read: %q: %w", rb.GetGenericName(), err)
+			}
+
+			newCodec, err := parsed.ToCodec()
+			if err != nil {
+				return fmt.Errorf("failed to create codec with address response hardcoder for read: %q: %w", rb.GetGenericName(), err)
+			}
+
+			rb.SetCodec(newCodec)
+		}
+	}
+	return nil
 }
 
 func (s *ContractReaderService) addEventRead(
@@ -499,6 +555,7 @@ func (s *ContractReaderService) addEventRead(
 		mappedTuples,
 		events,
 		filter.EventSig,
+		readDefinition,
 	))
 
 	return nil

--- a/pkg/solana/chainreader/event_read_binding.go
+++ b/pkg/solana/chainreader/event_read_binding.go
@@ -13,6 +13,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
+
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller"
 )
@@ -26,6 +28,7 @@ type eventReadBinding struct {
 	indexedSubKeys         map[string]uint64
 	reader                 EventsReader
 	eventSig               [logpoller.EventSignatureLength]byte
+	readDefinition         config.ReadDefinition
 }
 
 func newEventReadBinding(
@@ -33,6 +36,7 @@ func newEventReadBinding(
 	indexedSubKeys map[string]uint64,
 	reader EventsReader,
 	eventSig [logpoller.EventSignatureLength]byte,
+	readDefinition config.ReadDefinition,
 ) *eventReadBinding {
 	binding := &eventReadBinding{
 		namespace:      namespace,
@@ -40,6 +44,7 @@ func newEventReadBinding(
 		indexedSubKeys: indexedSubKeys,
 		reader:         reader,
 		eventSig:       eventSig,
+		readDefinition: readDefinition,
 	}
 
 	binding.remapper = remapHelper{binding.remapPrimitive}
@@ -47,12 +52,28 @@ func newEventReadBinding(
 	return binding
 }
 
-func (b *eventReadBinding) SetAddress(key solana.PublicKey) {
-	b.key = key
-}
-
 func (b *eventReadBinding) GetAddress(_ context.Context, _ any) (solana.PublicKey, error) {
 	return b.key, nil
+}
+
+func (b *eventReadBinding) GetGenericName() string {
+	return b.genericName
+}
+
+func (b *eventReadBinding) GetReadDefinition() config.ReadDefinition {
+	return b.readDefinition
+}
+
+func (b *eventReadBinding) GetIDLInfo() (idl codec.IDL, inputIDLTypeDef interface{}, outputIDLTypeDef codec.IdlTypeDef) {
+	return codec.IDL{}, codec.IdlTypeDef{}, codec.IdlTypeDef{}
+}
+
+func (b *eventReadBinding) GetAddressResponseHardCoder() *commoncodec.HardCodeModifierConfig {
+	return nil
+}
+
+func (b *eventReadBinding) SetAddress(key solana.PublicKey) {
+	b.key = key
 }
 
 func (b *eventReadBinding) SetCodec(codec types.RemoteCodec) {

--- a/pkg/solana/config/chain_reader.go
+++ b/pkg/solana/config/chain_reader.go
@@ -45,11 +45,13 @@ type ReadDefinition struct {
 	InputModifications  commoncodec.ModifiersConfig `json:"inputModifications,omitempty"`
 	OutputModifications commoncodec.ModifiersConfig `json:"outputModifications,omitempty"`
 	PDADefinition       codec.PDATypeDef            `json:"pdaDefinition,omitempty"` // Only used for PDA account reads
-	MultiReader         *MultiReader
-	IndexedField0       *IndexedField `json:"indexedField0"`
-	IndexedField1       *IndexedField `json:"indexedField1"`
-	IndexedField2       *IndexedField `json:"indexedField2"`
-	IndexedField3       *IndexedField `json:"indexedField3"`
+	MultiReader         *MultiReader                `json:"multiReader,omitempty"`
+	IndexedField0       *IndexedField               `json:"indexedField0"`
+	IndexedField1       *IndexedField               `json:"indexedField1"`
+	IndexedField2       *IndexedField               `json:"indexedField2"`
+	IndexedField3       *IndexedField               `json:"indexedField3"`
+	// ResponseAddressHardCoder hardcodes the address of the contract into the defined field in the response.
+	ResponseAddressHardCoder *commoncodec.HardCodeModifierConfig `json:"responseAddressHardCoder,omitempty"`
 	// This will create a log poller filter for this event.
 	*PollingFilter `json:"pollingFilter,omitempty"`
 }


### PR DESCRIPTION
### Description
Enables CR Account Bindings to share the contract address as a return value in the response. Field names that will store this program address are given name in the cfg
