### PR TITLE
Fix JSON Unmarshaling for IdlType

### DIFF
--- a/pkg/solana/codec/anchoridl.go
+++ b/pkg/solana/codec/anchoridl.go
@@ -288,7 +288,7 @@ func (env *IdlType) UnmarshalJSON(data []byte) error {
 			env.AsIdlTypeVec = &target
 		}
 		if _, ok := v["option"]; ok {
-			if typeFound == true {
+			if typeFound {
 				return fmt.Errorf("multiple types found for IdlType: %s", spew.Sdump(temp))
 			}
 			var target IdlTypeOption
@@ -297,8 +297,9 @@ func (env *IdlType) UnmarshalJSON(data []byte) error {
 			}
 			typeFound = true
 			env.asIdlTypeOption = &target
-		} else if _, ok := v["defined"]; ok {
-			if typeFound == true {
+		}
+		if _, ok := v["defined"]; ok {
+			if typeFound {
 				return fmt.Errorf("multiple types found for IdlType: %s", spew.Sdump(temp))
 			}
 			var target IdlTypeDefined
@@ -307,16 +308,17 @@ func (env *IdlType) UnmarshalJSON(data []byte) error {
 			}
 			typeFound = true
 			env.AsIdlTypeDefined = &target
-		} else if got, ok := v["array"]; ok {
-			if typeFound == true {
+		}
+		if got, ok := v["array"]; ok {
+			if typeFound {
 				return fmt.Errorf("multiple types found for IdlType: %s", spew.Sdump(temp))
 			}
 			if _, ok := got.([]interface{}); !ok {
-				panic(utilz.Sf("array is not in expected format:\n%s", spew.Sdump(got)))
+				return fmt.Errorf("array is not in expected format: %s", spew.Sdump(got))
 			}
 			arrVal := got.([]interface{})
 			if len(arrVal) != 2 {
-				panic(utilz.Sf("array is not of expected length:\n%s", spew.Sdump(got)))
+				return fmt.Errorf("array is not of expected length: %s", spew.Sdump(got))
 			}
 			var target IdlTypeArray
 			if err := utilz.TranscodeJSON(arrVal[0], &target.Thing); err != nil {

--- a/pkg/solana/codec/anchoridl.go
+++ b/pkg/solana/codec/anchoridl.go
@@ -278,28 +278,39 @@ func (env *IdlType) UnmarshalJSON(data []byte) error {
 			return nil
 		}
 
+		var typeFound bool
 		if _, ok := v["vec"]; ok {
 			var target IdlTypeVec
 			if err := utilz.TranscodeJSON(temp, &target); err != nil {
 				return err
 			}
+			typeFound = true
 			env.AsIdlTypeVec = &target
 		}
 		if _, ok := v["option"]; ok {
+			if typeFound == true {
+				return fmt.Errorf("multiple types found for IdlType: %s", spew.Sdump(temp))
+			}
 			var target IdlTypeOption
 			if err := utilz.TranscodeJSON(temp, &target); err != nil {
 				return err
 			}
+			typeFound = true
 			env.asIdlTypeOption = &target
-		}
-		if _, ok := v["defined"]; ok {
+		} else if _, ok := v["defined"]; ok {
+			if typeFound == true {
+				return fmt.Errorf("multiple types found for IdlType: %s", spew.Sdump(temp))
+			}
 			var target IdlTypeDefined
 			if err := utilz.TranscodeJSON(temp, &target); err != nil {
 				return err
 			}
+			typeFound = true
 			env.AsIdlTypeDefined = &target
-		}
-		if got, ok := v["array"]; ok {
+		} else if got, ok := v["array"]; ok {
+			if typeFound == true {
+				return fmt.Errorf("multiple types found for IdlType: %s", spew.Sdump(temp))
+			}
 			if _, ok := got.([]interface{}); !ok {
 				panic(utilz.Sf("array is not in expected format:\n%s", spew.Sdump(got)))
 			}
@@ -313,7 +324,7 @@ func (env *IdlType) UnmarshalJSON(data []byte) error {
 			}
 
 			target.Num = int(arrVal[1].(float64))
-
+			typeFound = true
 			env.AsIdlTypeArray = &target
 		}
 	default:

--- a/pkg/solana/codec/anchoridl.go
+++ b/pkg/solana/codec/anchoridl.go
@@ -326,7 +326,6 @@ func (env *IdlType) UnmarshalJSON(data []byte) error {
 			}
 
 			target.Num = int(arrVal[1].(float64))
-			typeFound = true
 			env.AsIdlTypeArray = &target
 		}
 	default:

--- a/pkg/solana/codec/anchoridl_test.go
+++ b/pkg/solana/codec/anchoridl_test.go
@@ -20,29 +20,35 @@ func ensureUnmarshal[T any](t *testing.T, originalStrIDL string) {
 }
 
 func TestIDLTypes_JSONMarshalUnmarshal(t *testing.T) {
-	t.Run("Array IDL Filed", func(t *testing.T) {
+	t.Run("Array IDL Field", func(t *testing.T) {
 		idl := `{ "name": "OracleIds", "type": { "array": ["u8", 32] } }`
 		ensureUnmarshal[IdlField](t, idl)
 	})
 	t.Run("CCIP IDL", func(t *testing.T) {
 		ensureUnmarshal[IDL](t, solana.FetchCCIPOfframpIDL())
 	})
+	t.Run("Invalid JSON: multiple IDLTypes provided", func(t *testing.T) {
+		idl := `{ "array": ["u8", 32], "vec": {"string": "test"}}`
+		var readIdlType IdlType
+		require.ErrorContains(t, json.Unmarshal([]byte(idl), &readIdlType), "multiple types found for IdlType:")
+	})
+}
 
-	t.Run("IdlAccountItem - Invalid (both 'isMut' and 'accounts')", func(t *testing.T) {
-		raw := `{
+// When both accounts and isMut are provided
+func TestIDLAccountItem_Invalid(t *testing.T) {
+	raw := `{
 			"isMut": true,
 			"accounts": {
 				"name": "myAccounts",
 				"accounts": [{ "name": "subAccount" }]
 			}
 		}`
-		var item IdlAccountItem
-		err := json.Unmarshal([]byte(raw), &item)
-		require.Error(t, err)
-	})
+	var item IdlAccountItem
+	err := json.Unmarshal([]byte(raw), &item)
+	require.Error(t, err)
 }
 
-func TestIDLTypes_Circular(t *testing.T) {
+func TestIDLAccountItem_Circular(t *testing.T) {
 	t.Run("Circular Dependency", func(t *testing.T) {
 		// Parent structure
 		root := IdlAccountItem{


### PR DESCRIPTION
UnmarshalJSON() for IdlType wasn't enforcing that it should only have exactly 1 type.
Thus it was possible to unmarshal to an IdlType, which was invalid, with multiple types being set.

Also, there were 2 panics in the unmarshal code, which can crash the code, thus removed them.
