### PR TITLE
fix: swap out usage of tj-actions/branch-names

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,7 +4,7 @@ inputs:
   only-modules:
     description: Set to 'true' to only cache modules
     default: "false"
-  cache-version: 
+  cache-version:
     description: Set this to cache bust
     default: "1"
   go-version-file:
@@ -26,7 +26,7 @@ runs:
     - name: Get branch name
       if: ${{ inputs.only-modules == 'false' }}
       id: branch-name
-      uses: tj-actions/branch-names@6871f53176ad61624f978536bbf089c574dc19a2 # v8.0.1
+      uses: smartcontractkit/.github/actions/branch-names@branch-names/1.0.0
 
     - name: Set go cache keys
       shell: bash


### PR DESCRIPTION
### Changes

Swaps out usage of defunct https://github.com/tj-actions/branch-names.

Related: https://github.com/smartcontractkit/chainlink/pull/16799
