### PR TITLE
refactor: use the built-in min to simplify the code

### DIFF
--- a/pkg/solana/fees/utils.go
+++ b/pkg/solana/fees/utils.go
@@ -26,13 +26,7 @@ func CalculateFee(base, maxFee, minFee uint64, count uint) uint64 {
 	}
 
 	// respect bounds
-	if amount < minFee {
-		return minFee
-	}
-	if amount > maxFee {
-		return maxFee
-	}
-	return amount
+	return min(max(amount, minFee), maxFee)
 }
 
 type BlockData struct {


### PR DESCRIPTION
### Description

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
