### PR TITLE
Update CODEOWNERS to add bix-framework

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,9 @@
 # global ownership
 * @smartcontractkit/bix-build
 
+# offchain code ownership
+/pkg/solana @smartcontractkit/bix-framework @smartcontractkit/bix-build
+
 # e2e test ownership
 /integration-tests @smartcontractkit/qa @smartcontractkit/bix-build
 


### PR DESCRIPTION
The framework team should be an owner of solana offchain code

### Description

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
