### PR TITLE
Add support for including logs from reverted transactions

### DIFF
--- a/pkg/solana/logpoller/filters.go
+++ b/pkg/solana/logpoller/filters.go
@@ -127,15 +127,15 @@ func (fl *filters) RegisterFilter(ctx context.Context, filter Filter) error {
 		}
 
 		fl.removeFilterFromIndexes(*existingFilter)
-	} else {
-		// ensure that the value of IncludeReverted isn't different from any other filters with the same address and event type
-		if contractFilters, okAddr := fl.filtersByAddress[filter.Address]; okAddr {
-			if similarFilters, okEv := contractFilters[filter.EventSig]; okEv {
-				for id := range similarFilters {
-					if conflicting := fl.filtersByID[id]; conflicting.IncludeReverted != filter.IncludeReverted {
-						return fmt.Errorf("IncludeReverted=%v for filter %v conflicts with IncludeReverted=%v for filter %v",
-							conflicting.IncludeReverted, conflicting, filter.IncludeReverted, filter)
-					}
+	}
+
+	// ensure that the value of IncludeReverted isn't different from any other filters with the same address and event type
+	if contractFilters, okAddr := fl.filtersByAddress[filter.Address]; okAddr {
+		if similarFilters, okEv := contractFilters[filter.EventSig]; okEv {
+			for id := range similarFilters {
+				if conflicting := fl.filtersByID[id]; conflicting.IncludeReverted != filter.IncludeReverted {
+					return fmt.Errorf("IncludeReverted=%v for filter %v conflicts with IncludeReverted=%v for filter %v",
+						conflicting.IncludeReverted, conflicting, filter.IncludeReverted, filter)
 				}
 			}
 		}

--- a/pkg/solana/logpoller/filters.go
+++ b/pkg/solana/logpoller/filters.go
@@ -131,7 +131,7 @@ func (fl *filters) RegisterFilter(ctx context.Context, filter Filter) error {
 		// ensure that the value of IncludeReverted isn't different from any other filters with the same address and event type
 		if contractFilters, okAddr := fl.filtersByAddress[filter.Address]; okAddr {
 			if similarFilters, okEv := contractFilters[filter.EventSig]; okEv {
-				for id, _ := range similarFilters {
+				for id := range similarFilters {
 					if conflicting := fl.filtersByID[id]; conflicting.IncludeReverted != filter.IncludeReverted {
 						return fmt.Errorf("IncludeReverted=%v for filter %v conflicts with IncludeReverted=%v for filter %v",
 							conflicting.IncludeReverted, conflicting, filter.IncludeReverted, filter)

--- a/pkg/solana/logpoller/filters.go
+++ b/pkg/solana/logpoller/filters.go
@@ -119,9 +119,26 @@ func (fl *filters) RegisterFilter(ctx context.Context, filter Filter) error {
 		if existingFilter.IsBackfilled {
 			// if existing filter was already backfilled, but starting block was higher we need to backfill filter again
 			filter.IsBackfilled = existingFilter.StartingBlock <= filter.StartingBlock
+
+			// also trigger a backfill if IncludeReverted is being updated from false to true
+			if !existingFilter.IncludeReverted && filter.IncludeReverted {
+				filter.IsBackfilled = false
+			}
 		}
 
 		fl.removeFilterFromIndexes(*existingFilter)
+	} else {
+		// ensure that the value of IncludeReverted isn't different from any other filters with the same address and event type
+		if contractFilters, okAddr := fl.filtersByAddress[filter.Address]; okAddr {
+			if similarFilters, okEv := contractFilters[filter.EventSig]; okEv {
+				for id, _ := range similarFilters {
+					if conflicting := fl.filtersByID[id]; conflicting.IncludeReverted != filter.IncludeReverted {
+						return fmt.Errorf("IncludeReverted=%v for filter %v conflicts with IncludeReverted=%v for filter %v",
+							conflicting.IncludeReverted, conflicting, filter.IncludeReverted, filter)
+					}
+				}
+			}
+		}
 	}
 
 	decoder, err := newDecoder(filter)

--- a/pkg/solana/logpoller/filters_test.go
+++ b/pkg/solana/logpoller/filters_test.go
@@ -1,6 +1,7 @@
 package logpoller
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -157,6 +158,52 @@ func TestFilters_RegisterFilter(t *testing.T) {
 				require.EqualError(t, err, ErrFilterNameConflict.Error())
 			})
 		}
+	})
+	t.Run("properly handles IncludeReverted field", func(t *testing.T) {
+		orm := NewMockORM(t)
+		fs := newFilters(lggr, orm)
+		addr := newRandomPublicKey(t)
+		eventSig := newRandomEventSignature(t)
+
+		filter1 := Filter{
+			ID:              1,
+			Name:            "existingFilter",
+			Address:         addr,
+			EventSig:        eventSig,
+			IncludeReverted: false,
+			IsBackfilled:    true,
+		}
+		orm.EXPECT().SelectFilters(mock.Anything).Return(
+			[]Filter{filter1}, nil).Once()
+		filter2 := Filter{
+			Name:            "new filter",
+			Address:         addr,
+			EventSig:        eventSig,
+			IncludeReverted: true,
+			IsBackfilled:    true,
+		}
+		orm.EXPECT().SelectSeqNums(mock.Anything).Return(nil, nil).Once()
+		err := fs.RegisterFilter(tests.Context(t), filter2)
+		require.ErrorContains(t, err, "conflicts with IncludeReverted=true", "shouldn't allow more than one value for IncludeReverted for an event")
+
+		orm.EXPECT().InsertFilter(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, filter Filter) (int64, error) {
+			assert.True(t, filter.IncludeReverted, "IncludeReverted should be true now")
+			assert.False(t, filter.IsBackfilled, "new backfill should be triggered when IsReverted updated from false to true")
+			return 2, nil
+		}).Once()
+		filter1.IncludeReverted = true // update IncludeReverted field of filter1 to true
+		err = fs.RegisterFilter(tests.Context(t), filter1)
+		require.NoError(t, err)
+
+		orm.EXPECT().InsertFilter(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, filter Filter) (int64, error) {
+			assert.True(t, filter.IncludeReverted)
+			assert.False(t, filter.IsBackfilled, "backfill should happen when new filter is added") // should trigger new backfill since reverted has been updated to true
+			return 3, nil
+		}).Once()
+
+		// should succeed this time
+		err = fs.RegisterFilter(tests.Context(t), filter2)
+		assert.NoError(t, err)
 	})
 	t.Run("Happy path", func(t *testing.T) {
 		orm := NewMockORM(t)

--- a/pkg/solana/logpoller/job_get_block.go
+++ b/pkg/solana/logpoller/job_get_block.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -103,11 +102,8 @@ func (j *getBlockJob) Run(ctx context.Context) error {
 		if txWithMeta.Meta == nil {
 			return fmt.Errorf("expected transaction to have meta. signature: %s; slot: %d; idx: %d", tx.Signatures[0], j.slotNumber, idx)
 		}
-		if txWithMeta.Meta.Err != nil {
-			// silently skip as at the moment there is no way for us to filter transactions produced by our contracts
-			continue
-		}
 		detail.trxSig = tx.Signatures[0] // according to Solana docs fist signature is used as ID
+		detail.err = txWithMeta.Meta.Err
 
 		txEvents := j.messagesToEvents(txWithMeta.Meta.LogMessages, detail)
 		events = append(events, txEvents...)
@@ -140,6 +136,7 @@ func (j *getBlockJob) messagesToEvents(messages []string, detail eventDetail) []
 			event.TransactionHash = detail.trxSig
 			event.TransactionIndex = detail.trxIdx
 			event.TransactionLogIndex = logIdx
+			event.Error = detail.err
 
 			logIdx++
 			outputs.Events[i] = event
@@ -158,4 +155,5 @@ type eventDetail struct {
 	blockTime   solana.UnixTimeSeconds
 	trxIdx      int
 	trxSig      solana.Signature
+	err         interface{}
 }

--- a/pkg/solana/logpoller/job_get_block_test.go
+++ b/pkg/solana/logpoller/job_get_block_test.go
@@ -191,6 +191,20 @@ func TestGetBlockJob(t *testing.T) {
 					Program: "myProgram",
 					Data:    "log3",
 				},
+				{
+					BlockData: BlockData{
+						SlotNumber:          slotNumber,
+						BlockHeight:         height,
+						BlockHash:           block.Blockhash,
+						BlockTime:           blockTime,
+						TransactionHash:     solana.Signature{10, 11},
+						TransactionLogIndex: 0,
+						TransactionIndex:    2,
+						Error:               fmt.Errorf("some error"),
+					},
+					Program: "myProgram",
+					Data:    "log4",
+				},
 			},
 		}, result)
 		select {

--- a/pkg/solana/logpoller/log_data_parser.go
+++ b/pkg/solana/logpoller/log_data_parser.go
@@ -23,6 +23,7 @@ type BlockData struct {
 	TransactionHash     solana.Signature
 	TransactionIndex    int
 	TransactionLogIndex uint
+	Error               interface{}
 }
 
 type ProgramLog struct {

--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
@@ -12,8 +13,6 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go/rpc"
-	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
@@ -147,21 +146,18 @@ func (lp *Service) Process(ctx context.Context, programEvent ProgramEvent) (err 
 	}
 
 	var logs []Log
-
 	for filter := range matchingFilters {
-		var revertErr error
+		var revertErr *string
 		if blockData.Error != nil {
-			switch e := blockData.Error.(type) {
-			case *jsonrpc.RPCError:
-				revertErr = fmt.Errorf("JsonRpcError %d: %s", e.Code, e.Message)
-			case error:
-				revertErr = e
-			default:
-				revertErr = fmt.Errorf("unknown type: %v", e)
-				lp.lggr.Warnf("received unknown revert error type %T for log with blockData=%v", revertErr, blockData)
-			}
 			if !filter.IncludeReverted {
-				continue // unless explicitly requested, discard reverted logs
+				continue
+			}
+			revertErr = new(string)
+			if j, err2 := json.Marshal(blockData.Error); err2 != nil {
+				*revertErr = fmt.Sprintf("%v", blockData.Error)
+				lp.lggr.Errorw("failed to marshal revert error", "revertErr", blockData.Error, "err", err2)
+			} else {
+				*revertErr = string(j)
 			}
 		}
 

--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -146,7 +147,24 @@ func (lp *Service) Process(ctx context.Context, programEvent ProgramEvent) (err 
 	}
 
 	var logs []Log
+
 	for filter := range matchingFilters {
+		var revertErr error
+		if blockData.Error != nil {
+			switch e := blockData.Error.(type) {
+			case *jsonrpc.RPCError:
+				revertErr = fmt.Errorf("JsonRpcError %d: %s", e.Code, e.Message)
+			case error:
+				revertErr = e
+			default:
+				revertErr = fmt.Errorf("unknown type: %v", e)
+				lp.lggr.Warnf("received unknown revert error type %T for log with blockData=%v", revertErr, blockData)
+			}
+			if !filter.IncludeReverted {
+				continue // unless explicitly requested, discard reverted logs
+			}
+		}
+
 		var logIndex int64
 		logIndex, err = makeLogIndex(blockData.TransactionIndex, blockData.TransactionLogIndex)
 		if err != nil {
@@ -158,6 +176,7 @@ func (lp *Service) Process(ctx context.Context, programEvent ProgramEvent) (err 
 			lp.lggr.Critical(err.Error())
 			return err
 		}
+
 		log := Log{
 			FilterID:       filter.ID,
 			ChainID:        lp.orm.ChainID(),
@@ -168,6 +187,7 @@ func (lp *Service) Process(ctx context.Context, programEvent ProgramEvent) (err 
 			Address:        filter.Address,
 			EventSig:       filter.EventSig,
 			TxHash:         Signature(blockData.TransactionHash),
+			Error:          revertErr,
 		}
 
 		log.Data, err = base64.StdEncoding.DecodeString(programEvent.Data)

--- a/pkg/solana/logpoller/log_poller_test.go
+++ b/pkg/solana/logpoller/log_poller_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math/rand"
 	"sync/atomic"
 	"testing"
@@ -14,7 +13,6 @@ import (
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
-	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -290,7 +288,7 @@ func TestProcess(t *testing.T) {
 			TransactionHash:     expectedLog.TxHash.ToSolana(),
 			TransactionIndex:    txIndex,
 			TransactionLogIndex: txLogIndex,
-			Error:               expectedLog.Error,
+			Error:               nil,
 		},
 		Data: base64.StdEncoding.EncodeToString(expectedLog.Data),
 	}
@@ -352,7 +350,9 @@ func TestProcess(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	ev.Error = &jsonrpc.RPCError{Code: -32000, Message: "Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1"}
+	jsonErr := []byte("{\"InstructionError\":[2,{\"Custom\":6001}]}")
+	err = json.Unmarshal(jsonErr, &ev.Error)
+	require.NoError(t, err)
 
 	t.Run("ignores reverted log when IncludeReverted = false", func(t *testing.T) {
 		// Should ignore this log, since reverted logs are not included. Should not call InsertLogs
@@ -360,15 +360,17 @@ func TestProcess(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	filter.IncludeReverted = true
+	orm.EXPECT().InsertFilter(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f Filter) (int64, error) {
+		require.Equal(t, f, filter)
+		return filterID, nil
+	}).Once()
+	err = lp.RegisterFilter(ctx, filter)
+	require.NoError(t, err)
+
 	t.Run("accepts reverted log when IncludeReverted = true", func(t *testing.T) {
-		filter.IncludeReverted = true
-		expectedLog.Error = fmt.Errorf("JsonRpcError -32000: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1")
-		orm.EXPECT().InsertFilter(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f Filter) (int64, error) {
-			require.Equal(t, f, filter)
-			return filterID, nil
-		}).Once()
-		err = lp.RegisterFilter(ctx, filter)
-		require.NoError(t, err)
+		expectedLog.Error = new(string)
+		*expectedLog.Error = string(jsonErr)
 
 		orm.EXPECT().InsertLogs(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, logs []Log) error {
 			require.Len(t, logs, 1)

--- a/pkg/solana/logpoller/log_poller_test.go
+++ b/pkg/solana/logpoller/log_poller_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/rand"
 	"sync/atomic"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -288,6 +290,7 @@ func TestProcess(t *testing.T) {
 			TransactionHash:     expectedLog.TxHash.ToSolana(),
 			TransactionIndex:    txIndex,
 			TransactionLogIndex: txLogIndex,
+			Error:               expectedLog.Error,
 		},
 		Data: base64.StdEncoding.EncodeToString(expectedLog.Data),
 	}
@@ -327,29 +330,69 @@ func TestProcess(t *testing.T) {
 		EventIdl:    idl,
 		SubkeyPaths: [][]string{{"A"}, {"B"}},
 	}
+	orm.EXPECT().ChainID().Return(chainID).Maybe()
 	orm.EXPECT().SelectFilters(mock.Anything).Return([]Filter{filter}, nil).Once()
 	orm.EXPECT().SelectSeqNums(mock.Anything).Return(map[int64]int64{}, nil).Once()
-	orm.EXPECT().ChainID().Return(chainID).Once()
 	orm.EXPECT().InsertFilter(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f Filter) (int64, error) {
 		require.Equal(t, f, filter)
 		return filterID, nil
 	}).Once()
 
-	orm.EXPECT().InsertLogs(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, logs []Log) error {
-		require.Len(t, logs, 1)
-		log := logs[0]
-		assert.Equal(t, log, expectedLog)
-		return nil
-	})
 	err = lp.RegisterFilter(ctx, filter)
 	require.NoError(t, err)
 
-	err = lp.Process(ctx, ev)
-	require.NoError(t, err)
+	t.Run("accepts matching log", func(t *testing.T) {
+		orm.EXPECT().InsertLogs(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, logs []Log) error {
+			require.Len(t, logs, 1)
+			log := logs[0]
+			assert.Equal(t, expectedLog, log)
+			return nil
+		}).Once()
+		err = lp.Process(ctx, ev)
+		assert.NoError(t, err)
+	})
+
+	ev.Error = &jsonrpc.RPCError{Code: -32000, Message: "Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1"}
+
+	t.Run("ignores reverted log when IncludeReverted = false", func(t *testing.T) {
+		// Should ignore this log, since reverted logs are not included. Should not call InsertLogs
+		err = lp.Process(ctx, ev)
+		assert.NoError(t, err)
+	})
+
+	t.Run("accepts reverted log when IncludeReverted = true", func(t *testing.T) {
+		filter.IncludeReverted = true
+		expectedLog.Error = fmt.Errorf("JsonRpcError -32000: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1")
+		orm.EXPECT().InsertFilter(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f Filter) (int64, error) {
+			require.Equal(t, f, filter)
+			return filterID, nil
+		}).Once()
+		err = lp.RegisterFilter(ctx, filter)
+		require.NoError(t, err)
+
+		orm.EXPECT().InsertLogs(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, logs []Log) error {
+			require.Len(t, logs, 1)
+			log := logs[0]
+			assert.Equal(t, expectedLog, log)
+			return nil
+		}).Once()
+
+		err = lp.Process(ctx, ev)
+		assert.NoError(t, err)
+	})
 
 	orm.EXPECT().MarkFilterDeleted(mock.Anything, mock.Anything).Return(nil).Once()
 	err = lp.UnregisterFilter(ctx, filter.Name)
 	require.NoError(t, err)
+
+	t.Run("ignores non-matching logs", func(t *testing.T) {
+		err = lp.Process(ctx, ev)
+		assert.NoError(t, err)
+
+		ev.Error = nil
+		err = lp.Process(ctx, ev)
+		assert.NoError(t, err)
+	})
 }
 
 func Test_LogPoller_Replay(t *testing.T) {

--- a/pkg/solana/logpoller/models.go
+++ b/pkg/solana/logpoller/models.go
@@ -5,18 +5,19 @@ import (
 )
 
 type Filter struct {
-	ID            int64 // only for internal usage. Values set externally are ignored.
-	Name          string
-	Address       PublicKey
-	EventName     string
-	EventSig      EventSignature
-	StartingBlock int64
-	EventIdl      EventIdl
-	SubkeyPaths   SubKeyPaths
-	Retention     time.Duration
-	MaxLogsKept   int64
-	IsDeleted     bool // only for internal usage. Values set externally are ignored.
-	IsBackfilled  bool // only for internal usage. Values set externally are ignored.
+	ID              int64 // only for internal usage. Values set externally are ignored.
+	Name            string
+	Address         PublicKey
+	EventName       string
+	EventSig        EventSignature
+	StartingBlock   int64
+	EventIdl        EventIdl
+	SubkeyPaths     SubKeyPaths
+	Retention       time.Duration
+	MaxLogsKept     int64
+	IsDeleted       bool // only for internal usage. Values set externally are ignored.
+	IsBackfilled    bool // only for internal usage. Values set externally are ignored.
+	IncludeReverted bool
 }
 
 func (f Filter) MatchSameLogs(other Filter) bool {
@@ -40,4 +41,5 @@ type Log struct {
 	CreatedAt      time.Time
 	ExpiresAt      *time.Time
 	SequenceNum    int64
+	Error          error
 }

--- a/pkg/solana/logpoller/models.go
+++ b/pkg/solana/logpoller/models.go
@@ -41,5 +41,5 @@ type Log struct {
 	CreatedAt      time.Time
 	ExpiresAt      *time.Time
 	SequenceNum    int64
-	Error          error
+	Error          *string
 }

--- a/pkg/solana/logpoller/orm.go
+++ b/pkg/solana/logpoller/orm.go
@@ -78,6 +78,7 @@ func (o *DSORM) InsertFilter(ctx context.Context, filter Filter) (id int64, err 
 		withEventIDL(filter.EventIdl).
 		withSubKeyPaths(filter.SubkeyPaths).
 		withIsBackfilled(filter.IsBackfilled).
+		withIncludeReverted(filter.IncludeReverted).
 		toArgs()
 	if err != nil {
 		return 0, err
@@ -94,7 +95,8 @@ func (o *DSORM) InsertFilter(ctx context.Context, filter Filter) (id int64, err 
 	  	                                                        starting_block = EXCLUDED.starting_block,
 	  	                                                        retention = EXCLUDED.retention,
 	  	                                                        max_logs_kept = EXCLUDED.max_logs_kept,
-	  	                                                        is_backfilled = EXCLUDED.is_backfilled
+	  	                                                        is_backfilled = EXCLUDED.is_backfilled,
+	  	                                                        include_reverted = EXCLUDED.include_reverted
 		RETURNING id;`
 
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -170,9 +172,9 @@ func (o *DSORM) insertLogsWithinTx(ctx context.Context, logs []Log, tx sqlutil.D
 		}
 
 		query := `INSERT INTO solana.logs
-					(filter_id, chain_id, log_index, block_hash, block_number, block_timestamp, address, event_sig, subkey_values, tx_hash, data, created_at, expires_at, sequence_num)
+					(filter_id, chain_id, log_index, block_hash, block_number, block_timestamp, address, event_sig, subkey_values, tx_hash, data, created_at, expires_at, sequence_num, error)
 				VALUES
-					(:filter_id, :chain_id, :log_index, :block_hash, :block_number, :block_timestamp, :address, :event_sig, :subkey_values, :tx_hash, :data, NOW(), :expires_at, :sequence_num)
+					(:filter_id, :chain_id, :log_index, :block_hash, :block_number, :block_timestamp, :address, :event_sig, :subkey_values, :tx_hash, :data, NOW(), :expires_at, :sequence_num, :error)
 				ON CONFLICT DO NOTHING`
 
 		res, err := tx.NamedExecContext(ctx, query, logs[start:end])

--- a/pkg/solana/logpoller/orm.go
+++ b/pkg/solana/logpoller/orm.go
@@ -87,8 +87,8 @@ func (o *DSORM) InsertFilter(ctx context.Context, filter Filter) (id int64, err 
 	// https://github.com/jmoiron/sqlx/issues/91, https://github.com/jmoiron/sqlx/issues/428
 	query := `
 		INSERT INTO solana.log_poller_filters
-		    (chain_id, name, address, event_name, event_sig, starting_block, event_idl, subkey_paths, retention, max_logs_kept, is_backfilled)
-	  		VALUES (:chain_id, :name, :address, :event_name, :event_sig, :starting_block, :event_idl, :subkey_paths, :retention, :max_logs_kept, :is_backfilled)
+		    (chain_id, name, address, event_name, event_sig, starting_block, event_idl, subkey_paths, retention, max_logs_kept, is_backfilled, include_reverted)
+			VALUES (:chain_id, :name, :address, :event_name, :event_sig, :starting_block, :event_idl, :subkey_paths, :retention, :max_logs_kept, :is_backfilled, :include_reverted)
 	  	ON CONFLICT (chain_id, name) WHERE NOT is_deleted DO UPDATE SET 
 	  	                                                        event_name = EXCLUDED.event_name,
 	  	                                                        starting_block = EXCLUDED.starting_block,

--- a/pkg/solana/logpoller/orm_test.go
+++ b/pkg/solana/logpoller/orm_test.go
@@ -316,10 +316,10 @@ func TestFilteredLogs(t *testing.T) {
 				{BlockNumber: 3, LogIndex: 0},
 			},
 			expected: []Log{
-				{BlockNumber: 1, LogIndex: 0},
-				{BlockNumber: 2, LogIndex: 1},
-				{BlockNumber: 2, LogIndex: 2},
 				{BlockNumber: 3, LogIndex: 0},
+				{BlockNumber: 2, LogIndex: 2},
+				{BlockNumber: 2, LogIndex: 1},
+				{BlockNumber: 1, LogIndex: 0},
 			},
 		},
 		{
@@ -330,11 +330,11 @@ func TestFilteredLogs(t *testing.T) {
 				{BlockNumber: 3, LogIndex: 2},
 			},
 			expected: []Log{
-				{BlockNumber: 1, LogIndex: 0},
-				{BlockNumber: 2, LogIndex: 1},
-				{BlockNumber: 2, LogIndex: 2},
-				{BlockNumber: 3, LogIndex: 0},
 				{BlockNumber: 3, LogIndex: 2},
+				{BlockNumber: 3, LogIndex: 0},
+				{BlockNumber: 2, LogIndex: 2},
+				{BlockNumber: 2, LogIndex: 1},
+				{BlockNumber: 1, LogIndex: 0},
 			},
 		},
 	}
@@ -358,7 +358,7 @@ func TestFilteredLogs(t *testing.T) {
 			l.ChainID = chainID
 			l.FilterID = filterID
 			l.BlockTimestamp = blockTimestamp
-			l.SubkeyValues = IndexedValues{}
+			l.SubkeyValues = nil
 			l.Data = data
 		}
 		t.Run(tt.name, func(t *testing.T) {
@@ -383,4 +383,9 @@ func sanitize(expected, actual *Log) {
 	// fill in fields populated by db write itself
 	expected.ID = actual.ID
 	expected.CreatedAt = actual.CreatedAt
+
+	// These are not returned by FilteredLogs
+	actual.SequenceNum = expected.SequenceNum
+	actual.FilterID = expected.FilterID
+	actual.SubkeyValues = expected.SubkeyValues
 }

--- a/pkg/solana/logpoller/parser.go
+++ b/pkg/solana/logpoller/parser.go
@@ -36,7 +36,7 @@ var (
 	ErrInvalidSortType     = errors.New("invalid sort by type")
 
 	logsFields = [...]string{"chain_id", "log_index", "block_hash", "block_number", "block_timestamp", "address",
-		"event_sig", "tx_hash", "data"}
+		"event_sig", "tx_hash", "data", "error"}
 
 	filterFields = [...]string{"id", "name", "address", "event_name", "event_sig", "starting_block",
 		"event_idl", "subkey_paths", "retention", "max_logs_kept", "is_deleted", "is_backfilled"}

--- a/pkg/solana/logpoller/query.go
+++ b/pkg/solana/logpoller/query.go
@@ -124,6 +124,10 @@ func (q *queryArgs) withIsBackfilled(isBackfilled bool) *queryArgs {
 	return q.withField("is_backfilled", isBackfilled)
 }
 
+func (q *queryArgs) withIncludeReverted(includeReverted bool) *queryArgs {
+	return q.withField("include_reverted", includeReverted)
+}
+
 func logsQuery(clause string) string {
 	// TODO: using DISTINCT in a query is less efficient but required because of duplicate logs coming from multipler filters
 	return fmt.Sprintf(`SELECT DISTINCT %s FROM solana.logs %s`, strings.Join(logsFields[:], ", "), clause)


### PR DESCRIPTION
### Description

JIRA: [NONEVM-1387](https://smartcontract-it.atlassian.net/browse/NONEVM-1387)

Logs from reverted transactions will now be included in LogPoller's logs table if `include_reverted` is set on the Filter object passed to `RegisterFilter`.

### Resolves Dependencies
- https://github.com/smartcontractkit/chainlink/pull/16731

[NONEVM-1387]: https://smartcontract-it.atlassian.net/browse/NONEVM-1387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ