### PR TITLE
Fixed incorrect error wrapping

### DIFF
--- a/pkg/solana/chainwriter/ata_creation.go
+++ b/pkg/solana/chainwriter/ata_creation.go
@@ -117,7 +117,7 @@ func (s *SolanaChainWriterService) handleATACreation(ctx context.Context, create
 		solana.TransactionPayer(feePayer),
 	)
 	if ataErr != nil {
-		return "", fmt.Errorf("error constructing ATA transaction: %w", err)
+		return "", fmt.Errorf("error constructing ATA transaction: %w", ataErr)
 	}
 	ataUUID := fmt.Sprintf("ATA-%s", uuid.NewString())
 

--- a/pkg/solana/fees/utils.go
+++ b/pkg/solana/fees/utils.go
@@ -55,7 +55,7 @@ func ParseBlock(res *rpc.GetBlockResult) (out BlockData, err error) {
 			// exit on GetTransaction error
 			// if this occurs, solana-go was unable to parse a transaction
 			// further investigation is required to determine if there is incompatibility
-			return out, fmt.Errorf("failed to GetTransaction (blockhash: %s): %w", res.Blockhash, err)
+			return out, fmt.Errorf("failed to GetTransaction (blockhash: %s): %w", res.Blockhash, getTxErr)
 		}
 		if baseTx == nil {
 			continue


### PR DESCRIPTION
The incorrect error was being wrapped in certain scenarios where we used unique error names