### PR TITLE
Track transaction status in TXM prior to broadcast

### DIFF
--- a/pkg/solana/chainwriter/ata_creation.go
+++ b/pkg/solana/chainwriter/ata_creation.go
@@ -149,9 +149,7 @@ func (s *SolanaChainWriterService) waitForTxFinality(ctx context.Context, transa
 			return fmt.Errorf("context ended while waiting for finality of transaction %s", transactionID)
 		case <-ticker.C:
 			status, err := s.txm.GetTransactionStatus(waitCtx, transactionID)
-			// Allow poll to continue if status not found for transaction since transactions are not immediately broadcasted
-			// Status check could have started before there is a status to report
-			if err != nil && !strings.Contains(err.Error(), "failed to find transaction") {
+			if err != nil {
 				return fmt.Errorf("error fetching transaction status: %w", err)
 			}
 			switch status {

--- a/pkg/solana/txm/pendingtx.go
+++ b/pkg/solana/txm/pendingtx.go
@@ -22,13 +22,13 @@ var (
 )
 
 type PendingTxContext interface {
-	// New adds a new transaction in Pending state to the storage
+	// New adds a new transaction in AwaitingBroadcast state to the storage
 	New(msg pendingTx) error
 	// AddSignature adds a new signature to a broadcasted transaction in the pending transaction context.
 	// It associates the provided context and cancel function with the signature to manage retry and bumping cycles.
 	AddSignature(cancel context.CancelFunc, id string, sig solana.Signature) error
-	// RevertToPending reverts the transaction's status to Pending. It also removes context and related signatures from storage associated to given tx id if not in finalized or errored state
-	RevertToPending(id string) error
+	// RevertToAwaitingBroadcast reverts the transaction's status to AwaitingBroadcast. It also removes context and related signatures from storage associated to given tx id if not in finalized or errored state
+	RevertToAwaitingBroadcast(id string) error
 	// ListAllSigs returns all of the signatures being tracked for all transactions not yet finalized or errored
 	ListAllSigs() []solana.Signature
 	// ListAllExpiredBroadcastedTxs returns all the txes that are in broadcasted state and have expired for given block number compared against lastValidBlockHeight (last valid block number)
@@ -58,8 +58,8 @@ type PendingTxContext interface {
 	// 	- Processed -> Broadcasted || Not Found
 	// The function returns the transaction ID associated with the signature and a boolean indicating whether a re-org has occurred.
 	IsTxReorged(sig solana.Signature, currentState utils.TxState) (string, bool)
-	// GetReorgTx returns the pendingTx for the given ID if it exists
-	GetReorgTx(id string) (pendingTx, error)
+	// GetPendingTx returns the pendingTx for the given ID if it exists
+	GetPendingTx(id string) (pendingTx, error)
 }
 
 // finishedTx is used to store info required to track transactions to finality or error
@@ -92,7 +92,7 @@ type pendingTxContext struct {
 	cancelBy    map[string]context.CancelFunc
 	sigToTxInfo map[solana.Signature]txInfo
 
-	pendingTxs              map[string]pendingTx  // pending transactions awaiting broadcast
+	queuedTxs               map[string]pendingTx  // pending transactions awaiting broadcast
 	broadcastedProcessedTxs map[string]pendingTx  // broadcasted and processed transactions that may require retry and bumping
 	confirmedTxs            map[string]pendingTx  // transactions that require monitoring for re-org
 	finalizedErroredTxs     map[string]finishedTx // finalized and errored transactions held onto for status
@@ -105,7 +105,7 @@ func newPendingTxContext() *pendingTxContext {
 		cancelBy:    map[string]context.CancelFunc{},
 		sigToTxInfo: map[solana.Signature]txInfo{},
 
-		pendingTxs:              map[string]pendingTx{},
+		queuedTxs:               map[string]pendingTx{},
 		broadcastedProcessedTxs: map[string]pendingTx{},
 		confirmedTxs:            map[string]pendingTx{},
 		finalizedErroredTxs:     map[string]finishedTx{},
@@ -115,7 +115,7 @@ func newPendingTxContext() *pendingTxContext {
 func (c *pendingTxContext) New(tx pendingTx) error {
 	err := c.withReadLock(func() error {
 		// Check if ID already exists in any of the maps
-		if _, exists := c.pendingTxs[tx.id]; exists {
+		if _, exists := c.queuedTxs[tx.id]; exists {
 			return ErrIDAlreadyExists
 		}
 		if _, exists := c.broadcastedProcessedTxs[tx.id]; exists {
@@ -136,7 +136,7 @@ func (c *pendingTxContext) New(tx pendingTx) error {
 	// upgrade to write lock if id does not exist
 	_, err = c.withWriteLock(func() (string, error) {
 		// Check if ID already exists in any of the maps
-		if _, exists := c.pendingTxs[tx.id]; exists {
+		if _, exists := c.queuedTxs[tx.id]; exists {
 			return "", ErrIDAlreadyExists
 		}
 		if _, exists := c.broadcastedProcessedTxs[tx.id]; exists {
@@ -149,9 +149,9 @@ func (c *pendingTxContext) New(tx pendingTx) error {
 			return "", ErrIDAlreadyExists
 		}
 		tx.createTs = time.Now()
-		tx.state = utils.Pending
+		tx.state = utils.AwaitingBroadcast
 		// save to the pending map
-		c.pendingTxs[tx.id] = tx
+		c.queuedTxs[tx.id] = tx
 		return "", nil
 	})
 	return err
@@ -164,7 +164,7 @@ func (c *pendingTxContext) OnBroadcasted(tx pendingTx) error {
 			return ErrAlreadyInExpectedState
 		}
 		// Transactions should only move to pending from broadcasted
-		_, exists := c.pendingTxs[tx.id]
+		_, exists := c.queuedTxs[tx.id]
 		if !exists {
 			return ErrTransactionNotFound
 		}
@@ -177,7 +177,7 @@ func (c *pendingTxContext) OnBroadcasted(tx pendingTx) error {
 	// upgrade to write lock if id does not exist
 	_, err = c.withWriteLock(func() (string, error) {
 		// Check if pending map has tx
-		pendingMsg, exists := c.pendingTxs[tx.id]
+		pendingMsg, exists := c.queuedTxs[tx.id]
 		if !exists {
 			return tx.id, ErrTransactionNotFound
 		}
@@ -187,7 +187,7 @@ func (c *pendingTxContext) OnBroadcasted(tx pendingTx) error {
 		// save transaction to broadcasted map
 		c.broadcastedProcessedTxs[tx.id] = tx
 		// remove tx from pending map
-		delete(c.pendingTxs, tx.id)
+		delete(c.queuedTxs, tx.id)
 		return "", nil
 	})
 	return err
@@ -237,10 +237,10 @@ func (c *pendingTxContext) AddSignature(cancel context.CancelFunc, id string, si
 
 // returns the id if removed (otherwise returns empty string)
 // removes transactions from any state except finalized and errored
-func (c *pendingTxContext) RevertToPending(id string) error {
+func (c *pendingTxContext) RevertToAwaitingBroadcast(id string) error {
 	err := c.withReadLock(func() error {
 		// check if transaction already in the expected state
-		if tx, pendingExists := c.pendingTxs[id]; pendingExists && tx.state == utils.Pending {
+		if tx, pendingExists := c.queuedTxs[id]; pendingExists && tx.state == utils.AwaitingBroadcast {
 			return ErrAlreadyInExpectedState
 		}
 		// transaction should only revert to pending from broadcasted, processed, or confirmed state
@@ -278,8 +278,8 @@ func (c *pendingTxContext) RevertToPending(id string) error {
 		for _, s := range tx.signatures {
 			delete(c.sigToTxInfo, s)
 		}
-		tx.state = utils.Pending
-		c.pendingTxs[id] = tx
+		tx.state = utils.AwaitingBroadcast
+		c.queuedTxs[id] = tx
 		return id, nil
 	})
 	return err
@@ -507,7 +507,7 @@ func (c *pendingTxContext) OnPrebroadcastError(id string, retentionTimeout time.
 		if broadcastedExists || confirmedExists {
 			return "", ErrIDAlreadyExists
 		}
-		delete(c.pendingTxs, id)
+		delete(c.queuedTxs, id)
 		// If retention timeout set to 0, skip adding it to the errored map
 		if retentionTimeout == 0 {
 			return "", nil
@@ -591,7 +591,7 @@ func (c *pendingTxContext) OnError(sig solana.Signature, retentionTimeout time.D
 func (c *pendingTxContext) GetTxState(id string) (utils.TxState, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	if tx, exists := c.pendingTxs[id]; exists {
+	if tx, exists := c.queuedTxs[id]; exists {
 		return tx.state, nil
 	}
 	if tx, exists := c.broadcastedProcessedTxs[id]; exists {
@@ -662,7 +662,7 @@ func (c *pendingTxContext) IsTxReorged(sig solana.Signature, sigOnChainState uti
 	return txInfo.id, hasReorg
 }
 
-func (c *pendingTxContext) GetReorgTx(id string) (pendingTx, error) {
+func (c *pendingTxContext) GetPendingTx(id string) (pendingTx, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	var tx, tempTx pendingTx
@@ -741,8 +741,8 @@ func (c *pendingTxContextWithProm) OnConfirmed(sig solana.Signature) (string, er
 	return id, err
 }
 
-func (c *pendingTxContextWithProm) RevertToPending(id string) error {
-	return c.pendingTx.RevertToPending(id)
+func (c *pendingTxContextWithProm) RevertToAwaitingBroadcast(id string) error {
+	return c.pendingTx.RevertToAwaitingBroadcast(id)
 }
 
 func (c *pendingTxContextWithProm) ListAllSigs() []solana.Signature {
@@ -815,6 +815,6 @@ func (c *pendingTxContextWithProm) IsTxReorged(sig solana.Signature, currentSigS
 	return c.pendingTx.IsTxReorged(sig, currentSigState)
 }
 
-func (c *pendingTxContextWithProm) GetReorgTx(id string) (pendingTx, error) {
-	return c.pendingTx.GetReorgTx(id)
+func (c *pendingTxContextWithProm) GetPendingTx(id string) (pendingTx, error) {
+	return c.pendingTx.GetPendingTx(id)
 }

--- a/pkg/solana/txm/pendingtx.go
+++ b/pkg/solana/txm/pendingtx.go
@@ -3,7 +3,6 @@ package txm
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -49,7 +48,7 @@ type PendingTxContext interface {
 	// OnError marks transaction as errored, matches err type using enum, moves it from the broadcasted or confirmed map to finalized/errored map, removes signatures from signature map to stop confirmation checks
 	OnError(sig solana.Signature, retentionTimeout time.Duration, txState utils.TxState, errType TxErrType) (string, error)
 	// GetTxState returns the transaction state for the provided ID if it exists
-	GetTxState(id string) (utils.TxState, error)
+	GetTxState(id string) (utils.TxState, bool)
 	// TrimFinalizedErroredTxs removes transactions that have reached their retention time
 	TrimFinalizedErroredTxs() int
 	// IsTxReorged determines whether the given signature has experienced a re-org by comparing its in-memory state with its current on-chain state.
@@ -588,22 +587,22 @@ func (c *pendingTxContext) OnError(sig solana.Signature, retentionTimeout time.D
 	})
 }
 
-func (c *pendingTxContext) GetTxState(id string) (utils.TxState, error) {
+func (c *pendingTxContext) GetTxState(id string) (utils.TxState, bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	if tx, exists := c.queuedTxs[id]; exists {
-		return tx.state, nil
+		return tx.state, true
 	}
 	if tx, exists := c.broadcastedProcessedTxs[id]; exists {
-		return tx.state, nil
+		return tx.state, true
 	}
 	if tx, exists := c.confirmedTxs[id]; exists {
-		return tx.state, nil
+		return tx.state, true
 	}
 	if tx, exists := c.finalizedErroredTxs[id]; exists {
-		return tx.state, nil
+		return tx.state, true
 	}
-	return utils.NotFound, fmt.Errorf("failed to find transaction for id: %s", id)
+	return utils.NotFound, false
 }
 
 // TrimFinalizedErroredTxs deletes transactions from the finalized/errored map and the allTxs map after the retention period has passed
@@ -803,7 +802,7 @@ func incrementErrorMetrics(errType TxErrType, chainID string) {
 	promSolTxmErrorTxs.WithLabelValues(chainID).Inc()
 }
 
-func (c *pendingTxContextWithProm) GetTxState(id string) (utils.TxState, error) {
+func (c *pendingTxContextWithProm) GetTxState(id string) (utils.TxState, bool) {
 	return c.pendingTx.GetTxState(id)
 }
 

--- a/pkg/solana/txm/pendingtx.go
+++ b/pkg/solana/txm/pendingtx.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/txm/utils"
-	txmutils "github.com/smartcontractkit/chainlink-solana/pkg/solana/txm/utils"
 )
 
 var (
@@ -23,13 +22,13 @@ var (
 )
 
 type PendingTxContext interface {
-	// New adds a new transaction in Broadcasted state to the storage
+	// New adds a new transaction in Pending state to the storage
 	New(msg pendingTx) error
 	// AddSignature adds a new signature to a broadcasted transaction in the pending transaction context.
 	// It associates the provided context and cancel function with the signature to manage retry and bumping cycles.
 	AddSignature(cancel context.CancelFunc, id string, sig solana.Signature) error
-	// Remove removes transaction, context and related signatures from storage associated to given tx id if not in finalized or errored state
-	Remove(id string) (string, error)
+	// RevertToPending reverts the transaction's status to Pending. It also removes context and related signatures from storage associated to given tx id if not in finalized or errored state
+	RevertToPending(id string) error
 	// ListAllSigs returns all of the signatures being tracked for all transactions not yet finalized or errored
 	ListAllSigs() []solana.Signature
 	// ListAllExpiredBroadcastedTxs returns all the txes that are in broadcasted state and have expired for given block number compared against lastValidBlockHeight (last valid block number)
@@ -37,6 +36,8 @@ type PendingTxContext interface {
 	ListAllExpiredBroadcastedTxs(currBlockNumber uint64) []pendingTx
 	// Expired returns whether or not confirmation timeout amount of time has passed since creation
 	Expired(sig solana.Signature, confirmationTimeout time.Duration) bool
+	// OnBroadcasted marks transaction as Broadcasted and moves it from the pending map to the broadcast map
+	OnBroadcasted(msg pendingTx) error
 	// OnProcessed marks transactions as Processed
 	OnProcessed(sig solana.Signature) (string, error)
 	// OnConfirmed marks transaction as Confirmed and moves it from broadcast map to confirmed map
@@ -56,33 +57,33 @@ type PendingTxContext interface {
 	// 	- Confirmed -> Processed || Broadcasted || Not Found
 	// 	- Processed -> Broadcasted || Not Found
 	// The function returns the transaction ID associated with the signature and a boolean indicating whether a re-org has occurred.
-	IsTxReorged(sig solana.Signature, currentState txmutils.TxState) (string, bool)
-	// GetPendingTx returns the pendingTx for the given ID if it exists
-	GetPendingTx(id string) (pendingTx, error)
+	IsTxReorged(sig solana.Signature, currentState utils.TxState) (string, bool)
+	// GetReorgTx returns the pendingTx for the given ID if it exists
+	GetReorgTx(id string) (pendingTx, error)
 }
 
 // finishedTx is used to store info required to track transactions to finality or error
 type pendingTx struct {
 	tx                   solana.Transaction
-	cfg                  txmutils.TxConfig
+	cfg                  utils.TxConfig
 	signatures           []solana.Signature
 	id                   string
 	createTs             time.Time
-	state                txmutils.TxState
+	state                utils.TxState
 	lastValidBlockHeight uint64 // to track expiration, equivalent to last valid block number.
 }
 
 // finishedTx is used to store minimal info specifically for finalized or errored transactions for external status checks
 type finishedTx struct {
 	retentionTs time.Time
-	state       txmutils.TxState
+	state       utils.TxState
 }
 
 type txInfo struct {
 	// id of the transaction
 	id string
 	// state of the signature
-	state txmutils.TxState
+	state utils.TxState
 }
 
 var _ PendingTxContext = &pendingTxContext{}
@@ -91,6 +92,7 @@ type pendingTxContext struct {
 	cancelBy    map[string]context.CancelFunc
 	sigToTxInfo map[solana.Signature]txInfo
 
+	pendingTxs              map[string]pendingTx  // pending transactions awaiting broadcast
 	broadcastedProcessedTxs map[string]pendingTx  // broadcasted and processed transactions that may require retry and bumping
 	confirmedTxs            map[string]pendingTx  // transactions that require monitoring for re-org
 	finalizedErroredTxs     map[string]finishedTx // finalized and errored transactions held onto for status
@@ -103,6 +105,7 @@ func newPendingTxContext() *pendingTxContext {
 		cancelBy:    map[string]context.CancelFunc{},
 		sigToTxInfo: map[solana.Signature]txInfo{},
 
+		pendingTxs:              map[string]pendingTx{},
 		broadcastedProcessedTxs: map[string]pendingTx{},
 		confirmedTxs:            map[string]pendingTx{},
 		finalizedErroredTxs:     map[string]finishedTx{},
@@ -112,6 +115,9 @@ func newPendingTxContext() *pendingTxContext {
 func (c *pendingTxContext) New(tx pendingTx) error {
 	err := c.withReadLock(func() error {
 		// Check if ID already exists in any of the maps
+		if _, exists := c.pendingTxs[tx.id]; exists {
+			return ErrIDAlreadyExists
+		}
 		if _, exists := c.broadcastedProcessedTxs[tx.id]; exists {
 			return ErrIDAlreadyExists
 		}
@@ -130,6 +136,9 @@ func (c *pendingTxContext) New(tx pendingTx) error {
 	// upgrade to write lock if id does not exist
 	_, err = c.withWriteLock(func() (string, error) {
 		// Check if ID already exists in any of the maps
+		if _, exists := c.pendingTxs[tx.id]; exists {
+			return "", ErrIDAlreadyExists
+		}
 		if _, exists := c.broadcastedProcessedTxs[tx.id]; exists {
 			return "", ErrIDAlreadyExists
 		}
@@ -139,11 +148,46 @@ func (c *pendingTxContext) New(tx pendingTx) error {
 		if _, exists := c.finalizedErroredTxs[tx.id]; exists {
 			return "", ErrIDAlreadyExists
 		}
-		tx.signatures = []solana.Signature{}
 		tx.createTs = time.Now()
+		tx.state = utils.Pending
+		// save to the pending map
+		c.pendingTxs[tx.id] = tx
+		return "", nil
+	})
+	return err
+}
+
+func (c *pendingTxContext) OnBroadcasted(tx pendingTx) error {
+	err := c.withReadLock(func() error {
+		// Check if transaction already in broadcasted state
+		if tempTx, exists := c.broadcastedProcessedTxs[tx.id]; exists && tempTx.state == utils.Broadcasted {
+			return ErrAlreadyInExpectedState
+		}
+		// Transactions should only move to pending from broadcasted
+		_, exists := c.pendingTxs[tx.id]
+		if !exists {
+			return ErrTransactionNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// upgrade to write lock if id does not exist
+	_, err = c.withWriteLock(func() (string, error) {
+		// Check if pending map has tx
+		pendingMsg, exists := c.pendingTxs[tx.id]
+		if !exists {
+			return tx.id, ErrTransactionNotFound
+		}
+		tx.signatures = []solana.Signature{}
+		tx.createTs = pendingMsg.createTs
 		tx.state = utils.Broadcasted
-		// save to the broadcasted map since transaction was just broadcasted
+		// save transaction to broadcasted map
 		c.broadcastedProcessedTxs[tx.id] = tx
+		// remove tx from pending map
+		delete(c.pendingTxs, tx.id)
 		return "", nil
 	})
 	return err
@@ -174,7 +218,7 @@ func (c *pendingTxContext) AddSignature(cancel context.CancelFunc, id string, si
 		if _, exists := c.broadcastedProcessedTxs[id]; !exists {
 			return "", ErrTransactionNotFound
 		}
-		c.sigToTxInfo[sig] = txInfo{id: id, state: txmutils.Broadcasted}
+		c.sigToTxInfo[sig] = txInfo{id: id, state: utils.Broadcasted}
 		tx := c.broadcastedProcessedTxs[id]
 		// save new signature
 		tx.signatures = append(tx.signatures, sig)
@@ -193,8 +237,13 @@ func (c *pendingTxContext) AddSignature(cancel context.CancelFunc, id string, si
 
 // returns the id if removed (otherwise returns empty string)
 // removes transactions from any state except finalized and errored
-func (c *pendingTxContext) Remove(id string) (string, error) {
+func (c *pendingTxContext) RevertToPending(id string) error {
 	err := c.withReadLock(func() error {
+		// check if transaction already in the expected state
+		if tx, pendingExists := c.pendingTxs[id]; pendingExists && tx.state == utils.Pending {
+			return ErrAlreadyInExpectedState
+		}
+		// transaction should only revert to pending from broadcasted, processed, or confirmed state
 		_, broadcastedIDExists := c.broadcastedProcessedTxs[id]
 		_, confirmedIDExists := c.confirmedTxs[id]
 		// transaction does not exist in tx maps
@@ -204,11 +253,11 @@ func (c *pendingTxContext) Remove(id string) (string, error) {
 		return nil
 	})
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	// upgrade to write lock if sig does not exist
-	return c.withWriteLock(func() (string, error) {
+	_, err = c.withWriteLock(func() (string, error) {
 		var tx pendingTx
 		if tempTx, exists := c.broadcastedProcessedTxs[id]; exists {
 			tx = tempTx
@@ -229,8 +278,11 @@ func (c *pendingTxContext) Remove(id string) (string, error) {
 		for _, s := range tx.signatures {
 			delete(c.sigToTxInfo, s)
 		}
+		tx.state = utils.Pending
+		c.pendingTxs[id] = tx
 		return id, nil
 	})
+	return err
 }
 
 func (c *pendingTxContext) ListAllSigs() []solana.Signature {
@@ -246,7 +298,7 @@ func (c *pendingTxContext) ListAllExpiredBroadcastedTxs(currBlockNumber uint64) 
 	defer c.lock.RUnlock()
 	expiredBroadcastedTxs := make([]pendingTx, 0, len(c.broadcastedProcessedTxs)) // worst case, all of them
 	for _, tx := range c.broadcastedProcessedTxs {
-		if tx.state == txmutils.Broadcasted && tx.lastValidBlockHeight < currBlockNumber {
+		if tx.state == utils.Broadcasted && tx.lastValidBlockHeight < currBlockNumber {
 			expiredBroadcastedTxs = append(expiredBroadcastedTxs, tx)
 		}
 	}
@@ -307,7 +359,7 @@ func (c *pendingTxContext) OnProcessed(sig solana.Signature) (string, error) {
 			return info.id, ErrTransactionNotFound
 		}
 		// update sig and tx to Processed
-		info.state, tx.state = txmutils.Processed, txmutils.Processed
+		info.state, tx.state = utils.Processed, utils.Processed
 		// save updated sig and tx back to the maps
 		c.sigToTxInfo[sig] = info
 		c.broadcastedProcessedTxs[info.id] = tx
@@ -323,7 +375,7 @@ func (c *pendingTxContext) OnConfirmed(sig solana.Signature) (string, error) {
 			return ErrSigDoesNotExist
 		}
 		// Check if transaction already in confirmed state
-		if tx, exists := c.confirmedTxs[info.id]; exists && tx.state == txmutils.Confirmed {
+		if tx, exists := c.confirmedTxs[info.id]; exists && tx.state == utils.Confirmed {
 			return ErrAlreadyInExpectedState
 		}
 		// Transactions should only move to confirmed from broadcasted/processed
@@ -352,7 +404,7 @@ func (c *pendingTxContext) OnConfirmed(sig solana.Signature) (string, error) {
 			delete(c.cancelBy, info.id)
 		}
 		// update sig and tx state to Confirmed
-		info.state, tx.state = txmutils.Confirmed, txmutils.Confirmed
+		info.state, tx.state = utils.Confirmed, utils.Confirmed
 		c.sigToTxInfo[sig] = info
 		// move tx to confirmed map
 		c.confirmedTxs[info.id] = tx
@@ -427,14 +479,12 @@ func (c *pendingTxContext) OnFinalized(sig solana.Signature, retentionTimeout ti
 }
 
 func (c *pendingTxContext) OnPrebroadcastError(id string, retentionTimeout time.Duration, txState utils.TxState, _ TxErrType) error {
-	// nothing to do if retention timeout is 0 since transaction is not stored yet.
-	if retentionTimeout == 0 {
-		return nil
-	}
 	err := c.withReadLock(func() error {
+		// check if transaction already in the expected state
 		if tx, exists := c.finalizedErroredTxs[id]; exists && tx.state == txState {
 			return ErrAlreadyInExpectedState
 		}
+		// check if transaction in higher state than pending, implying that the transaction has progressed past pre-broadcast errors
 		_, broadcastedExists := c.broadcastedProcessedTxs[id]
 		_, confirmedExists := c.confirmedTxs[id]
 		if broadcastedExists || confirmedExists {
@@ -456,6 +506,11 @@ func (c *pendingTxContext) OnPrebroadcastError(id string, retentionTimeout time.
 		_, confirmedExists := c.confirmedTxs[id]
 		if broadcastedExists || confirmedExists {
 			return "", ErrIDAlreadyExists
+		}
+		delete(c.pendingTxs, id)
+		// If retention timeout set to 0, skip adding it to the errored map
+		if retentionTimeout == 0 {
+			return "", nil
 		}
 		erroredTx := finishedTx{
 			state:       txState,
@@ -536,6 +591,9 @@ func (c *pendingTxContext) OnError(sig solana.Signature, retentionTimeout time.D
 func (c *pendingTxContext) GetTxState(id string) (utils.TxState, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
+	if tx, exists := c.pendingTxs[id]; exists {
+		return tx.state, nil
+	}
 	if tx, exists := c.broadcastedProcessedTxs[id]; exists {
 		return tx.state, nil
 	}
@@ -576,7 +634,7 @@ func (c *pendingTxContext) TrimFinalizedErroredTxs() int {
 	return len(expiredIDs)
 }
 
-func (c *pendingTxContext) IsTxReorged(sig solana.Signature, sigOnChainState txmutils.TxState) (string, bool) {
+func (c *pendingTxContext) IsTxReorged(sig solana.Signature, sigOnChainState utils.TxState) (string, bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
@@ -590,12 +648,12 @@ func (c *pendingTxContext) IsTxReorged(sig solana.Signature, sigOnChainState txm
 	sigInMemoryState := txInfo.state
 	var hasReorg bool
 	switch sigInMemoryState {
-	case txmutils.Confirmed:
-		if sigOnChainState == txmutils.Processed || sigOnChainState == txmutils.Broadcasted || sigOnChainState == txmutils.NotFound {
+	case utils.Confirmed:
+		if sigOnChainState == utils.Processed || sigOnChainState == utils.Broadcasted || sigOnChainState == utils.NotFound {
 			hasReorg = true
 		}
-	case txmutils.Processed:
-		if sigOnChainState == txmutils.Broadcasted || sigOnChainState == txmutils.NotFound {
+	case utils.Processed:
+		if sigOnChainState == utils.Broadcasted || sigOnChainState == utils.NotFound {
 			hasReorg = true
 		}
 	default: // No reorg if the signature is not in a state that can be reorged
@@ -604,7 +662,7 @@ func (c *pendingTxContext) IsTxReorged(sig solana.Signature, sigOnChainState txm
 	return txInfo.id, hasReorg
 }
 
-func (c *pendingTxContext) GetPendingTx(id string) (pendingTx, error) {
+func (c *pendingTxContext) GetReorgTx(id string) (pendingTx, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	var tx, tempTx pendingTx
@@ -663,6 +721,10 @@ func (c *pendingTxContextWithProm) New(msg pendingTx) error {
 	return c.pendingTx.New(msg)
 }
 
+func (c *pendingTxContextWithProm) OnBroadcasted(msg pendingTx) error {
+	return c.pendingTx.OnBroadcasted(msg)
+}
+
 func (c *pendingTxContextWithProm) AddSignature(cancel context.CancelFunc, id string, sig solana.Signature) error {
 	return c.pendingTx.AddSignature(cancel, id, sig)
 }
@@ -679,8 +741,8 @@ func (c *pendingTxContextWithProm) OnConfirmed(sig solana.Signature) (string, er
 	return id, err
 }
 
-func (c *pendingTxContextWithProm) Remove(id string) (string, error) {
-	return c.pendingTx.Remove(id)
+func (c *pendingTxContextWithProm) RevertToPending(id string) error {
+	return c.pendingTx.RevertToPending(id)
 }
 
 func (c *pendingTxContextWithProm) ListAllSigs() []solana.Signature {
@@ -749,10 +811,10 @@ func (c *pendingTxContextWithProm) TrimFinalizedErroredTxs() int {
 	return c.pendingTx.TrimFinalizedErroredTxs()
 }
 
-func (c *pendingTxContextWithProm) IsTxReorged(sig solana.Signature, currentSigState txmutils.TxState) (string, bool) {
+func (c *pendingTxContextWithProm) IsTxReorged(sig solana.Signature, currentSigState utils.TxState) (string, bool) {
 	return c.pendingTx.IsTxReorged(sig, currentSigState)
 }
 
-func (c *pendingTxContextWithProm) GetPendingTx(id string) (pendingTx, error) {
-	return c.pendingTx.GetPendingTx(id)
+func (c *pendingTxContextWithProm) GetReorgTx(id string) (pendingTx, error) {
+	return c.pendingTx.GetReorgTx(id)
 }

--- a/pkg/solana/txm/pendingtx_test.go
+++ b/pkg/solana/txm/pendingtx_test.go
@@ -868,7 +868,7 @@ func TestPendingTxContext_on_prebroadcast_error(t *testing.T) {
 	})
 }
 
-func TestPendingTxContext_RevertToPending(t *testing.T) {
+func TestPendingTxContext_RevertToAwaitingBroadcast(t *testing.T) {
 	t.Parallel()
 	_, cancel := context.WithCancel(tests.Context(t))
 
@@ -921,7 +921,7 @@ func TestPendingTxContext_RevertToPending(t *testing.T) {
 	require.Equal(t, erroredMsg.id, id)
 
 	// Revert broadcasted transaction back to pending
-	err = txs.RevertToPending(broadcastedID)
+	err = txs.RevertToAwaitingBroadcast(broadcastedID)
 	require.NoError(t, err)
 
 	// Check removed from broadcasted map
@@ -929,9 +929,9 @@ func TestPendingTxContext_RevertToPending(t *testing.T) {
 	require.False(t, exists)
 
 	// Check that it is moved back to the pending map
-	tx, exists := txs.pendingTxs[broadcastedMsg.id]
+	tx, exists := txs.queuedTxs[broadcastedMsg.id]
 	require.True(t, exists)
-	require.Equal(t, utils.Pending, tx.state)
+	require.Equal(t, utils.AwaitingBroadcast, tx.state)
 
 	// Check all signatures removed from sig map
 	_, exists = txs.sigToTxInfo[broadcastedSig1]
@@ -940,7 +940,7 @@ func TestPendingTxContext_RevertToPending(t *testing.T) {
 	require.False(t, exists)
 
 	// Revert processed transaction back to pending
-	err = txs.RevertToPending(processedID)
+	err = txs.RevertToAwaitingBroadcast(processedID)
 	require.NoError(t, err)
 
 	// Check removed from broadcasted map
@@ -952,12 +952,12 @@ func TestPendingTxContext_RevertToPending(t *testing.T) {
 	require.False(t, exists)
 
 	// Check that it is moved back to the pending map
-	tx, exists = txs.pendingTxs[processedMsg.id]
+	tx, exists = txs.queuedTxs[processedMsg.id]
 	require.True(t, exists)
-	require.Equal(t, utils.Pending, tx.state)
+	require.Equal(t, utils.AwaitingBroadcast, tx.state)
 
 	// Revert confirmed transaction back to pending
-	err = txs.RevertToPending(confirmedID)
+	err = txs.RevertToAwaitingBroadcast(confirmedID)
 	require.NoError(t, err)
 
 	// Check removed from confirmed map
@@ -965,20 +965,20 @@ func TestPendingTxContext_RevertToPending(t *testing.T) {
 	require.False(t, exists)
 
 	// Check that it is moved back to the pending map
-	tx, exists = txs.pendingTxs[confirmedMsg.id]
+	tx, exists = txs.queuedTxs[confirmedMsg.id]
 	require.True(t, exists)
-	require.Equal(t, utils.Pending, tx.state)
+	require.Equal(t, utils.AwaitingBroadcast, tx.state)
 
 	// Check all signatures removed from sig map
 	_, exists = txs.sigToTxInfo[confirmedSig]
 	require.False(t, exists)
 
-	// Check RevertToPending cannot be called on finalized transaction
-	err = txs.RevertToPending(finalizedID)
+	// Check RevertToAwaitingBroadcast cannot be called on finalized transaction
+	err = txs.RevertToAwaitingBroadcast(finalizedID)
 	require.Error(t, err)
 
 	// Check remove cannot be called on errored transaction
-	err = txs.RevertToPending(erroredID)
+	err = txs.RevertToAwaitingBroadcast(erroredID)
 	require.Error(t, err)
 
 	// Check sig list is empty after all removals
@@ -1499,7 +1499,7 @@ func TestPendingTxContext_GetReorgTx(t *testing.T) {
 	t.Run("successfully retrieve broadcasted transaction", func(t *testing.T) {
 		txID, _ := createTxAndAddSig(t, txs)
 
-		tx, err := txs.GetReorgTx(txID)
+		tx, err := txs.GetPendingTx(txID)
 		require.NoError(t, err)
 		require.Equal(t, txID, tx.id)
 		require.Equal(t, utils.Broadcasted, tx.state)
@@ -1510,7 +1510,7 @@ func TestPendingTxContext_GetReorgTx(t *testing.T) {
 		_, err := txs.OnProcessed(sig)
 		require.NoError(t, err)
 
-		tx, err := txs.GetReorgTx(txID)
+		tx, err := txs.GetPendingTx(txID)
 		require.NoError(t, err)
 		require.Equal(t, txID, tx.id)
 		require.Equal(t, utils.Processed, tx.state)
@@ -1523,14 +1523,14 @@ func TestPendingTxContext_GetReorgTx(t *testing.T) {
 		_, err = txs.OnConfirmed(sig)
 		require.NoError(t, err)
 
-		tx, err := txs.GetReorgTx(txID)
+		tx, err := txs.GetPendingTx(txID)
 		require.NoError(t, err)
 		require.Equal(t, txID, tx.id)
 		require.Equal(t, utils.Confirmed, tx.state)
 	})
 
 	t.Run("fail to retrieve non-existent transaction", func(t *testing.T) {
-		_, err := txs.GetReorgTx("non-existent-id")
+		_, err := txs.GetPendingTx("non-existent-id")
 		require.ErrorIs(t, err, ErrTransactionNotFound)
 	})
 }

--- a/pkg/solana/txm/pendingtx_test.go
+++ b/pkg/solana/txm/pendingtx_test.go
@@ -1133,8 +1133,8 @@ func TestGetTxState(t *testing.T) {
 	require.Equal(t, processedMsg.id, id)
 
 	// Check Processed state is returned
-	state, err = txs.GetTxState(processedMsg.id)
-	require.NoError(t, err)
+	state, exists := txs.GetTxState(processedMsg.id)
+	require.True(t, exists)
 	require.Equal(t, utils.Processed, state)
 
 	// Create new confirmed transaction
@@ -1146,8 +1146,8 @@ func TestGetTxState(t *testing.T) {
 	require.Equal(t, confirmedMsg.id, id)
 
 	// Check Confirmed state is returned
-	state, err = txs.GetTxState(confirmedMsg.id)
-	require.NoError(t, err)
+	state, exists = txs.GetTxState(confirmedMsg.id)
+	require.True(t, exists)
 	require.Equal(t, utils.Confirmed, state)
 
 	// Create new finalized transaction
@@ -1159,8 +1159,8 @@ func TestGetTxState(t *testing.T) {
 	require.Equal(t, finalizedMsg.id, id)
 
 	// Check Finalized state is returned
-	state, err = txs.GetTxState(finalizedMsg.id)
-	require.NoError(t, err)
+	state, exists = txs.GetTxState(finalizedMsg.id)
+	require.True(t, exists)
 	require.Equal(t, utils.Finalized, state)
 
 	// Create new errored transaction
@@ -1172,8 +1172,8 @@ func TestGetTxState(t *testing.T) {
 	require.Equal(t, erroredMsg.id, id)
 
 	// Check Errored state is returned
-	state, err = txs.GetTxState(erroredMsg.id)
-	require.NoError(t, err)
+	state, exists = txs.GetTxState(erroredMsg.id)
+	require.True(t, exists)
 	require.Equal(t, utils.Errored, state)
 
 	// Create new fatally errored transaction
@@ -1185,13 +1185,13 @@ func TestGetTxState(t *testing.T) {
 	require.Equal(t, fatallyErroredMsg.id, id)
 
 	// Check Errored state is returned
-	state, err = txs.GetTxState(fatallyErroredMsg.id)
-	require.NoError(t, err)
+	state, exists = txs.GetTxState(fatallyErroredMsg.id)
+	require.True(t, exists)
 	require.Equal(t, utils.FatallyErrored, state)
 
 	// Check NotFound state is returned if unknown id provided
-	state, err = txs.GetTxState("unknown id")
-	require.Error(t, err)
+	state, exists = txs.GetTxState("unknown id")
+	require.False(t, exists)
 	require.Equal(t, utils.NotFound, state)
 }
 

--- a/pkg/solana/txm/pendingtx_test.go
+++ b/pkg/solana/txm/pendingtx_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/txm/utils"
-	txmutils "github.com/smartcontractkit/chainlink-solana/pkg/solana/txm/utils"
 )
 
 func TestPendingTxContext_add_remove_multiple(t *testing.T) {
@@ -43,38 +42,97 @@ func TestPendingTxContext_add_remove_multiple(t *testing.T) {
 	for i := 0; i < n; i++ {
 		sig, cancel := newProcess()
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		assert.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		assert.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 		ids[sig] = msg.id
 	}
 
 	// cannot add signature for non existent ID
-	require.Error(t, txs.AddSignature(func() {}, uuid.New().String(), solana.Signature{}))
-
-	list := make([]string, 0, n)
-	for _, info := range txs.sigToTxInfo {
-		list = append(list, info.id)
-	}
-	assert.Equal(t, n, len(list))
+	require.Error(t, txs.AddSignature(func() {}, uuid.NewString(), solana.Signature{}))
+	assert.Equal(t, n, len(txs.sigToTxInfo))
 
 	// stop all sub processes
-	for i := 0; i < len(list); i++ {
-		txID := list[i]
-		_, err := txs.Remove(txID)
+	for sig, id := range ids {
+		_, err := txs.OnError(sig, 0, utils.Errored, TxFailReject)
 		assert.NoError(t, err)
-		assert.Equal(t, n-i-1, len(txs.ListAllSigs()))
-
-		// second remove should not return valid id - already removed
-		id, err := txs.Remove(txID)
-		require.Error(t, err)
-		assert.Equal(t, "", id)
+		// sig does not exist in map anymore
+		_, exists := txs.sigToTxInfo[sig]
+		require.False(t, exists)
+		// tx does not exist in broadcasted map anymore
+		_, exists = txs.broadcastedProcessedTxs[id]
+		require.False(t, exists)
+		// tx does not exist in finalized/errored map since retention is set to 0
+		_, exists = txs.finalizedErroredTxs[id]
+		require.False(t, exists)
 	}
 	wg.Wait()
 }
 
-func TestPendingTxContext_new(t *testing.T) {
+func TestPendingTxContext_New(t *testing.T) {
+	t.Parallel()
+
+	txs := newPendingTxContext()
+	ctx := tests.Context(t)
+	_, cancel := context.WithCancel(ctx)
+
+	t.Run("successfully adds new transaction in pending state", func(t *testing.T) {
+		msg := pendingTx{id: uuid.NewString()}
+		require.NoError(t, txs.New(msg))
+	})
+
+	t.Run("errors if transaction already exists in pending state", func(t *testing.T) {
+		msg := pendingTx{id: uuid.NewString()}
+		require.NoError(t, txs.New(msg))
+		require.ErrorIs(t, txs.New(msg), ErrIDAlreadyExists)
+	})
+
+	t.Run("errors if transaction already exists in broadcasted state", func(t *testing.T) {
+		msg := pendingTx{id: uuid.NewString()}
+		sig := randomSignature(t)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
+		require.ErrorIs(t, txs.New(msg), ErrIDAlreadyExists)
+	})
+
+	t.Run("errors if transaction already exists in processed state", func(t *testing.T) {
+		msg := pendingTx{id: uuid.NewString()}
+		sig := randomSignature(t)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
+		_, err := txs.OnProcessed(sig)
+		require.NoError(t, err)
+		require.ErrorIs(t, txs.New(msg), ErrIDAlreadyExists)
+	})
+
+	t.Run("errors if transaction already exists in confirmed state", func(t *testing.T) {
+		msg := pendingTx{id: uuid.NewString()}
+		sig := randomSignature(t)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
+		_, err := txs.OnProcessed(sig)
+		require.NoError(t, err)
+		_, err = txs.OnConfirmed(sig)
+		require.NoError(t, err)
+		require.ErrorIs(t, txs.New(msg), ErrIDAlreadyExists)
+	})
+
+	t.Run("errors if transaction already exists in finalized state", func(t *testing.T) {
+		msg := pendingTx{id: uuid.NewString()}
+		sig := randomSignature(t)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
+		_, err := txs.OnProcessed(sig)
+		require.NoError(t, err)
+		_, err = txs.OnConfirmed(sig)
+		require.NoError(t, err)
+		_, err = txs.OnFinalized(sig, 1*time.Second)
+		require.NoError(t, err)
+		require.ErrorIs(t, txs.New(msg), ErrIDAlreadyExists)
+	})
+
+	t.Run("errors if transaction already exists in errored state", func(t *testing.T) {
+		msg := pendingTx{id: uuid.NewString()}
+		require.NoError(t, txs.OnPrebroadcastError(msg.id, 1*time.Second, utils.Errored, TxFailReject))
+		require.ErrorIs(t, txs.New(msg), ErrIDAlreadyExists)
+	})
+}
+
+func TestPendingTxContext_OnBroadcasted(t *testing.T) {
 	t.Parallel()
 	_, cancel := context.WithCancel(tests.Context(t))
 	sig := randomSignature(t)
@@ -82,10 +140,7 @@ func TestPendingTxContext_new(t *testing.T) {
 
 	// Create new transaction
 	msg := pendingTx{id: uuid.NewString()}
-	err := txs.New(msg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, msg.id, sig)
-	require.NoError(t, err, "expected no error when adding a new transaction")
+	addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 	// Check it exists in signature map and mapped to the correct txID
 	txInfo, exists := txs.sigToTxInfo[sig]
@@ -107,25 +162,17 @@ func TestPendingTxContext_new(t *testing.T) {
 	_, exists = txs.finalizedErroredTxs[msg.id]
 	require.False(t, exists, "transaction should not exist in finalizedErroredTxs map")
 
-	// Attempt to add the same transaction again
-	err = txs.New(msg)
-	require.ErrorIs(t, err, ErrIDAlreadyExists, "expected ErrIDAlreadyExists when adding duplicate transaction ID")
+	// Attempt to mark the same transaction as broadcasted again
+	err := txs.OnBroadcasted(msg)
+	require.ErrorIs(t, err, ErrAlreadyInExpectedState, "expected ErrAlreadyInExpectedState when adding duplicate transaction ID")
 
 	// Simulate moving the transaction to confirmedTxs map
 	_, err = txs.OnConfirmed(sig)
 	require.NoError(t, err, "expected no error when confirming transaction")
 
-	// Attempt to add a new transaction with the same ID (now in confirmedTxs)
-	err = txs.New(pendingTx{id: msg.id})
-	require.ErrorIs(t, err, ErrIDAlreadyExists, "expected ErrIDAlreadyExists when adding transaction ID that exists in confirmedTxs")
-
 	// Simulate moving the transaction to finalizedErroredTxs map
 	_, err = txs.OnFinalized(sig, 10*time.Second)
 	require.NoError(t, err, "expected no error when finalizing transaction")
-
-	// Attempt to add a new transaction with the same ID (now in finalizedErroredTxs)
-	err = txs.New(pendingTx{id: msg.id})
-	require.ErrorIs(t, err, ErrIDAlreadyExists, "expected ErrIDAlreadyExists when adding transaction ID that exists in finalizedErroredTxs")
 }
 
 func TestPendingTxContext_add_signature(t *testing.T) {
@@ -139,12 +186,9 @@ func TestPendingTxContext_add_signature(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig1)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig1, cancel)
 
-		err = txs.AddSignature(cancel, msg.id, sig2)
+		err := txs.AddSignature(cancel, msg.id, sig2)
 		require.NoError(t, err)
 
 		// Check signature map
@@ -176,12 +220,9 @@ func TestPendingTxContext_add_signature(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
-		err = txs.AddSignature(cancel, msg.id, sig)
+		err := txs.AddSignature(cancel, msg.id, sig)
 		require.ErrorIs(t, err, ErrSigAlreadyExists)
 	})
 
@@ -191,12 +232,9 @@ func TestPendingTxContext_add_signature(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig1)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig1, cancel)
 
-		err = txs.AddSignature(cancel, "bad id", sig2)
+		err := txs.AddSignature(cancel, "bad id", sig2)
 		require.ErrorIs(t, err, ErrTransactionNotFound)
 	})
 
@@ -206,10 +244,7 @@ func TestPendingTxContext_add_signature(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig1)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig1, cancel)
 
 		// Transition to processed state
 		id, err := txs.OnProcessed(sig1)
@@ -237,10 +272,7 @@ func TestPendingTxContext_on_broadcasted_processed(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to processed state
 		id, err := txs.OnProcessed(sig)
@@ -275,10 +307,7 @@ func TestPendingTxContext_on_broadcasted_processed(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to processed state
 		id, err := txs.OnProcessed(sig)
@@ -300,10 +329,7 @@ func TestPendingTxContext_on_broadcasted_processed(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to processed state
 		id, err := txs.OnProcessed(sig)
@@ -330,10 +356,7 @@ func TestPendingTxContext_on_broadcasted_processed(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to errored state
 		id, err := txs.OnError(sig, retentionTimeout, utils.Errored, 0)
@@ -350,10 +373,7 @@ func TestPendingTxContext_on_broadcasted_processed(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to processed state
 		id, err := txs.OnProcessed(sig)
@@ -377,10 +397,7 @@ func TestPendingTxContext_on_confirmed(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to processed state
 		id, err := txs.OnProcessed(sig)
@@ -420,10 +437,7 @@ func TestPendingTxContext_on_confirmed(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to processed state
 		id, err := txs.OnProcessed(sig)
@@ -450,10 +464,7 @@ func TestPendingTxContext_on_confirmed(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to errored state
 		id, err := txs.OnError(sig, retentionTimeout, utils.Errored, 0)
@@ -470,10 +481,7 @@ func TestPendingTxContext_on_confirmed(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to processed state
 		id, err := txs.OnProcessed(sig)
@@ -503,13 +511,10 @@ func TestPendingTxContext_on_finalized(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig1)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig1, cancel)
 
 		// Add second signature
-		err = txs.AddSignature(cancel, msg.id, sig2)
+		err := txs.AddSignature(cancel, msg.id, sig2)
 		require.NoError(t, err)
 
 		// Transition to finalized state
@@ -545,13 +550,10 @@ func TestPendingTxContext_on_finalized(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig1)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig1, cancel)
 
 		// Add second signature
-		err = txs.AddSignature(cancel, msg.id, sig2)
+		err := txs.AddSignature(cancel, msg.id, sig2)
 		require.NoError(t, err)
 
 		// Transition to processed state
@@ -596,10 +598,7 @@ func TestPendingTxContext_on_finalized(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig1)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig1, cancel)
 
 		// Transition to processed state
 		id, err := txs.OnProcessed(sig1)
@@ -638,10 +637,7 @@ func TestPendingTxContext_on_finalized(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to errored state
 		id, err := txs.OnError(sig, retentionTimeout, utils.Errored, 0)
@@ -665,10 +661,7 @@ func TestPendingTxContext_on_error(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to errored state
 		id, err := txs.OnError(sig, retentionTimeout, utils.Errored, 0)
@@ -700,10 +693,7 @@ func TestPendingTxContext_on_error(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to errored state
 		id, err := txs.OnConfirmed(sig)
@@ -740,10 +730,7 @@ func TestPendingTxContext_on_error(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to fatally errored state
 		id, err := txs.OnError(sig, retentionTimeout, utils.FatallyErrored, 0)
@@ -771,10 +758,7 @@ func TestPendingTxContext_on_error(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to confirmed state
 		id, err := txs.OnConfirmed(sig)
@@ -808,10 +792,7 @@ func TestPendingTxContext_on_error(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to finalized state
 		id, err := txs.OnFinalized(sig, retentionTimeout)
@@ -819,7 +800,7 @@ func TestPendingTxContext_on_error(t *testing.T) {
 		require.Equal(t, msg.id, id)
 
 		// Transition to errored state
-		id, err = txs.OnError(sig, retentionTimeout, txmutils.Errored, 0)
+		id, err = txs.OnError(sig, retentionTimeout, utils.Errored, 0)
 		require.Error(t, err)
 		require.Equal(t, "", id)
 	})
@@ -867,14 +848,10 @@ func TestPendingTxContext_on_prebroadcast_error(t *testing.T) {
 
 		// Create new transaction
 		msg := pendingTx{id: uuid.NewString()}
-		// Add transaction to broadcasted map
-		err := txs.New(msg)
-		require.NoError(t, err)
-		err = txs.AddSignature(cancel, msg.id, sig)
-		require.NoError(t, err)
+		addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 		// Transition to errored state
-		err = txs.OnPrebroadcastError(msg.id, retentionTimeout, utils.FatallyErrored, 0)
+		err := txs.OnPrebroadcastError(msg.id, retentionTimeout, utils.FatallyErrored, 0)
 		require.ErrorIs(t, err, ErrIDAlreadyExists)
 	})
 
@@ -891,82 +868,70 @@ func TestPendingTxContext_on_prebroadcast_error(t *testing.T) {
 	})
 }
 
-func TestPendingTxContext_remove(t *testing.T) {
+func TestPendingTxContext_RevertToPending(t *testing.T) {
 	t.Parallel()
 	_, cancel := context.WithCancel(tests.Context(t))
 
 	txs := newPendingTxContext()
 	retentionTimeout := 5 * time.Second
 
+	// Create new broadcasted transaction with extra sig
 	broadcastedID := uuid.NewString()
 	broadcastedSig1 := randomSignature(t)
 	broadcastedSig2 := randomSignature(t)
-	processedID := uuid.NewString()
-	processedSig := randomSignature(t)
-	confirmedID := uuid.NewString()
-	confirmedSig := randomSignature(t)
-	finalizedID := uuid.NewString()
-	finalizedSig := randomSignature(t)
-	erroredID := uuid.NewString()
-	erroredSig := randomSignature(t)
-
-	// Create new broadcasted transaction with extra sig
 	broadcastedMsg := pendingTx{id: broadcastedID}
-	err := txs.New(broadcastedMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, broadcastedMsg.id, broadcastedSig1)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, broadcastedMsg.id, broadcastedSig2)
+	addBroadcastedTxWithSigAndCancel(t, txs, broadcastedMsg, broadcastedSig1, cancel)
+	err := txs.AddSignature(cancel, broadcastedMsg.id, broadcastedSig2)
 	require.NoError(t, err)
 
 	// Create new processed transaction
+	processedID := uuid.NewString()
+	processedSig := randomSignature(t)
 	processedMsg := pendingTx{id: processedID}
-	err = txs.New(processedMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, processedMsg.id, processedSig)
-	require.NoError(t, err)
+	addBroadcastedTxWithSigAndCancel(t, txs, processedMsg, processedSig, cancel)
 	id, err := txs.OnProcessed(processedSig)
 	require.NoError(t, err)
 	require.Equal(t, processedMsg.id, id)
 
 	// Create new confirmed transaction
+	confirmedID := uuid.NewString()
+	confirmedSig := randomSignature(t)
 	confirmedMsg := pendingTx{id: confirmedID}
-	err = txs.New(confirmedMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, confirmedMsg.id, confirmedSig)
-	require.NoError(t, err)
+	addBroadcastedTxWithSigAndCancel(t, txs, confirmedMsg, confirmedSig, cancel)
 	id, err = txs.OnConfirmed(confirmedSig)
 	require.NoError(t, err)
 	require.Equal(t, confirmedMsg.id, id)
 
 	// Create new finalized transaction
+	finalizedID := uuid.NewString()
+	finalizedSig := randomSignature(t)
 	finalizedMsg := pendingTx{id: finalizedID}
-	err = txs.New(finalizedMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, finalizedMsg.id, finalizedSig)
-	require.NoError(t, err)
+	addBroadcastedTxWithSigAndCancel(t, txs, finalizedMsg, finalizedSig, cancel)
 	id, err = txs.OnFinalized(finalizedSig, retentionTimeout)
 	require.NoError(t, err)
 	require.Equal(t, finalizedMsg.id, id)
 
 	// Create new errored transaction
+	erroredID := uuid.NewString()
+	erroredSig := randomSignature(t)
 	erroredMsg := pendingTx{id: erroredID}
-	err = txs.New(erroredMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, erroredMsg.id, erroredSig)
-	require.NoError(t, err)
-	id, err = txs.OnError(erroredSig, retentionTimeout, txmutils.Errored, 0)
+	addBroadcastedTxWithSigAndCancel(t, txs, erroredMsg, erroredSig, cancel)
+	id, err = txs.OnError(erroredSig, retentionTimeout, utils.Errored, 0)
 	require.NoError(t, err)
 	require.Equal(t, erroredMsg.id, id)
 
-	// Remove broadcasted transaction
-	id, err = txs.Remove(broadcastedID)
+	// Revert broadcasted transaction back to pending
+	err = txs.RevertToPending(broadcastedID)
 	require.NoError(t, err)
-	require.Equal(t, broadcastedMsg.id, id)
 
 	// Check removed from broadcasted map
 	_, exists := txs.broadcastedProcessedTxs[broadcastedMsg.id]
 	require.False(t, exists)
+
+	// Check that it is moved back to the pending map
+	tx, exists := txs.pendingTxs[broadcastedMsg.id]
+	require.True(t, exists)
+	require.Equal(t, utils.Pending, tx.state)
 
 	// Check all signatures removed from sig map
 	_, exists = txs.sigToTxInfo[broadcastedSig1]
@@ -974,41 +939,47 @@ func TestPendingTxContext_remove(t *testing.T) {
 	_, exists = txs.sigToTxInfo[broadcastedSig2]
 	require.False(t, exists)
 
-	// Remove processed transaction
-	id, err = txs.Remove(processedID)
+	// Revert processed transaction back to pending
+	err = txs.RevertToPending(processedID)
 	require.NoError(t, err)
-	require.Equal(t, processedMsg.id, id)
 
 	// Check removed from broadcasted map
-	_, exists = txs.broadcastedProcessedTxs[processedMsg.id]
+	tx, exists = txs.broadcastedProcessedTxs[processedMsg.id]
 	require.False(t, exists)
 
 	// Check all signatures removed from sig map
 	_, exists = txs.sigToTxInfo[processedSig]
 	require.False(t, exists)
 
-	// Remove confirmed transaction
-	id, err = txs.Remove(confirmedID)
+	// Check that it is moved back to the pending map
+	tx, exists = txs.pendingTxs[processedMsg.id]
+	require.True(t, exists)
+	require.Equal(t, utils.Pending, tx.state)
+
+	// Revert confirmed transaction back to pending
+	err = txs.RevertToPending(confirmedID)
 	require.NoError(t, err)
-	require.Equal(t, confirmedMsg.id, id)
 
 	// Check removed from confirmed map
 	_, exists = txs.confirmedTxs[confirmedMsg.id]
 	require.False(t, exists)
 
+	// Check that it is moved back to the pending map
+	tx, exists = txs.pendingTxs[confirmedMsg.id]
+	require.True(t, exists)
+	require.Equal(t, utils.Pending, tx.state)
+
 	// Check all signatures removed from sig map
 	_, exists = txs.sigToTxInfo[confirmedSig]
 	require.False(t, exists)
 
-	// Check remove cannot be called on finalized transaction
-	id, err = txs.Remove(finalizedID)
+	// Check RevertToPending cannot be called on finalized transaction
+	err = txs.RevertToPending(finalizedID)
 	require.Error(t, err)
-	require.Equal(t, "", id)
 
 	// Check remove cannot be called on errored transaction
-	id, err = txs.Remove(erroredID)
+	err = txs.RevertToPending(erroredID)
 	require.Error(t, err)
-	require.Equal(t, "", id)
 
 	// Check sig list is empty after all removals
 	require.Empty(t, txs.ListAllSigs())
@@ -1056,10 +1027,7 @@ func TestPendingTxContext_expired(t *testing.T) {
 	txID := uuid.NewString()
 
 	msg := pendingTx{id: txID}
-	err := txs.New(msg)
-	assert.NoError(t, err)
-	err = txs.AddSignature(cancel, msg.id, sig)
-	assert.NoError(t, err)
+	addBroadcastedTxWithSigAndCancel(t, txs, msg, sig, cancel)
 
 	msg, exists := txs.broadcastedProcessedTxs[msg.id]
 	require.True(t, exists)
@@ -1071,11 +1039,6 @@ func TestPendingTxContext_expired(t *testing.T) {
 	assert.False(t, txs.Expired(sig, 0*time.Second))  // false if timeout 0
 	assert.True(t, txs.Expired(sig, 5*time.Second))   // expired for 5s lifetime
 	assert.False(t, txs.Expired(sig, 60*time.Second)) // not expired for 60s lifetime
-
-	id, err := txs.Remove(txID)
-	assert.NoError(t, err)
-	assert.Equal(t, msg.id, id)
-	assert.False(t, txs.Expired(sig, 60*time.Second)) // no longer exists, should return false
 }
 
 func TestPendingTxContext_race(t *testing.T) {
@@ -1104,6 +1067,8 @@ func TestPendingTxContext_race(t *testing.T) {
 		msg := pendingTx{id: uuid.NewString()}
 		createErr := txCtx.New(msg)
 		require.NoError(t, createErr)
+		broadcastErr := txCtx.OnBroadcasted(msg)
+		require.NoError(t, broadcastErr)
 		var wg sync.WaitGroup
 		wg.Add(2)
 		var err [2]error
@@ -1127,17 +1092,19 @@ func TestPendingTxContext_race(t *testing.T) {
 		msg := pendingTx{id: txID}
 		err := txCtx.New(msg)
 		require.NoError(t, err)
+		err = txCtx.OnPrebroadcastError(msg.id, 1*time.Millisecond, utils.Errored, TxFailRevert)
+		require.NoError(t, err)
 		var wg sync.WaitGroup
 		wg.Add(2)
 
 		go func() {
-			assert.NotPanics(t, func() { txCtx.Remove(txID) }) //nolint // no need to check error
-			assert.NotPanics(t, func() { txCtx.Remove(txID) }) //nolint // no need to check error
+			assert.NotPanics(t, func() { txCtx.TrimFinalizedErroredTxs() }) //nolint // no need to check error
+			assert.NotPanics(t, func() { txCtx.TrimFinalizedErroredTxs() }) //nolint // no need to check error
 			wg.Done()
 		}()
 		go func() {
-			assert.NotPanics(t, func() { txCtx.Remove(txID) }) //nolint // no need to check error
-			assert.NotPanics(t, func() { txCtx.Remove(txID) }) //nolint // no need to check error
+			assert.NotPanics(t, func() { txCtx.TrimFinalizedErroredTxs() }) //nolint // no need to check error
+			assert.NotPanics(t, func() { txCtx.TrimFinalizedErroredTxs() }) //nolint // no need to check error
 			wg.Done()
 		}()
 
@@ -1151,27 +1118,16 @@ func TestGetTxState(t *testing.T) {
 	txs := newPendingTxContext()
 	retentionTimeout := 5 * time.Second
 
-	broadcastedSig := randomSignature(t)
-	processedSig := randomSignature(t)
-	confirmedSig := randomSignature(t)
-	finalizedSig := randomSignature(t)
-	erroredSig := randomSignature(t)
-	fatallyErroredSig := randomSignature(t)
-
 	// Create new broadcasted transaction with extra sig
+	broadcastedSig := randomSignature(t)
 	broadcastedMsg := pendingTx{id: uuid.NewString()}
-	err := txs.New(broadcastedMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, broadcastedMsg.id, broadcastedSig)
-	require.NoError(t, err)
+	addBroadcastedTxWithSigAndCancel(t, txs, broadcastedMsg, broadcastedSig, cancel)
 
 	// Create new processed transaction
-	var state txmutils.TxState
+	var state utils.TxState
+	processedSig := randomSignature(t)
 	processedMsg := pendingTx{id: uuid.NewString()}
-	err = txs.New(processedMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, processedMsg.id, processedSig)
-	require.NoError(t, err)
+	addBroadcastedTxWithSigAndCancel(t, txs, processedMsg, processedSig, cancel)
 	id, err := txs.OnProcessed(processedSig)
 	require.NoError(t, err)
 	require.Equal(t, processedMsg.id, id)
@@ -1182,11 +1138,9 @@ func TestGetTxState(t *testing.T) {
 	require.Equal(t, utils.Processed, state)
 
 	// Create new confirmed transaction
+	confirmedSig := randomSignature(t)
 	confirmedMsg := pendingTx{id: uuid.NewString()}
-	err = txs.New(confirmedMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, confirmedMsg.id, confirmedSig)
-	require.NoError(t, err)
+	addBroadcastedTxWithSigAndCancel(t, txs, confirmedMsg, confirmedSig, cancel)
 	id, err = txs.OnConfirmed(confirmedSig)
 	require.NoError(t, err)
 	require.Equal(t, confirmedMsg.id, id)
@@ -1197,11 +1151,9 @@ func TestGetTxState(t *testing.T) {
 	require.Equal(t, utils.Confirmed, state)
 
 	// Create new finalized transaction
+	finalizedSig := randomSignature(t)
 	finalizedMsg := pendingTx{id: uuid.NewString()}
-	err = txs.New(finalizedMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, finalizedMsg.id, finalizedSig)
-	require.NoError(t, err)
+	addBroadcastedTxWithSigAndCancel(t, txs, finalizedMsg, finalizedSig, cancel)
 	id, err = txs.OnFinalized(finalizedSig, retentionTimeout)
 	require.NoError(t, err)
 	require.Equal(t, finalizedMsg.id, id)
@@ -1212,12 +1164,10 @@ func TestGetTxState(t *testing.T) {
 	require.Equal(t, utils.Finalized, state)
 
 	// Create new errored transaction
+	erroredSig := randomSignature(t)
 	erroredMsg := pendingTx{id: uuid.NewString()}
-	err = txs.New(erroredMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, erroredMsg.id, erroredSig)
-	require.NoError(t, err)
-	id, err = txs.OnError(erroredSig, retentionTimeout, txmutils.Errored, 0)
+	addBroadcastedTxWithSigAndCancel(t, txs, erroredMsg, erroredSig, cancel)
+	id, err = txs.OnError(erroredSig, retentionTimeout, utils.Errored, 0)
 	require.NoError(t, err)
 	require.Equal(t, erroredMsg.id, id)
 
@@ -1227,12 +1177,10 @@ func TestGetTxState(t *testing.T) {
 	require.Equal(t, utils.Errored, state)
 
 	// Create new fatally errored transaction
+	fatallyErroredSig := randomSignature(t)
 	fatallyErroredMsg := pendingTx{id: uuid.NewString()}
-	err = txs.New(fatallyErroredMsg)
-	require.NoError(t, err)
-	err = txs.AddSignature(cancel, fatallyErroredMsg.id, fatallyErroredSig)
-	require.NoError(t, err)
-	id, err = txs.OnError(fatallyErroredSig, retentionTimeout, txmutils.FatallyErrored, 0)
+	addBroadcastedTxWithSigAndCancel(t, txs, fatallyErroredMsg, fatallyErroredSig, cancel)
+	id, err = txs.OnError(fatallyErroredSig, retentionTimeout, utils.FatallyErrored, 0)
 	require.NoError(t, err)
 	require.Equal(t, fatallyErroredMsg.id, id)
 
@@ -1409,11 +1357,18 @@ func TestPendingTxContext_ListAllExpiredBroadcastedTxs(t *testing.T) {
 	}
 }
 
+func addBroadcastedTxWithSigAndCancel(t *testing.T, txs *pendingTxContext, tx pendingTx, sig solana.Signature, cancel context.CancelFunc) {
+	require.NoError(t, txs.New(tx))
+	require.NoError(t, txs.OnBroadcasted(tx))
+	require.NoError(t, txs.AddSignature(cancel, tx.id, sig))
+}
+
 func createTxAndAddSig(t *testing.T, txs *pendingTxContext) (string, solana.Signature) {
 	sig := randomSignature(t)
 	txID := uuid.NewString()
 	tx := pendingTx{id: txID}
 	require.NoError(t, txs.New(tx))
+	require.NoError(t, txs.OnBroadcasted(tx))
 	require.NoError(t, txs.AddSignature(func() {}, txID, sig))
 	return txID, sig
 }
@@ -1424,19 +1379,19 @@ func TestPendingTxContext_IsTxReorged(t *testing.T) {
 
 	// This helper creates a brand new transaction/signature,
 	// then sets the in-memory state to the provided memoryState
-	setMemoryState := func(t *testing.T, txs *pendingTxContext, memoryState txmutils.TxState) (txID string, sig solana.Signature) {
+	setMemoryState := func(t *testing.T, txs *pendingTxContext, memoryState utils.TxState) (txID string, sig solana.Signature) {
 		txID, sig = createTxAndAddSig(t, txs)
 
 		switch memoryState {
-		case txmutils.Processed:
+		case utils.Processed:
 			_, err := txs.OnProcessed(sig)
 			require.NoError(t, err, "OnProcessed should succeed")
-		case txmutils.Confirmed:
+		case utils.Confirmed:
 			_, err := txs.OnProcessed(sig)
 			require.NoError(t, err)
 			_, err = txs.OnConfirmed(sig)
 			require.NoError(t, err, "OnConfirmed should succeed")
-		case txmutils.Broadcasted: // do nothing; newly created sig is in memory=Broadcasted by default
+		case utils.Broadcasted: // do nothing; newly created sig is in memory=Broadcasted by default
 		default:
 			require.FailNowf(t, "unexpected memory state", "%v", memoryState)
 		}
@@ -1445,68 +1400,68 @@ func TestPendingTxContext_IsTxReorged(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		memoryState txmutils.TxState
-		chainState  txmutils.TxState
+		memoryState utils.TxState
+		chainState  utils.TxState
 		wantReorg   bool
 	}{
 		{
 			name:        "non-existent signature => no reorg",
-			memoryState: txmutils.Broadcasted, // doesn't matter, we'll handle this case specially
-			chainState:  txmutils.Broadcasted,
+			memoryState: utils.Broadcasted, // doesn't matter, we'll handle this case specially
+			chainState:  utils.Broadcasted,
 			wantReorg:   false,
 		},
 		{
 			name:        "memory=Confirmed, chain=Confirmed => no reorg",
-			memoryState: txmutils.Confirmed,
-			chainState:  txmutils.Confirmed,
+			memoryState: utils.Confirmed,
+			chainState:  utils.Confirmed,
 			wantReorg:   false,
 		},
 		{
 			name:        "memory=Confirmed, chain=Processed => reorg",
-			memoryState: txmutils.Confirmed,
-			chainState:  txmutils.Processed,
+			memoryState: utils.Confirmed,
+			chainState:  utils.Processed,
 			wantReorg:   true,
 		},
 		{
 			name:        "memory=Confirmed, chain=NotFound => reorg",
-			memoryState: txmutils.Confirmed,
-			chainState:  txmutils.NotFound,
+			memoryState: utils.Confirmed,
+			chainState:  utils.NotFound,
 			wantReorg:   true,
 		},
 		{
 			name:        "memory=Processed, chain=Confirmed => no reorg",
-			memoryState: txmutils.Processed,
-			chainState:  txmutils.Confirmed,
+			memoryState: utils.Processed,
+			chainState:  utils.Confirmed,
 			wantReorg:   false,
 		},
 		{
 			name:        "memory=Processed, chain=Processed => no reorg",
-			memoryState: txmutils.Processed,
-			chainState:  txmutils.Processed,
+			memoryState: utils.Processed,
+			chainState:  utils.Processed,
 			wantReorg:   false,
 		},
 		{
 			name:        "memory=Processed, chain=NotFound => reorg",
-			memoryState: txmutils.Processed,
-			chainState:  txmutils.NotFound,
+			memoryState: utils.Processed,
+			chainState:  utils.NotFound,
 			wantReorg:   true,
 		},
 		{
 			name:        "memory=Broadcasted, chain=Confirmed => no reorg",
-			memoryState: txmutils.Broadcasted,
-			chainState:  txmutils.Confirmed,
+			memoryState: utils.Broadcasted,
+			chainState:  utils.Confirmed,
 			wantReorg:   false,
 		},
 		{
 			name:        "memory=Broadcasted, chain=Processed => no reorg",
-			memoryState: txmutils.Broadcasted,
-			chainState:  txmutils.Processed,
+			memoryState: utils.Broadcasted,
+			chainState:  utils.Processed,
 			wantReorg:   false,
 		},
 		{
 			name:        "memory=Broadcasted, chain=NotFound => no reorg",
-			memoryState: txmutils.Broadcasted,
-			chainState:  txmutils.NotFound,
+			memoryState: utils.Broadcasted,
+			chainState:  utils.NotFound,
 			wantReorg:   false,
 		},
 	}
@@ -1537,14 +1492,14 @@ func TestPendingTxContext_IsTxReorged(t *testing.T) {
 	}
 }
 
-func TestPendingTxContext_GetPendingTx(t *testing.T) {
+func TestPendingTxContext_GetReorgTx(t *testing.T) {
 	t.Parallel()
 	txs := newPendingTxContext()
 
 	t.Run("successfully retrieve broadcasted transaction", func(t *testing.T) {
 		txID, _ := createTxAndAddSig(t, txs)
 
-		tx, err := txs.GetPendingTx(txID)
+		tx, err := txs.GetReorgTx(txID)
 		require.NoError(t, err)
 		require.Equal(t, txID, tx.id)
 		require.Equal(t, utils.Broadcasted, tx.state)
@@ -1555,7 +1510,7 @@ func TestPendingTxContext_GetPendingTx(t *testing.T) {
 		_, err := txs.OnProcessed(sig)
 		require.NoError(t, err)
 
-		tx, err := txs.GetPendingTx(txID)
+		tx, err := txs.GetReorgTx(txID)
 		require.NoError(t, err)
 		require.Equal(t, txID, tx.id)
 		require.Equal(t, utils.Processed, tx.state)
@@ -1568,14 +1523,14 @@ func TestPendingTxContext_GetPendingTx(t *testing.T) {
 		_, err = txs.OnConfirmed(sig)
 		require.NoError(t, err)
 
-		tx, err := txs.GetPendingTx(txID)
+		tx, err := txs.GetReorgTx(txID)
 		require.NoError(t, err)
 		require.Equal(t, txID, tx.id)
 		require.Equal(t, utils.Confirmed, tx.state)
 	})
 
 	t.Run("fail to retrieve non-existent transaction", func(t *testing.T) {
-		_, err := txs.GetPendingTx("non-existent-id")
+		_, err := txs.GetReorgTx("non-existent-id")
 		require.ErrorIs(t, err, ErrTransactionNotFound)
 	})
 }

--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -195,7 +195,7 @@ func (txm *Txm) sendWithRetry(ctx context.Context, msg pendingTx) (solanaGo.Tran
 	}
 
 	// Create new transaction in memory
-	if err := txm.txs.New(msg); err != nil {
+	if err := txm.txs.OnBroadcasted(msg); err != nil {
 		cancel()
 		return solanaGo.Transaction{}, "", solanaGo.Signature{}, fmt.Errorf("failed to create new transaction: %w", err)
 	}
@@ -516,7 +516,7 @@ func (txm *Txm) handleErrorSignatureStatus(ctx context.Context, sig solanaGo.Sig
 // - Processed -> Not Found
 //
 // When a signature re-org is detected, the following steps are taken:
-// - Remove the prior transaction, along with all associated signatures, and cancel the prior context.
+// - Revert the prior transaction state to Pending and remove all associated signatures, and cancel the prior context.
 // - Rebroadcast the prior transaction with a new blockhash and an updated compute unit price.
 func (txm *Txm) handleReorg(ctx context.Context, client client.ReaderWriter, sig solanaGo.Signature, status *rpc.SignatureStatusesResult) {
 	// Determine if a re-org has occurred
@@ -528,7 +528,7 @@ func (txm *Txm) handleReorg(ctx context.Context, client client.ReaderWriter, sig
 
 	// At this point, we have detected a re-org. We need to rebroadcast the tx.
 	txm.lggr.Debugw("re-org detected for transaction", "txID", txID, "signature", sig)
-	pTx, err := txm.getPendingTx(txID)
+	pTx, err := txm.txs.GetReorgTx(txID)
 	if err != nil {
 		txm.lggr.Errorw("failed to get pending tx for rebroadcast", "txID", txID, "error", err)
 		return
@@ -720,6 +720,20 @@ func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Tran
 	if tx == nil {
 		return errors.New("error in soltxm.Enqueue: tx is nil pointer")
 	}
+
+	// Use transaction ID provided by caller if set
+	id := uuid.NewString()
+	if txID != nil && *txID != "" {
+		id = *txID
+	}
+
+	_, err := txm.txs.GetTxState(id)
+	// Transaction for ID already exists. No-op to avoid creating another tx for the same ID.
+	if err == nil {
+		txm.lggr.Infow("transaction already exists for ID", "id", id)
+		return nil
+	}
+
 	// validate account keys slice
 	if len(tx.Message.AccountKeys) == 0 {
 		return errors.New("error in soltxm.Enqueue: not enough account keys in tx")
@@ -728,7 +742,7 @@ func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Tran
 	// validate expected key exists by trying to sign with it
 	// fee payer account is index 0 account
 	// https://github.com/gagliardetto/solana-go/blob/main/transaction.go#L252
-	_, err := txm.ks.Sign(ctx, tx.Message.AccountKeys[0].String(), nil)
+	_, err = txm.ks.Sign(ctx, tx.Message.AccountKeys[0].String(), nil)
 	if err != nil {
 		return fmt.Errorf("error in soltxm.Enqueue.GetKey: %w", err)
 	}
@@ -739,18 +753,12 @@ func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Tran
 		v(&cfg)
 	}
 
-	// Use transaction ID provided by caller if set
-	id := uuid.New().String()
-	if txID != nil && *txID != "" {
-		id = *txID
-	}
-
 	// Perform compute unit limit estimation after storing transaction
 	// If error found during simulation, transaction should be in storage to mark accordingly
 	if cfg.EstimateComputeUnitLimit {
-		computeUnitLimit, err := txm.EstimateComputeUnitLimit(ctx, tx, id)
-		if err != nil {
-			return fmt.Errorf("transaction failed simulation: %w", err)
+		computeUnitLimit, simErr := txm.EstimateComputeUnitLimit(ctx, tx, id)
+		if simErr != nil {
+			return fmt.Errorf("transaction failed simulation: %w", simErr)
 		}
 		// If estimation returns 0 compute unit limit without error, fallback to original config
 		if computeUnitLimit != 0 {
@@ -763,6 +771,14 @@ func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Tran
 		tx:                   *tx,
 		cfg:                  cfg,
 		lastValidBlockHeight: txLastValidBlockHeight,
+	}
+
+	err = txm.txs.New(msg)
+	// No-op if transaction already exists for provided ID
+	if err != nil && errors.Is(err, ErrIDAlreadyExists) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to store new transaction with ID %s: %w", id, err)
 	}
 
 	select {
@@ -782,7 +798,7 @@ func (txm *Txm) GetTransactionStatus(ctx context.Context, transactionID string) 
 	}
 
 	switch state {
-	case txmutils.Broadcasted:
+	case txmutils.Pending, txmutils.Broadcasted:
 		return commontypes.Pending, nil
 	case txmutils.Processed, txmutils.Confirmed:
 		return commontypes.Unconfirmed, nil
@@ -974,8 +990,8 @@ func (txm *Txm) InflightTxs() int {
 // Removes all signatures associated with the prior tx, cancels prior ctx, updates compute unit price and sets given blockhash for rebroadcasting.
 // Calls sendWithRetry directly to avoid enqueuing the transaction. It logs the error when rebroadcast fails and returns the new signature when successful.
 func (txm *Txm) rebroadcastWithGivenBlockhash(ctx context.Context, pTx pendingTx, blockhash solana.Hash, lastValidBlockHeight uint64) (solana.Signature, error) {
-	// Remove the previous tx from state
-	_, err := txm.txs.Remove(pTx.id)
+	// Revert tx state back to pending
+	err := txm.txs.RevertToPending(pTx.id)
 	if err != nil {
 		txm.lggr.Errorw("failed to remove tx", "id", pTx.id, "error", err)
 		return solana.Signature{}, err
@@ -1038,8 +1054,4 @@ func (txm *Txm) defaultTxConfig() txmutils.TxConfig {
 		ComputeUnitLimit:         txm.cfg.ComputeUnitLimitDefault(),
 		EstimateComputeUnitLimit: txm.cfg.EstimateComputeUnitLimit(),
 	}
-}
-
-func (txm *Txm) getPendingTx(txID string) (pendingTx, error) {
-	return txm.txs.GetPendingTx(txID)
 }

--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -727,9 +727,9 @@ func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Tran
 		id = *txID
 	}
 
-	_, err := txm.txs.GetTxState(id)
+	_, exists := txm.txs.GetTxState(id)
 	// Transaction for ID already exists. No-op to avoid creating another tx for the same ID.
-	if err == nil {
+	if exists {
 		txm.lggr.Infow("transaction already exists for ID", "id", id)
 		return nil
 	}
@@ -742,7 +742,7 @@ func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Tran
 	// validate expected key exists by trying to sign with it
 	// fee payer account is index 0 account
 	// https://github.com/gagliardetto/solana-go/blob/main/transaction.go#L252
-	_, err = txm.ks.Sign(ctx, tx.Message.AccountKeys[0].String(), nil)
+	_, err := txm.ks.Sign(ctx, tx.Message.AccountKeys[0].String(), nil)
 	if err != nil {
 		return fmt.Errorf("error in soltxm.Enqueue.GetKey: %w", err)
 	}
@@ -792,9 +792,9 @@ func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Tran
 
 // GetTransactionStatus translates internal TXM transaction statuses to chainlink common statuses
 func (txm *Txm) GetTransactionStatus(ctx context.Context, transactionID string) (commontypes.TransactionStatus, error) {
-	state, err := txm.txs.GetTxState(transactionID)
-	if err != nil {
-		return commontypes.Unknown, fmt.Errorf("failed to find transaction with id %s: %w", transactionID, err)
+	state, exists := txm.txs.GetTxState(transactionID)
+	if !exists {
+		return commontypes.Unknown, fmt.Errorf("failed to find transaction with id %s", transactionID)
 	}
 
 	switch state {
@@ -809,7 +809,7 @@ func (txm *Txm) GetTransactionStatus(ctx context.Context, transactionID string) 
 	case txmutils.FatallyErrored:
 		return commontypes.Fatal, nil
 	default:
-		return commontypes.Unknown, fmt.Errorf("found unknown transaction state: %s", state.String())
+		return commontypes.Unknown, fmt.Errorf("found unknown transaction state for id %s: %s", transactionID, state.String())
 	}
 }
 

--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -516,7 +516,7 @@ func (txm *Txm) handleErrorSignatureStatus(ctx context.Context, sig solanaGo.Sig
 // - Processed -> Not Found
 //
 // When a signature re-org is detected, the following steps are taken:
-// - Revert the prior transaction state to Pending and remove all associated signatures, and cancel the prior context.
+// - Revert the prior transaction state to AwaitingBroadcast and remove all associated signatures, and cancel the prior context.
 // - Rebroadcast the prior transaction with a new blockhash and an updated compute unit price.
 func (txm *Txm) handleReorg(ctx context.Context, client client.ReaderWriter, sig solanaGo.Signature, status *rpc.SignatureStatusesResult) {
 	// Determine if a re-org has occurred
@@ -528,7 +528,7 @@ func (txm *Txm) handleReorg(ctx context.Context, client client.ReaderWriter, sig
 
 	// At this point, we have detected a re-org. We need to rebroadcast the tx.
 	txm.lggr.Debugw("re-org detected for transaction", "txID", txID, "signature", sig)
-	pTx, err := txm.txs.GetReorgTx(txID)
+	pTx, err := txm.txs.GetPendingTx(txID)
 	if err != nil {
 		txm.lggr.Errorw("failed to get pending tx for rebroadcast", "txID", txID, "error", err)
 		return
@@ -798,7 +798,7 @@ func (txm *Txm) GetTransactionStatus(ctx context.Context, transactionID string) 
 	}
 
 	switch state {
-	case txmutils.Pending, txmutils.Broadcasted:
+	case txmutils.AwaitingBroadcast, txmutils.Broadcasted:
 		return commontypes.Pending, nil
 	case txmutils.Processed, txmutils.Confirmed:
 		return commontypes.Unconfirmed, nil
@@ -990,8 +990,8 @@ func (txm *Txm) InflightTxs() int {
 // Removes all signatures associated with the prior tx, cancels prior ctx, updates compute unit price and sets given blockhash for rebroadcasting.
 // Calls sendWithRetry directly to avoid enqueuing the transaction. It logs the error when rebroadcast fails and returns the new signature when successful.
 func (txm *Txm) rebroadcastWithGivenBlockhash(ctx context.Context, pTx pendingTx, blockhash solana.Hash, lastValidBlockHeight uint64) (solana.Signature, error) {
-	// Revert tx state back to pending
-	err := txm.txs.RevertToPending(pTx.id)
+	// Revert tx state back to AwaitingBroadcast
+	err := txm.txs.RevertToAwaitingBroadcast(pTx.id)
 	if err != nil {
 		txm.lggr.Errorw("failed to remove tx", "id", pTx.id, "error", err)
 		return solana.Signature{}, err

--- a/pkg/solana/txm/txm_integration_test.go
+++ b/pkg/solana/txm/txm_integration_test.go
@@ -255,7 +255,7 @@ func TestTxm_Integration_Reorg(t *testing.T) {
 				return false
 			}
 			if status == types.Unconfirmed {
-				pTx, errPtx := txmInstance.txs.GetReorgTx(txID)
+				pTx, errPtx := txmInstance.txs.GetPendingTx(txID)
 				if errPtx != nil || len(pTx.signatures) == 0 {
 					return false
 				}

--- a/pkg/solana/txm/txm_integration_test.go
+++ b/pkg/solana/txm/txm_integration_test.go
@@ -255,7 +255,7 @@ func TestTxm_Integration_Reorg(t *testing.T) {
 				return false
 			}
 			if status == types.Unconfirmed {
-				pTx, errPtx := txmInstance.getPendingTx(txID)
+				pTx, errPtx := txmInstance.txs.GetReorgTx(txID)
 				if errPtx != nil || len(pTx.signatures) == 0 {
 					return false
 				}

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -1208,6 +1208,14 @@ func TestTxm_Enqueue(t *testing.T) {
 			assert.Error(t, txm.Enqueue(ctx, run.name, run.tx, nil, run.lastValidBlockHeight))
 		})
 	}
+
+	t.Run("duplicate tx ID does not error", func(t *testing.T) {
+		id := uuid.NewString()
+		err := txm.Enqueue(ctx, "", tx, &id, 100)
+		require.NoError(t, err)
+		err = txm.Enqueue(ctx, "", tx, &id, 100)
+		require.NoError(t, err)
+	})
 }
 
 func addSigAndLimitToTx(t *testing.T, keystore SimpleKeystore, pubkey solana.PublicKey, tx solana.Transaction, limit fees.ComputeUnitLimit) *solana.Transaction {
@@ -1790,4 +1798,91 @@ func TestTxm_OnReorg(t *testing.T) {
 			require.Equal(t, types.Finalized, status)
 		})
 	}
+}
+
+func TestTxm_GetTransactionStatus(t *testing.T) {
+	// set up configs needed in txm
+	lggr := logger.Test(t)
+	ctx := tests.Context(t)
+	_, cancel := context.WithCancel(ctx)
+
+	// set up configs needed in txm
+	estimator := "fixed"
+	id := "mocknet-" + estimator + "-" + uuid.NewString()
+
+	cfg := config.NewDefault()
+	cfg.Chain.FeeEstimatorMode = &estimator
+	// Enable retention timeout to keep transactions after finality or error
+	cfg.Chain.TxRetentionTimeout = relayconfig.MustNewDuration(5 * time.Second)
+	mc := mocks.NewReaderWriter(t)
+
+	// mock solana keystore
+	mkey := keyMocks.NewSimpleKeystore(t)
+
+	loader := utils.NewStaticLoader[client.ReaderWriter](mc)
+	txm := NewTxm(id, loader, nil, cfg, mkey, lggr)
+
+	msg := pendingTx{id: uuid.NewString()}
+
+	// Create new tx in pending state
+	err := txm.txs.New(msg)
+	require.NoError(t, err)
+	state, err := txm.GetTransactionStatus(ctx, msg.id)
+	require.NoError(t, err)
+	require.Equal(t, commontypes.Pending, state)
+
+	// Move tx to broadcasted state
+	err = txm.txs.OnBroadcasted(msg)
+	require.NoError(t, err)
+	state, err = txm.GetTransactionStatus(ctx, msg.id)
+	require.NoError(t, err)
+	require.Equal(t, commontypes.Pending, state)
+
+	sig := randomSignature(t)
+	txm.txs.AddSignature(cancel, msg.id, sig)
+
+	// Move tx to processed state
+	msgId, err := txm.txs.OnProcessed(sig)
+	require.NoError(t, err)
+	require.Equal(t, msg.id, msgId)
+	state, err = txm.GetTransactionStatus(ctx, msg.id)
+	require.NoError(t, err)
+	require.Equal(t, commontypes.Unconfirmed, state)
+
+	// Move tx to confirmed state
+	msgId, err = txm.txs.OnConfirmed(sig)
+	require.NoError(t, err)
+	require.Equal(t, msg.id, msgId)
+	state, err = txm.GetTransactionStatus(ctx, msg.id)
+	require.NoError(t, err)
+	require.Equal(t, commontypes.Unconfirmed, state)
+
+	// Move tx to finalized state
+	msgId, err = txm.txs.OnFinalized(sig, 1*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, msg.id, msgId)
+	state, err = txm.GetTransactionStatus(ctx, msg.id)
+	require.NoError(t, err)
+	require.Equal(t, commontypes.Finalized, state)
+
+	// Add errored tx
+	errMsg := pendingTx{id: uuid.NewString()}
+	err = txm.txs.OnPrebroadcastError(errMsg.id, 1*time.Second, txmutils.Errored, TxFailReject)
+	require.NoError(t, err)
+	state, err = txm.GetTransactionStatus(ctx, errMsg.id)
+	require.NoError(t, err)
+	require.Equal(t, commontypes.Failed, state)
+
+	// Add fatally errored tx
+	fatalMsg := pendingTx{id: uuid.NewString()}
+	err = txm.txs.OnPrebroadcastError(fatalMsg.id, 1*time.Second, txmutils.FatallyErrored, TxFailReject)
+	require.NoError(t, err)
+	state, err = txm.GetTransactionStatus(ctx, fatalMsg.id)
+	require.NoError(t, err)
+	require.Equal(t, commontypes.Fatal, state)
+
+	// Unknown tx returns error
+	state, err = txm.GetTransactionStatus(ctx, uuid.NewString())
+	require.Error(t, err)
+	require.Equal(t, commontypes.Unknown, state)
 }

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -23,7 +23,6 @@ import (
 	relayconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	bigmath "github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
@@ -1124,7 +1123,7 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 		// tx should be stored in-memory and moved to errored state
 		status, err := txm.GetTransactionStatus(ctx, txID)
 		require.NoError(t, err)
-		require.Equal(t, commontypes.Fatal, status)
+		require.Equal(t, types.Fatal, status)
 	})
 }
 
@@ -1829,14 +1828,14 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 	require.NoError(t, err)
 	state, err := txm.GetTransactionStatus(ctx, msg.id)
 	require.NoError(t, err)
-	require.Equal(t, commontypes.Pending, state)
+	require.Equal(t, types.Pending, state)
 
 	// Move tx to broadcasted state
 	err = txm.txs.OnBroadcasted(msg)
 	require.NoError(t, err)
 	state, err = txm.GetTransactionStatus(ctx, msg.id)
 	require.NoError(t, err)
-	require.Equal(t, commontypes.Pending, state)
+	require.Equal(t, types.Pending, state)
 
 	sig := randomSignature(t)
 	txm.txs.AddSignature(cancel, msg.id, sig)
@@ -1847,7 +1846,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 	require.Equal(t, msg.id, msgId)
 	state, err = txm.GetTransactionStatus(ctx, msg.id)
 	require.NoError(t, err)
-	require.Equal(t, commontypes.Unconfirmed, state)
+	require.Equal(t, types.Unconfirmed, state)
 
 	// Move tx to confirmed state
 	msgId, err = txm.txs.OnConfirmed(sig)
@@ -1855,7 +1854,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 	require.Equal(t, msg.id, msgId)
 	state, err = txm.GetTransactionStatus(ctx, msg.id)
 	require.NoError(t, err)
-	require.Equal(t, commontypes.Unconfirmed, state)
+	require.Equal(t, types.Unconfirmed, state)
 
 	// Move tx to finalized state
 	msgId, err = txm.txs.OnFinalized(sig, 1*time.Second)
@@ -1863,7 +1862,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 	require.Equal(t, msg.id, msgId)
 	state, err = txm.GetTransactionStatus(ctx, msg.id)
 	require.NoError(t, err)
-	require.Equal(t, commontypes.Finalized, state)
+	require.Equal(t, types.Finalized, state)
 
 	// Add errored tx
 	errMsg := pendingTx{id: uuid.NewString()}
@@ -1871,7 +1870,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 	require.NoError(t, err)
 	state, err = txm.GetTransactionStatus(ctx, errMsg.id)
 	require.NoError(t, err)
-	require.Equal(t, commontypes.Failed, state)
+	require.Equal(t, types.Failed, state)
 
 	// Add fatally errored tx
 	fatalMsg := pendingTx{id: uuid.NewString()}
@@ -1879,10 +1878,10 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 	require.NoError(t, err)
 	state, err = txm.GetTransactionStatus(ctx, fatalMsg.id)
 	require.NoError(t, err)
-	require.Equal(t, commontypes.Fatal, state)
+	require.Equal(t, types.Fatal, state)
 
 	// Unknown tx returns error
 	state, err = txm.GetTransactionStatus(ctx, uuid.NewString())
 	require.Error(t, err)
-	require.Equal(t, commontypes.Unknown, state)
+	require.Equal(t, types.Unknown, state)
 }

--- a/pkg/solana/txm/txm_race_test.go
+++ b/pkg/solana/txm/txm_race_test.go
@@ -68,8 +68,9 @@ func TestTxm_SendWithRetry_Race(t *testing.T) {
 		txm.fee = fee
 
 		msg.cfg = txm.defaultTxConfig()
-
-		_, _, _, err := txm.sendWithRetry(tests.Context(t), msg)
+		err := txm.txs.New(msg)
+		require.NoError(t, err)
+		_, _, _, err = txm.sendWithRetry(tests.Context(t), msg)
 		require.NoError(t, err)
 
 		time.Sleep(txRetryDuration / 4 * 5)                                     // wait 1.25x longer of tx life to capture all logs

--- a/pkg/solana/txm/utils/utils.go
+++ b/pkg/solana/txm/utils/utils.go
@@ -23,6 +23,7 @@ type TxState int
 const (
 	NotFound TxState = iota
 	Errored
+	Pending
 	Broadcasted
 	Processed
 	Confirmed
@@ -36,6 +37,8 @@ func (s TxState) String() string {
 		return "NotFound"
 	case Errored:
 		return "Errored"
+	case Pending:
+		return "Pending"
 	case Broadcasted:
 		return "Broadcasted"
 	case Processed:

--- a/pkg/solana/txm/utils/utils.go
+++ b/pkg/solana/txm/utils/utils.go
@@ -23,7 +23,7 @@ type TxState int
 const (
 	NotFound TxState = iota
 	Errored
-	Pending
+	AwaitingBroadcast
 	Broadcasted
 	Processed
 	Confirmed
@@ -37,8 +37,8 @@ func (s TxState) String() string {
 		return "NotFound"
 	case Errored:
 		return "Errored"
-	case Pending:
-		return "Pending"
+	case AwaitingBroadcast:
+		return "AwaitingBroadcast"
 	case Broadcasted:
 		return "Broadcasted"
 	case Processed:


### PR DESCRIPTION
- Added pending state to internal transaction states in TXM
- Created new state map to store pending transactions
- Add transactions to in-memory store on `Enqueue`