### PR TITLE
Updated ccip execute args transform to use mapstructure to decode args

### DIFF
--- a/pkg/solana/chainwriter/chain_writer_test.go
+++ b/pkg/solana/chainwriter/chain_writer_test.go
@@ -946,7 +946,7 @@ func TestChainWriter_CCIPOfframp(t *testing.T) {
 		encodedReport, err := json.Marshal(abstractReport)
 		require.NoError(t, err)
 
-		args := chainwriter.ReportPreTransform{
+		args := ReportPreTransform{
 			ReportContext: [2][32]byte{{0x01}, {0x02}},
 			Report:        encodedReport,
 			Info: ccipocr3.ExecuteReportInfo{

--- a/pkg/solana/chainwriter/transform_registry.go
+++ b/pkg/solana/chainwriter/transform_registry.go
@@ -6,17 +6,10 @@ import (
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/mitchellh/mapstructure"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
-
-// TODO: make this type in the chainlink-common CW package
-type ReportPreTransform struct {
-	ReportContext  [2][32]byte
-	Report         []byte
-	Info           ccipocr3.ExecuteReportInfo
-	AbstractReport ccip_offramp.ExecutionReportSingleChain
-}
 
 type ReportPostTransform struct {
 	ReportContext  [2][32]byte
@@ -40,15 +33,10 @@ func FindTransform(id string) (func(context.Context, any, solana.AccountMetaSlic
 // This Transform function looks up the token pool addresses in the accounts slice and augments the args
 // with the indexes of the token pool addresses in the accounts slice.
 func CCIPExecuteArgsTransform(ctx context.Context, args any, accounts solana.AccountMetaSlice, tableMap map[string]map[string][]*solana.AccountMeta) (any, solana.AccountMetaSlice, error) {
-	argsTyped, ok := args.(ReportPreTransform)
-	if !ok {
-		return nil, nil, fmt.Errorf("args is not of type ReportPreTransform")
-	}
-	argsTransformed := ReportPostTransform{
-		ReportContext:  argsTyped.ReportContext,
-		Report:         argsTyped.Report,
-		AbstractReport: argsTyped.AbstractReport,
-		Info:           argsTyped.Info,
+	var argsTransformed ReportPostTransform
+	err := mapstructure.Decode(args, &argsTransformed)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	registryTables, exists := tableMap["PoolLookupTable"]

--- a/pkg/solana/chainwriter/transform_registry_test.go
+++ b/pkg/solana/chainwriter/transform_registry_test.go
@@ -4,12 +4,20 @@ import (
 	"testing"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/chainwriter"
 )
+
+type ReportPreTransform struct {
+	ReportContext  [2][32]byte
+	Report         []byte
+	Info           ccipocr3.ExecuteReportInfo
+	AbstractReport ccip_offramp.ExecutionReportSingleChain
+}
 
 func Test_CCIPExecuteArgsTransform(t *testing.T) {
 	ctx := tests.Context(t)
@@ -18,7 +26,7 @@ func Test_CCIPExecuteArgsTransform(t *testing.T) {
 	poolKeys := []solana.PublicKey{destTokenAddr}
 	poolKeys = append(poolKeys, chainwriter.CreateTestPubKeys(t, 1)...)
 
-	args := chainwriter.ReportPreTransform{
+	args := ReportPreTransform{
 		Info: ccipocr3.ExecuteReportInfo{
 			AbstractReports: []ccipocr3.ExecutePluginReportSingleChain{{
 				Messages: []ccipocr3.Message{{
@@ -62,6 +70,21 @@ func Test_CCIPExecuteArgsTransform(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, typedArgs.TokenIndexes)
 		require.Len(t, typedArgs.TokenIndexes, 0)
+	})
+
+	t.Run("CCIPExecute ArgsTransform does not get args that conform to ReportPreTransform", func(t *testing.T) {
+		args := struct {
+			ReportContext [2][32]uint8
+			Report        []uint8
+		}{
+			ReportContext: [2][32]uint8{},
+			Report:        []uint8{},
+		}
+		transformedArgs, newAccounts, err := chainwriter.CCIPExecuteArgsTransform(ctx, args, accounts, nil)
+		require.NoError(t, err)
+		_, ok := transformedArgs.(chainwriter.ReportPostTransform)
+		require.True(t, ok)
+		require.Len(t, newAccounts, 2)
 	})
 }
 


### PR DESCRIPTION
Updated CCIPExecute args transform to use mapstructure to decode args since it does not always conform to `ReportPreTransform`.

**Example**
We can get args like this: ```struct { ReportContext [2][32]uint8; Report []uint8; Info ccipocr3.ExecuteReportInfo }```
which would result in an error like: ```args is not of type ReportPreTransform```