### PR TITLE
Log pruning for Solana LogPoller

### DIFF
--- a/pkg/solana/logpoller/filters.go
+++ b/pkg/solana/logpoller/filters.go
@@ -85,9 +85,9 @@ func (fl *filters) PruneFilters(ctx context.Context) error {
 // Returns a randomly shuffled snapshot of all currently registered filters
 func (fl *filters) shuffledFilters() iter.Seq[Filter] {
 	fl.filtersMutex.Lock()
-	filterSlice := make([]*Filter, len(fl.filtersByID))
-	for i, filter := range fl.filtersByID {
-		filterSlice[i] = filter
+	filterSlice := make([]*Filter, 0, len(fl.filtersByID))
+	for _, filter := range fl.filtersByID {
+		filterSlice = append(filterSlice, filter)
 	}
 	fl.filtersMutex.Unlock()
 

--- a/pkg/solana/logpoller/filters.go
+++ b/pkg/solana/logpoller/filters.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"math/rand"
 	"reflect"
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/gagliardetto/solana-go"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings/binary"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -76,6 +77,52 @@ func (fl *filters) PruneFilters(ctx context.Context) error {
 		defer fl.filtersMutex.Unlock()
 		maps.Copy(fl.filtersToDelete, filtersToDelete)
 		return fmt.Errorf("failed to delete filters: %w", err)
+	}
+
+	return nil
+}
+
+// Returns a randomly shuffled snapshot of all currently registered filters
+func (fl *filters) shuffledFilters() iter.Seq[Filter] {
+	fl.filtersMutex.Lock()
+	filterSlice := make([]*Filter, len(fl.filtersByID))
+	for i, filter := range fl.filtersByID {
+		filterSlice[i] = filter
+	}
+	fl.filtersMutex.Unlock()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano())) // nolint:gosec // disable G404
+	r.Shuffle(len(filterSlice), func(i, j int) {
+		filterSlice[i], filterSlice[j] = filterSlice[j], filterSlice[i]
+	})
+
+	return func(yield func(Filter) bool) {
+		for _, filter := range filterSlice {
+			if !yield(*filter) {
+				return
+			}
+		}
+	}
+}
+
+func (fl *filters) PruneLogs(ctx context.Context) error {
+	err := fl.LoadFilters(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load filters: %w", err)
+	}
+
+	for filter := range fl.shuffledFilters() {
+		// Intentionally not holding the filtersMutex lock here, since getting through all of these DELETE
+		// operations could take a while. New filters may be added while we are pruning the old ones, but
+		// those won't be eligible yet for pruning anyway. Some may be removed (along with their logs) while
+		// we're iterating through the snapshot we have. For those, the DELETE will succeed immediately
+		// since there are no rows to delete.
+
+		_, err = fl.orm.PruneLogsForFilter(ctx, filter)
+		if err != nil {
+			return fmt.Errorf("failed to prune logs for filter %s: %w", filter.Name, err)
+		}
+		time.Sleep(1 * time.Second) // pause for a moment to avoid overwhelming the database
 	}
 
 	return nil

--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 )
 
@@ -35,6 +36,7 @@ type ORM interface {
 	InsertLogs(context.Context, []Log) (err error)
 	SelectSeqNums(ctx context.Context) (map[int64]int64, error)
 	FilteredLogs(ctx context.Context, queryFilter []query.Expression, limitAndSort query.LimitAndSort, queryName string) ([]Log, error)
+	PruneLogsForFilter(ctx context.Context, filter Filter) (int64, error)
 }
 
 type logsLoader interface {
@@ -47,6 +49,7 @@ type filtersI interface {
 	UnregisterFilter(ctx context.Context, name string) error
 	LoadFilters(ctx context.Context) error
 	PruneFilters(ctx context.Context) error
+	PruneLogs(ctx context.Context) error
 	GetDistinctAddresses(ctx context.Context) ([]PublicKey, error)
 	GetFiltersToBackfill() []Filter
 	MarkFilterBackfilled(ctx context.Context, filterID int64) error
@@ -112,6 +115,8 @@ func NewWithCustomProcessor(lggr logger.SugaredLogger, orm ORM, client RPCClient
 	return lp
 }
 
+const BackgroundWorkerInterval = 10 * time.Minute
+
 func (lp *Service) start(_ context.Context) error {
 	lp.eng.GoTick(services.NewTicker(time.Second), func(ctx context.Context) {
 		err := lp.run(ctx)
@@ -119,7 +124,7 @@ func (lp *Service) start(_ context.Context) error {
 			lp.lggr.Errorw("log poller iteration failed - retrying", "err", err)
 		}
 	})
-	lp.eng.GoTick(services.NewTicker(time.Minute), lp.backgroundWorkerRun)
+	lp.eng.GoTick(services.NewTicker(BackgroundWorkerInterval), lp.backgroundWorkerRun)
 	return nil
 }
 
@@ -501,9 +506,19 @@ func appendBuffered(ch <-chan Block, maxNum int, blocks []Block) []Block {
 }
 
 func (lp *Service) backgroundWorkerRun(ctx context.Context) {
+	// Set deadline for log pruning to 90% of the time left until the next scheduled BackgroundWorkerRun
+	logsCtx, cancel := context.WithTimeout(sqlutil.WithoutDefaultTimeout(ctx), 9*BackgroundWorkerInterval/10)
+	defer cancel()
+
+	// Filters table is much smaller, so default timeout makes the most sense for that
 	err := lp.filters.PruneFilters(ctx)
 	if err != nil {
 		lp.lggr.Errorw("Failed to prune filters", "err", err)
+	}
+
+	err = lp.filters.PruneLogs(logsCtx)
+	if err != nil {
+		lp.lggr.Errorw("Failed to prune logs", "err", err)
 	}
 }
 

--- a/pkg/solana/logpoller/log_poller_test.go
+++ b/pkg/solana/logpoller/log_poller_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
@@ -347,6 +348,27 @@ func TestProcess(t *testing.T) {
 		}).Once()
 		err = lp.Process(ctx, ev)
 		assert.NoError(t, err)
+	})
+
+	t.Run("populates expiresAt field when retention is set", func(t *testing.T) {
+		filter.Retention = 30 * time.Minute
+		orm.EXPECT().InsertFilter(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f Filter) (int64, error) {
+			require.Equal(t, f, filter)
+			return filterID, nil
+		}).Once()
+		err = lp.RegisterFilter(ctx, filter)
+		require.NoError(t, err)
+
+		orm.EXPECT().InsertLogs(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, logs []Log) error {
+			require.Len(t, logs, 1)
+			log := logs[0]
+			assert.Less(t, time.Until(*log.ExpiresAt), 30*time.Minute) // should be slightly less than 30 minutes from now
+			assert.Greater(t, time.Until(*log.ExpiresAt), 29*time.Minute)
+			return nil
+		}).Once()
+		err = lp.Process(ctx, ev)
+		assert.NoError(t, err)
+		filter.Retention = 0
 	})
 
 	jsonErr := []byte("{\"InstructionError\":[2,{\"Custom\":6001}]}")

--- a/pkg/solana/logpoller/log_poller_test.go
+++ b/pkg/solana/logpoller/log_poller_test.go
@@ -490,3 +490,48 @@ func Test_LogPoller_Replay(t *testing.T) {
 		assertReplayInfo(3, ReplayStatusRequested)
 	})
 }
+
+func TestShuffledFilters(t *testing.T) {
+	fl := &filters{
+		filtersByID: map[int64]*Filter{
+			0: {Name: "Filter A"},
+			1: {Name: "Filter B"},
+			2: {Name: "Filter C"},
+		},
+	}
+
+	seen := map[string]bool{}
+	for filter := range fl.shuffledFilters() {
+		seen[filter.Name] = true
+	}
+
+	require.Len(t, seen, 3)
+
+	for _, filter := range fl.filtersByID {
+		assert.Contains(t, seen, filter.Name)
+	}
+}
+
+func TestBackgroundWorkerRun(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	lggr := logger.TestSugared(t)
+	orm := NewMockORM(t)
+	cl := mocks.NewRPCClient(t)
+	lp := New(lggr, orm, cl)
+
+	filter1 := Filter{ID: 1, Name: "Filter A"}
+	filter2 := Filter{ID: 2, Name: "Filter B"}
+	filter3 := Filter{ID: 3, Name: "Filter C"}
+
+	filters := []Filter{
+		filter1, filter2, filter3,
+	}
+
+	orm.EXPECT().SelectFilters(mock.Anything).Return(filters, nil).Once()
+	orm.EXPECT().SelectSeqNums(mock.Anything).Return(map[int64]int64{}, nil)
+	orm.EXPECT().PruneLogsForFilter(mock.Anything, mock.Anything).Return(int64(1), nil)
+
+	lp.backgroundWorkerRun(ctx)
+	orm.AssertNumberOfCalls(t, "PruneLogsForFilter", 3)
+}

--- a/pkg/solana/logpoller/mock_filters.go
+++ b/pkg/solana/logpoller/mock_filters.go
@@ -470,6 +470,52 @@ func (_c *mockFilters_PruneFilters_Call) RunAndReturn(run func(context.Context) 
 	return _c
 }
 
+// PruneLogs provides a mock function with given fields: ctx
+func (_m *mockFilters) PruneLogs(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PruneLogs")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// mockFilters_PruneLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PruneLogs'
+type mockFilters_PruneLogs_Call struct {
+	*mock.Call
+}
+
+// PruneLogs is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *mockFilters_Expecter) PruneLogs(ctx interface{}) *mockFilters_PruneLogs_Call {
+	return &mockFilters_PruneLogs_Call{Call: _e.mock.On("PruneLogs", ctx)}
+}
+
+func (_c *mockFilters_PruneLogs_Call) Run(run func(ctx context.Context)) *mockFilters_PruneLogs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *mockFilters_PruneLogs_Call) Return(_a0 error) *mockFilters_PruneLogs_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *mockFilters_PruneLogs_Call) RunAndReturn(run func(context.Context) error) *mockFilters_PruneLogs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RegisterFilter provides a mock function with given fields: ctx, filter
 func (_m *mockFilters) RegisterFilter(ctx context.Context, filter Filter) error {
 	ret := _m.Called(ctx, filter)

--- a/pkg/solana/logpoller/mock_orm.go
+++ b/pkg/solana/logpoller/mock_orm.go
@@ -486,6 +486,63 @@ func (_c *MockORM_MarkFilterDeleted_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// PruneLogsForFilter provides a mock function with given fields: ctx, filter
+func (_m *MockORM) PruneLogsForFilter(ctx context.Context, filter Filter) (int64, error) {
+	ret := _m.Called(ctx, filter)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PruneLogsForFilter")
+	}
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, Filter) (int64, error)); ok {
+		return rf(ctx, filter)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, Filter) int64); ok {
+		r0 = rf(ctx, filter)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, Filter) error); ok {
+		r1 = rf(ctx, filter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockORM_PruneLogsForFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PruneLogsForFilter'
+type MockORM_PruneLogsForFilter_Call struct {
+	*mock.Call
+}
+
+// PruneLogsForFilter is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filter Filter
+func (_e *MockORM_Expecter) PruneLogsForFilter(ctx interface{}, filter interface{}) *MockORM_PruneLogsForFilter_Call {
+	return &MockORM_PruneLogsForFilter_Call{Call: _e.mock.On("PruneLogsForFilter", ctx, filter)}
+}
+
+func (_c *MockORM_PruneLogsForFilter_Call) Run(run func(ctx context.Context, filter Filter)) *MockORM_PruneLogsForFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(Filter))
+	})
+	return _c
+}
+
+func (_c *MockORM_PruneLogsForFilter_Call) Return(_a0 int64, _a1 error) *MockORM_PruneLogsForFilter_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockORM_PruneLogsForFilter_Call) RunAndReturn(run func(context.Context, Filter) (int64, error)) *MockORM_PruneLogsForFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SelectFilters provides a mock function with given fields: ctx
 func (_m *MockORM) SelectFilters(ctx context.Context) ([]Filter, error) {
 	ret := _m.Called(ctx)

--- a/pkg/solana/logpoller/observability.go
+++ b/pkg/solana/logpoller/observability.go
@@ -110,7 +110,7 @@ func (o *ObservedORM) DeleteFilters(ctx context.Context, filters map[int64]Filte
 }
 
 func (o *ObservedORM) MarkFilterDeleted(ctx context.Context, id int64) error {
-	return withObservedExec(o, "MarkFilterDeleted", del, func() error {
+	return withObservedExec(o, "MarkFilterDeleted", create, func() error {
 		return o.ORM.MarkFilterDeleted(ctx, id)
 	})
 }
@@ -136,6 +136,12 @@ func (o *ObservedORM) FilteredLogs(ctx context.Context, filter []query.Expressio
 func (o *ObservedORM) GetLatestBlock(ctx context.Context) (int64, error) {
 	return withObservedQuery(o, "GetLatestBlack", func() (int64, error) {
 		return o.ORM.GetLatestBlock(ctx)
+	})
+}
+
+func (o *ObservedORM) PruneLogsForFilter(ctx context.Context, filter Filter) (int64, error) {
+	return withObservedExecAndRowsAffected(o, "PruneLogsForFilter", del, func() (int64, error) {
+		return o.ORM.PruneLogsForFilter(ctx, filter)
 	})
 }
 
@@ -167,6 +173,22 @@ func withObservedExec(o *ObservedORM, query string, queryType queryType, exec fu
 			Observe(float64(time.Since(queryStarted)))
 	}()
 	return exec()
+}
+
+func withObservedExecAndRowsAffected(o *ObservedORM, queryName string, queryType queryType, exec func() (int64, error)) (int64, error) {
+	queryStarted := time.Now()
+	rowsAffected, err := exec()
+	o.queryDuration.
+		WithLabelValues(o.chainID, queryName, string(queryType)).
+		Observe(float64(time.Since(queryStarted)))
+
+	if err == nil {
+		o.datasetSize.
+			WithLabelValues(o.chainID, queryName, string(queryType)).
+			Set(float64(rowsAffected))
+	}
+
+	return rowsAffected, err
 }
 
 func trackInsertedLogs(o *ObservedORM, logs []Log, err error) {

--- a/pkg/solana/logpoller/orm.go
+++ b/pkg/solana/logpoller/orm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
@@ -303,4 +304,23 @@ func (o *DSORM) SelectSeqNums(ctx context.Context) (map[int64]int64, error) {
 		seqNums[row.FilterID] = row.SequenceNum
 	}
 	return seqNums, nil
+}
+
+func (o *DSORM) PruneLogsForFilter(ctx context.Context, filter Filter) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	query := `DELETE FROM solana.logs AS l
+		  		 WHERE chain_id = $1 AND filter_id = $2 AND
+		  		       ( l.expires_at <= NOW() OR $3 > 0 AND
+		  		        	( SELECT MAX(sequence_num) FROM solana.logs
+		  		    			WHERE chain_id = $1 AND filter_id = $2
+							) - l.sequence_num >= $3
+					   )`
+	res, err := o.ds.ExecContext(ctx, query, o.chainID, filter.ID, filter.MaxLogsKept)
+	if err != nil {
+		return 0, err
+	}
+
+	return res.RowsAffected()
 }

--- a/pkg/solana/logpoller/orm_test.go
+++ b/pkg/solana/logpoller/orm_test.go
@@ -373,6 +373,96 @@ func TestFilteredLogs(t *testing.T) {
 	}
 }
 
+func TestPruneLogsForFilter(t *testing.T) {
+	t.Parallel()
+	sqltest.SkipInMemory(t)
+	lggr := logger.Test(t)
+	dbx := sqltest.NewDB(t, sqltest.TestURL(t))
+	orm := NewORM(chainID, dbx, lggr)
+	ctx := t.Context()
+
+	filter := newRandomFilter(t)
+	filter.MaxLogsKept = 0
+	filterID, err := orm.InsertFilter(ctx, filter)
+	require.NoError(t, err)
+
+	filter.ID = filterID
+
+	logs := make([]Log, 7)
+
+	for i := range logs {
+		logs[i].FilterID = filterID
+		logs[i].ChainID = chainID
+		logs[i].BlockNumber = int64(i + 1)
+		logs[i].SequenceNum = int64(i + 1)
+		logs[i].EventSig = filter.EventSig
+		logs[i].Address = filter.Address
+		logs[i].Data = []byte{}
+	}
+
+	moreLogs := logs[5:]
+	logs = logs[:5]
+
+	err = orm.InsertLogs(ctx, logs)
+	require.NoError(t, err)
+
+	t.Run("default setting is permanent retention", func(t *testing.T) {
+		deleted, err2 := orm.PruneLogsForFilter(ctx, filter)
+		require.NoError(t, err2)
+
+		assert.Equal(t, int64(0), deleted)
+		//require.NoError(t, orm.DeleteFilter(ctx, filterID))
+	})
+
+	t.Run("MaxLogsKept=3 should keep last three logs", func(t *testing.T) {
+		filter.MaxLogsKept = 3
+		filterID, err = orm.InsertFilter(ctx, filter)
+		require.NoError(t, err)
+
+		var deleted int64
+		deleted, err = orm.PruneLogsForFilter(ctx, filter)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(2), deleted)
+
+		var actual []Log
+		actual, err = orm.SelectLogs(ctx, 0, 10, filter.Address, filter.EventSig)
+		require.NoError(t, err)
+
+		require.Len(t, actual, 3)
+		for i := range actual {
+			sanitize(&logs[2+i], &actual[i])
+			assert.Equal(t, logs[2+i].BlockNumber, actual[i].BlockNumber)
+		}
+	})
+
+	t.Run("Expired logs should be pruned", func(t *testing.T) {
+		filter.MaxLogsKept = 18
+		var initial []Log
+		initial, err = orm.SelectLogs(ctx, 0, 10, filter.Address, filter.EventSig)
+		require.NoError(t, err)
+
+		past := time.Now().Add(-40 * time.Minute).UTC()
+		moreLogs[0].ExpiresAt = &past
+
+		future := time.Now().Add(40 * time.Minute).UTC()
+		moreLogs[1].ExpiresAt = &future
+
+		err = orm.InsertLogs(ctx, moreLogs)
+		require.NoError(t, err)
+
+		deleted, err := orm.PruneLogsForFilter(ctx, filter)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(1), deleted)
+
+		var actual []Log
+		actual, err = orm.SelectLogs(ctx, 0, 10, filter.Address, filter.EventSig)
+		require.NoError(t, err)
+		assert.Len(t, actual, len(initial)+1)
+	})
+}
+
 func sanitize(expected, actual *Log) {
 	// TODO: override ScanLocation with custom TimestamptzCodec?
 	// See: https://github.com/jackc/pgx/issues/2117


### PR DESCRIPTION
### Description

This adds a `PruneLogs` method to `lp.filters` which gets run by the background worker thread every 10 minutes, just after `PruneFilters` is run. A 9 minute deadline on the context is set, to make sure a previous pruning run never interferes with the next one.

The filters are shuffled randomly and iterated over. This could potentially help in a case where the db is overloaded enough that not all filters can be pruned, and some have a lot more logs than others.  It avoids a situation where the first few filters have too many logs to successfully prune at once, in which case it might never make an attempt to prune the rest of the filters.

`orm.PruneLogsForFilter` prunes any logs which have expired (based on their `expiresAt` column, which is already set during log intake based on the `Retention` field of the filter). And in the same query, it also removes older logs in excess of the most recent MaxLogsKept logs, as specified by the filter.  Each filter requires a single query, whose timeout is set to 1 minute.

As long as everything is functioning normally, these DELETE queries should be fast (< 100ms), not needing anywhere near that much time. Most of the above are just preventive measures to help recover from a hypothetical spike in log volume, where the db is already under high load and then millions of logs somehow get inserted before the pruner can run.

  [NONEVM-1261](https://smartcontract-it.atlassian.net/browse/NONEVM-1261)


[NONEVM-1261]: https://smartcontract-it.atlassian.net/browse/NONEVM-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Required for CI to pass until https://github.com/smartcontractkit/chainlink/pull/16915 gets merged (but okay to merge in either order):