### PR TITLE
Bump chainlink-ccip tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/smartcontractkit/chainlink-solana
 
-go 1.23.3
+go 1.24
+
+toolchain go1.24.0
 
 require (
 	github.com/cometbft/cometbft v0.37.5
@@ -18,7 +20,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/prometheus/client_golang v1.20.5
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250203132120-f0d42463e405
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250303180513-6bfa4f0a7b98
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250206215114-fb6c3c35e8e3
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250224210553-dc2073fe0d21
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250211162441-3d6cea220efb

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/smartcontractkit/chainlink-solana
 
-go 1.24
-
-toolchain go1.24.0
+go 1.23.3
 
 require (
 	github.com/cometbft/cometbft v0.37.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/smartcontractkit/chainlink-solana
 
-go 1.23.3
+go 1.24
+
+toolchain go1.24.0
 
 require (
 	github.com/cometbft/cometbft v0.37.5

--- a/go.sum
+++ b/go.sum
@@ -580,8 +580,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250203132120-f0d42463e405 h1:5QyaPGLmt+rlnvQL7drAE23Wq9rX5hO35kTZirAb97A=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250203132120-f0d42463e405/go.mod h1:UEnHaxkUsfreeA7rR45LMmua1Uen95tOFUR8/AI9BAo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250303180513-6bfa4f0a7b98 h1:T2uQaJTNZFTstMmz63wHlD2wNQLg5MPuv5YbwEJxAUg=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250303180513-6bfa4f0a7b98/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250206215114-fb6c3c35e8e3 h1:f4F/7OCuMybsPKKXXvLQz+Q1hGq07I1cfoWy5EA9iRg=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250206215114-fb6c3c35e8e3/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250224210553-dc2073fe0d21 h1:8FxTTGngs5S6TyByl75Nu8udjONelk9ezCOlW+3PF9w=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -1,6 +1,8 @@
 module github.com/smartcontractkit/chainlink-solana/integration-tests
 
-go 1.23.3
+go 1.24
+
+toolchain go1.24.0
 
 replace github.com/smartcontractkit/chainlink-solana => ../
 

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -1,8 +1,6 @@
 module github.com/smartcontractkit/chainlink-solana/integration-tests
 
-go 1.24
-
-toolchain go1.24.0
+go 1.23.3
 
 replace github.com/smartcontractkit/chainlink-solana => ../
 

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -1,6 +1,8 @@
 module github.com/smartcontractkit/chainlink-solana/integration-tests
 
-go 1.23.3
+go 1.24
+
+toolchain go1.24.0
 
 replace github.com/smartcontractkit/chainlink-solana => ../
 
@@ -14,7 +16,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/rs/zerolog v1.33.0
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250212131315-e9b53b05b02a
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250303180513-6bfa4f0a7b98
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250210201649-d9b9b053905e
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250224210553-dc2073fe0d21
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250213035259-e727e73f6181

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1100,8 +1100,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250212131315-e9b53b05b02a h1:iciffyGz76BiyILT8WSHePGr2C9v5PYK+PKwcW5ETLw=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250212131315-e9b53b05b02a/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250303180513-6bfa4f0a7b98 h1:T2uQaJTNZFTstMmz63wHlD2wNQLg5MPuv5YbwEJxAUg=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250303180513-6bfa4f0a7b98/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250210201649-d9b9b053905e h1:ivjjw4j0psSIRfEdGa5WSqXlV6KJ1CPb61Entm7fdVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250210201649-d9b9b053905e/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250224210553-dc2073fe0d21 h1:8FxTTGngs5S6TyByl75Nu8udjONelk9ezCOlW+3PF9w=


### PR DESCRIPTION
- Bump tag to fix dependency issue when bumping in `chainlink` repo to fix tests caused by this `chainlink-ccip` PR: https://github.com/smartcontractkit/chainlink-ccip/pull/526