### PR TITLE
Updated compute unit limit estimation to use provided limit as a cap

### DIFF
--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -748,14 +748,11 @@ func (txm *Txm) Enqueue(ctx context.Context, accountID string, tx *solanaGo.Tran
 	// Perform compute unit limit estimation after storing transaction
 	// If error found during simulation, transaction should be in storage to mark accordingly
 	if cfg.EstimateComputeUnitLimit {
-		computeUnitLimit, err := txm.EstimateComputeUnitLimit(ctx, tx, id)
+		computeUnitLimit, err := txm.EstimateComputeUnitLimit(ctx, tx, id, cfg.ComputeUnitLimit)
 		if err != nil {
 			return fmt.Errorf("transaction failed simulation: %w", err)
 		}
-		// If estimation returns 0 compute unit limit without error, fallback to original config
-		if computeUnitLimit != 0 {
-			cfg.ComputeUnitLimit = computeUnitLimit
-		}
+		cfg.ComputeUnitLimit = computeUnitLimit
 	}
 
 	msg := pendingTx{
@@ -799,7 +796,7 @@ func (txm *Txm) GetTransactionStatus(ctx context.Context, transactionID string) 
 
 // EstimateComputeUnitLimit estimates the compute unit limit needed for a transaction.
 // It simulates the provided transaction to determine the used compute and applies a buffer to it.
-func (txm *Txm) EstimateComputeUnitLimit(ctx context.Context, tx *solanaGo.Transaction, id string) (uint32, error) {
+func (txm *Txm) EstimateComputeUnitLimit(ctx context.Context, tx *solanaGo.Transaction, id string, providedComputeUnitLimit uint32) (uint32, error) {
 	txCopy := *tx
 
 	// Set max compute unit limit when simulating a transaction to avoid getting an error for exceeding the default 200k compute unit limit
@@ -840,25 +837,35 @@ func (txm *Txm) EstimateComputeUnitLimit(ctx context.Context, tx *solanaGo.Trans
 			}
 			err := txm.txs.OnPrebroadcastError(id, txm.cfg.TxRetentionTimeout(), txState, errType)
 			if err != nil {
-				return 0, fmt.Errorf("failed to process error %v for tx ID %s: %w", res.Err, id, err)
+				return 0, fmt.Errorf("failed to mark tx ID %s as %s: %w", id, txState, err)
 			}
 		}
 		return 0, fmt.Errorf("simulated tx returned error: %v", res.Err)
 	}
 
 	if res.UnitsConsumed == nil || *res.UnitsConsumed == 0 {
-		txm.lggr.Debug("failed to get units consumed for tx")
-		// Do not return error to allow falling back to default compute unit limit
-		return 0, nil
+		// Return error if units consumed is not estimated since it is required to verify the provided limit
+		return 0, fmt.Errorf("failed to get units consumed for tx: %s", id)
 	}
 
 	unitsConsumed := *res.UnitsConsumed
 	// Add buffer to the used compute estimate
-	computeUnitLimit := bigmath.AddPercentage(new(big.Int).SetUint64(unitsConsumed), EstimateComputeUnitLimitBuffer).Uint64()
+	estimatedComputeUnitLimit := bigmath.AddPercentage(new(big.Int).SetUint64(unitsConsumed), EstimateComputeUnitLimitBuffer).Uint64()
 	// Ensure computeUnitLimit does not exceed the max compute unit limit for a transaction after adding buffer
-	computeUnitLimit = mathutil.Min(computeUnitLimit, MaxComputeUnitLimit)
+	estimatedComputeUnitLimit = mathutil.Min(estimatedComputeUnitLimit, MaxComputeUnitLimit)
 
-	return uint32(computeUnitLimit), nil //nolint // computeUnitLimit can only be a maximum of 1.4M
+	// Validate that the estimated compute unit limit does not exceed the provided limit
+	// If it does, mark the transaction as fatally errored to avoid broadcasting and wasting funds
+	if estimatedComputeUnitLimit > uint64(providedComputeUnitLimit) {
+		// NoFailure provided as the TxErrType since there isn't a metric to increment for this type of error
+		err := txm.txs.OnPrebroadcastError(id, txm.cfg.TxRetentionTimeout(), txmutils.FatallyErrored, NoFailure)
+		if err != nil {
+			return 0, fmt.Errorf("failed to mark tx ID %s as %s: %w", id, txmutils.FatallyErrored, err)
+		}
+		return 0, fmt.Errorf("estimated compute unit limit %d for tx ID %s exceeds the provided limit %d", estimatedComputeUnitLimit, id, providedComputeUnitLimit)
+	}
+
+	return uint32(estimatedComputeUnitLimit), nil //nolint // computeUnitLimit can only be a maximum of 1.4M
 }
 
 // simulateTx simulates transactions using the SimulateTx client method

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -1037,7 +1037,8 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(3)
 
-		computeUnitConsumed := uint64(1_000_000)
+		// use low enough compute unit limit so it does not exceed the default limit with the buffer
+		computeUnitConsumed := uint64(100)
 		computeUnitLimit := fees.ComputeUnitLimit(uint32(bigmath.AddPercentage(new(big.Int).SetUint64(computeUnitConsumed), EstimateComputeUnitLimitBuffer).Uint64()))
 		mc.On("SendTx", mock.Anything, signed(0, true, computeUnitLimit)).Return(sig, nil)
 		// First simulation before broadcast with signature and max compute unit limit set
@@ -1073,7 +1074,7 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 		// send tx
 		testTxID := uuid.New().String()
 		lastValidBlockHeight := uint64(100)
-		assert.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, lastValidBlockHeight))
+		require.NoError(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, lastValidBlockHeight))
 		wg.Wait()
 
 		// no transactions stored inflight txs list
@@ -1103,7 +1104,7 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 
 		// tx should NOT be able to queue
 		lastValidBlockHeight := uint64(0)
-		assert.Error(t, txm.Enqueue(ctx, t.Name(), tx, nil, lastValidBlockHeight))
+		require.Error(t, txm.Enqueue(ctx, t.Name(), tx, nil, lastValidBlockHeight))
 	})
 
 	t.Run("simulation_returns_error", func(t *testing.T) {
@@ -1120,11 +1121,37 @@ func TestTxm_compute_unit_limit_estimation(t *testing.T) {
 		txID := uuid.NewString()
 		lastValidBlockHeight := uint64(100)
 		// tx should NOT be able to queue
-		assert.Error(t, txm.Enqueue(ctx, t.Name(), tx, &txID, lastValidBlockHeight))
+		require.Error(t, txm.Enqueue(ctx, t.Name(), tx, &txID, lastValidBlockHeight))
 		// tx should be stored in-memory and moved to errored state
 		status, err := txm.GetTransactionStatus(ctx, txID)
 		require.NoError(t, err)
 		require.Equal(t, commontypes.Fatal, status)
+	})
+
+	t.Run("simulation_estimates_higher_limit_than_provided", func(t *testing.T) {
+		// Test tx is not discarded due to confirm timeout and tracked to finalization
+		// use unique val across tests to avoid collision during mocking
+		tx, _ := getTx(t, 1, mkey)
+		// add signature and compute unit limit to tx for simulation (excludes compute unit price)
+		simulateTx := addSigAndLimitToTx(t, mkey, solana.PublicKey{}, *tx, MaxComputeUnitLimit)
+		var wg sync.WaitGroup
+		wg.Add(3)
+
+		// use low enough compute unit limit so it does not exceed the default limit with the buffer
+		computeUnitConsumed := uint64(cfg.ComputeUnitLimitDefault())
+		// First simulation before broadcast that estimates compute units used
+		mc.On("SimulateTx", mock.Anything, simulateTx, mock.Anything).Run(func(mock.Arguments) {
+			wg.Done()
+		}).Return(&rpc.SimulateTransactionResult{UnitsConsumed: &computeUnitConsumed}, nil).Once()
+
+		// send tx
+		testTxID := uuid.New().String()
+		lastValidBlockHeight := uint64(100)
+		require.Error(t, txm.Enqueue(ctx, t.Name(), tx, &testTxID, lastValidBlockHeight))
+
+		status, err := txm.GetTransactionStatus(ctx, testTxID)
+		require.NoError(t, err)
+		require.Equal(t, types.Fatal, status)
 	})
 }
 

--- a/pkg/solana/txm/txm_unit_test.go
+++ b/pkg/solana/txm/txm_unit_test.go
@@ -51,7 +51,7 @@ func TestTxm_EstimateComputeUnitLimit(t *testing.T) {
 	loader := utils.NewStaticLoader[solanaClient.ReaderWriter](client)
 	txm := solanatxm.NewTxm("localnet", loader, nil, cfg, mkey, lggr)
 
-	t.Run("successfully sets estimated compute unit limit", func(t *testing.T) {
+	t.Run("successfully estimates compute unit limit", func(t *testing.T) {
 		usedCompute := uint64(100)
 		client.On("LatestBlockhash", mock.Anything).Return(&rpc.GetLatestBlockhashResult{
 			Value: &rpc.LatestBlockhashResult{
@@ -74,7 +74,7 @@ func TestTxm_EstimateComputeUnitLimit(t *testing.T) {
 			UnitsConsumed: &usedCompute,
 		}, nil).Once()
 		tx := createTx(t, client, pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
-		computeUnitLimit, estimateErr := txm.EstimateComputeUnitLimit(ctx, tx, "")
+		computeUnitLimit, estimateErr := txm.EstimateComputeUnitLimit(ctx, tx, "", cfg.ComputeUnitLimitDefault())
 		require.NoError(t, estimateErr)
 		usedComputeWithBuffer := bigmath.AddPercentage(new(big.Int).SetUint64(usedCompute), solanatxm.EstimateComputeUnitLimitBuffer).Uint64()
 		require.Equal(t, usedComputeWithBuffer, uint64(computeUnitLimit))
@@ -89,7 +89,7 @@ func TestTxm_EstimateComputeUnitLimit(t *testing.T) {
 		}, nil).Once()
 		client.On("SimulateTx", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("failed to simulate")).Once()
 		tx := createTx(t, client, pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
-		_, estimateErr := txm.EstimateComputeUnitLimit(ctx, tx, "")
+		_, estimateErr := txm.EstimateComputeUnitLimit(ctx, tx, "", cfg.ComputeUnitLimitDefault())
 		require.Error(t, estimateErr)
 	})
 
@@ -104,11 +104,11 @@ func TestTxm_EstimateComputeUnitLimit(t *testing.T) {
 			Err: errors.New("InstructionError"),
 		}, nil).Once()
 		tx := createTx(t, client, pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
-		_, err = txm.EstimateComputeUnitLimit(ctx, tx, "")
+		_, err = txm.EstimateComputeUnitLimit(ctx, tx, "", cfg.ComputeUnitLimitDefault())
 		require.Error(t, err)
 	})
 
-	t.Run("simulation returns nil err with 0 compute unit limit", func(t *testing.T) {
+	t.Run("simulation returns error if simulated compute unit limit is 0", func(t *testing.T) {
 		client.On("LatestBlockhash", mock.Anything).Return(&rpc.GetLatestBlockhashResult{
 			Value: &rpc.LatestBlockhashResult{
 				LastValidBlockHeight: 100,
@@ -119,9 +119,8 @@ func TestTxm_EstimateComputeUnitLimit(t *testing.T) {
 			Err: nil,
 		}, nil).Once()
 		tx := createTx(t, client, pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
-		computeUnitLimit, err := txm.EstimateComputeUnitLimit(ctx, tx, "")
-		require.NoError(t, err)
-		require.Equal(t, uint32(0), computeUnitLimit)
+		_, err := txm.EstimateComputeUnitLimit(ctx, tx, "", cfg.ComputeUnitLimitDefault())
+		require.Error(t, err)
 	})
 
 	t.Run("simulation returns max compute unit limit if adding buffer exceeds it", func(t *testing.T) {
@@ -147,9 +146,36 @@ func TestTxm_EstimateComputeUnitLimit(t *testing.T) {
 			UnitsConsumed: &usedCompute,
 		}, nil).Once()
 		tx := createTx(t, client, pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
-		computeUnitLimit, err := txm.EstimateComputeUnitLimit(ctx, tx, "")
+		computeUnitLimit, err := txm.EstimateComputeUnitLimit(ctx, tx, "", uint32(usedCompute))
 		require.NoError(t, err)
 		require.Equal(t, uint32(1_400_000), computeUnitLimit)
+	})
+
+	t.Run("simulation returns error if estimated compute unit limit exceeds the provided limit", func(t *testing.T) {
+		usedCompute := uint64(1_400_000)
+		client.On("LatestBlockhash", mock.Anything).Return(&rpc.GetLatestBlockhashResult{
+			Value: &rpc.LatestBlockhashResult{
+				LastValidBlockHeight: 100,
+				Blockhash:            solana.Hash{},
+			},
+		}, nil).Once()
+		client.On("SimulateTx", mock.Anything, mock.IsType(&solana.Transaction{}), mock.IsType(&rpc.SimulateTransactionOpts{})).Run(func(args mock.Arguments) {
+			// Validate max compute unit limit is set in transaction
+			tx := args.Get(1).(*solana.Transaction)
+			limit, err := fees.ParseComputeUnitLimit(tx.Message.Instructions[len(tx.Message.Instructions)-1].Data)
+			require.NoError(t, err)
+			require.Equal(t, fees.ComputeUnitLimit(solanatxm.MaxComputeUnitLimit), limit)
+
+			// Validate signature verification is enabled
+			opts := args.Get(2).(*rpc.SimulateTransactionOpts)
+			require.True(t, opts.SigVerify)
+		}).Return(&rpc.SimulateTransactionResult{
+			Err:           nil,
+			UnitsConsumed: &usedCompute,
+		}, nil).Once()
+		tx := createTx(t, client, pubKey, pubKey, pubKeyReceiver, solana.LAMPORTS_PER_SOL)
+		_, err := txm.EstimateComputeUnitLimit(ctx, tx, "", cfg.ComputeUnitLimitDefault())
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
### Context
The existing compute unit limit estimation would ignore the provided limit and allow any limit to be set to ensure transaction success. This behavior is problematic for some products where the compute unit limits need to be capped to ensure our cost does not exceed what the user has paid for

### Changes
Updated the compute unit limit estimation to compare the estimated limit against the provided limit. If the estimated value (+buffer) exceeds the provided limit, broadcast is prevented to avoid wasted gas and the transaction is marked as fatal to avoid future rebroadcast.