### PR TITLE
pkg/solana/logpoller: simplify construction

### DIFF
--- a/pkg/solana/logpoller/filters.go
+++ b/pkg/solana/logpoller/filters.go
@@ -37,10 +37,10 @@ type filters struct {
 	discriminatorExtractor codec.DiscriminatorExtractor
 }
 
-func newFilters(lggr logger.SugaredLogger, orm ORM) *filters {
+func newFilters(lggr logger.Logger, orm ORM) *filters {
 	return &filters{
 		orm:                    orm,
-		lggr:                   lggr,
+		lggr:                   logger.Sugared(lggr),
 		decoders:               make(map[int64]Decoder),
 		discriminatorExtractor: codec.NewDiscriminatorExtractor(),
 	}

--- a/pkg/solana/logpoller/loader.go
+++ b/pkg/solana/logpoller/loader.go
@@ -44,11 +44,10 @@ type EncodedLogCollector struct {
 
 func NewEncodedLogCollector(
 	client RPCClient,
-	lggr logger.SugaredLogger,
+	lggr logger.Logger,
 ) *EncodedLogCollector {
 	c := &EncodedLogCollector{
 		client: client,
-		lggr:   lggr,
 	}
 
 	c.Service, c.engine = services.Config{
@@ -59,6 +58,7 @@ func NewEncodedLogCollector(
 			return []services.Service{c.workers}
 		},
 	}.NewServiceEngine(lggr)
+	c.lggr = c.engine
 
 	return c
 }

--- a/pkg/solana/logpoller/loader_test.go
+++ b/pkg/solana/logpoller/loader_test.go
@@ -36,7 +36,7 @@ func TestEncodedLogCollector_MultipleEventOrdered(t *testing.T) {
 	client := mocks.NewRPCClient(t)
 	ctx := tests.Context(t)
 
-	collector := logpoller.NewEncodedLogCollector(client, logger.TestSugared(t))
+	collector := logpoller.NewEncodedLogCollector(client, logger.Test(t))
 
 	require.NoError(t, collector.Start(ctx))
 	t.Cleanup(func() {

--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go/rpc"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
@@ -82,19 +83,18 @@ type Service struct {
 }
 
 func New(lggr logger.SugaredLogger, orm ORM, cl RPCClient) *Service {
-	lggr = logger.Sugared(logger.Named(lggr, "LogPoller"))
 	lp := &Service{
-		orm:     orm,
-		client:  cl,
-		filters: newFilters(lggr, orm),
+		orm:    orm,
+		client: cl,
 	}
 
 	lp.processBlocks = lp.processBlocksImpl
 
 	lp.Service, lp.eng = services.Config{
-		Name:  "LogPollerService",
+		Name:  "LogPoller",
 		Start: lp.start,
-		NewSubServices: func(l logger.Logger) []services.Service {
+		NewSubServices: func(lggr logger.Logger) []services.Service {
+			lp.filters = newFilters(lggr, orm)
 			loader := NewEncodedLogCollector(cl, lggr)
 			lp.loader = loader
 			return []services.Service{loader}


### PR DESCRIPTION
Tweak construction to simplify, align names, and nest loggers.