### PR TITLE
Parallel Decode for Contract Reader

### DIFF
--- a/pkg/solana/chainreader/event_read_binding.go
+++ b/pkg/solana/chainreader/event_read_binding.go
@@ -2,6 +2,7 @@ package chainreader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -373,7 +374,25 @@ func (b *eventReadBinding) decodeLogsIntoSequences(
 	logs []logpoller.Log,
 	into any,
 ) ([]types.Sequence, error) {
+	var (
+		wg  sync.WaitGroup
+		err error
+	)
+
 	sequences := make([]types.Sequence, len(logs))
+	chErrs := make(chan error, 1)
+	chDone := make(chan struct{}, 1)
+
+	go func() {
+		select {
+		case fErr := <-chErrs:
+			if fErr != nil {
+				err = errors.Join(err, fErr)
+			}
+		case <-chDone:
+			return
+		}
+	}()
 
 	for idx := range logs {
 		sequences[idx] = types.Sequence{
@@ -397,9 +416,22 @@ func (b *eventReadBinding) decodeLogsIntoSequences(
 		// create a new value of the same type as 'into' for the data to be extracted to
 		sequences[idx].Data = typeVal.Interface()
 
-		if err := b.decodeLog(ctx, &logs[idx], sequences[idx].Data); err != nil {
-			return nil, err
-		}
+		wg.Add(1)
+		go func(ctx context.Context, log *logpoller.Log, into any, errs chan error) {
+			defer wg.Done()
+
+			if lErr := b.decodeLog(ctx, log, into); lErr != nil {
+				errs <- lErr
+			}
+		}(ctx, &logs[idx], sequences[idx].Data, chErrs)
+	}
+
+	wg.Wait()
+
+	chDone <- struct{}{}
+
+	if err != nil {
+		return nil, err
 	}
 
 	return sequences, nil

--- a/pkg/solana/codec/decoder_test.go
+++ b/pkg/solana/codec/decoder_test.go
@@ -1,11 +1,15 @@
 package codec
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	commoncodec "github.com/smartcontractkit/chainlink-common/pkg/codec"
 	commonencodings "github.com/smartcontractkit/chainlink-common/pkg/codec/encodings"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
@@ -80,3 +84,175 @@ func TestDecoder_GetMaxDecodingSize_Errors(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+type UnknownAddress []byte
+
+type Bytes32 [32]byte
+
+type MerkleRoot struct {
+	SourceChainSelector uint64
+	OnRampAddress       UnknownAddress
+	MinSeqNr            uint64
+	MaxSeqNr            uint64
+	MerkleRoot          Bytes32
+}
+
+type TokenPriceUpdate struct {
+	SourceToken UnknownAddress
+	UsdPerToken *big.Int
+}
+
+type GasPriceUpdate struct {
+	DestChainSelector uint64
+	UsdPerUnitGas     *big.Int
+}
+
+type PriceUpdates struct {
+	TokenPriceUpdates []TokenPriceUpdate
+	GasPriceUpdates   []GasPriceUpdate
+}
+
+type CommitReportAcceptedEvent struct {
+	BlessedMerkleRoots   []MerkleRoot
+	UnblessedMerkleRoots []MerkleRoot
+	PriceUpdates         PriceUpdates
+}
+
+func BenchmarkDecode(b *testing.B) {
+	b.StopTimer()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(cancel)
+
+	// create a new codec
+	rmCodec := setupCodec(b)
+	encoded, err := rmCodec.Encode(ctx, createTestStruct(b), WrapItemType(true, "Contract", "CommitReportAcceptedEvent"))
+
+	require.NoError(b, err)
+
+	b.StartTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		var into CommitReportAcceptedEvent
+
+		require.NoError(b, rmCodec.Decode(ctx, encoded, &into, WrapItemType(false, "Contract", "CommitReportAcceptedEvent")))
+	}
+}
+
+type TestingT interface {
+	require.TestingT
+	Helper()
+}
+
+func setupCodec(t TestingT) commontypes.RemoteCodec {
+	t.Helper()
+
+	// create an IDL that defines the expected encoded type
+	var idl IDL
+	require.NoError(t, json.Unmarshal([]byte(benchmarkIDL), &idl))
+
+	def, err := FindDefinitionFromIDL(ChainConfigTypeEventDef, "CommitReportAcceptedEvent", idl)
+
+	require.NoError(t, err)
+
+	mods := commoncodec.MultiModifier{
+		commoncodec.NewConstrainedLengthBytesToStringModifier([]string{"BlessedMerkleRoots.MerkleRoot"}, 32),
+	}
+
+	entry, err := CreateCodecEntry(def, "CommitReportAcceptedEvent", idl, mods)
+
+	require.NoError(t, err)
+
+	parsed := &ParsedTypes{
+		EncoderDefs: map[string]Entry{WrapItemType(true, "Contract", "CommitReportAcceptedEvent"): entry},
+		DecoderDefs: map[string]Entry{WrapItemType(false, "Contract", "CommitReportAcceptedEvent"): entry},
+	}
+
+	rmCodec, err := parsed.ToCodec()
+
+	require.NoError(t, err)
+
+	return rmCodec
+}
+
+func createTestStruct(t TestingT) CommitReportAcceptedEvent {
+	t.Helper()
+
+	return CommitReportAcceptedEvent{
+		BlessedMerkleRoots:   []MerkleRoot{},
+		UnblessedMerkleRoots: []MerkleRoot{},
+		PriceUpdates: PriceUpdates{
+			TokenPriceUpdates: []TokenPriceUpdate{},
+			GasPriceUpdates: []GasPriceUpdate{
+				{789068866484373046, big.NewInt(40000000028000)},
+				{909606746561742123, big.NewInt(40000000028000)},
+				{3379446385462418246, big.NewInt(4000000000000)},
+				{5721565186521185178, big.NewInt(40000000028000)},
+				{12922642891491394802, big.NewInt(40000000028000)},
+			},
+		},
+	}
+}
+
+const benchmarkIDL = `
+{
+	"version": "0.1.0",
+	"name": "benchmark_idl",
+	"types": [
+		{
+			"name": "MerkleRoot",
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{ "name": "SourceChainSelector", "type": "u64" },
+					{ "name": "OnRampAddress", "type": "publicKey" },
+					{ "name": "MinSeqNr", "type": "u64" },
+					{ "name": "MaxSeqNr", "type": "u64" },
+					{ "name": "MerkleRoot", "type": { "array": ["u8", 32] } }
+				]
+			}
+		},
+		{
+			"name": "TokenPriceUpdate",
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{ "name": "SourceToken", "type": "publicKey" },
+					{ "name": "UsdPerToken", "type": "i128" }	
+				]
+			}
+		},
+		{
+			"name": "GasPriceUpdate",
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{ "name": "DestChainSelector", "type": "u64" },
+					{ "name": "UsdPerUnitGas", "type": "i128" }	
+				]
+			}
+		},
+		{
+			"name": "PriceUpdates",
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{ "name": "TokenPriceUpdates", "type": { "vec": { "defined": "TokenPriceUpdate" } } },
+					{ "name": "GasPriceUpdates", "type": { "vec": { "defined": "GasPriceUpdate" } } }	
+				]
+			}
+		}
+	],
+	"events": [
+		{
+			"name": "CommitReportAcceptedEvent",
+			"fields": [
+				{"name": "BlessedMerkleRoots", "type": {"vec": {"defined": "MerkleRoot"}}},
+				{"name": "UnblessedMerkleRoots", "type": {"vec": {"defined": "MerkleRoot"}}},
+				{"name": "PriceUpdates", "type": {"defined": "PriceUpdates"}}
+			]
+		}
+	]
+}
+`


### PR DESCRIPTION
### Description

Run event decode process in parallel for each event instead of in sequence to reduce call latency.

Included is a benchmark that shows the time required to decode a standard CCIP event.