### PR TITLE
Verify ChainID matches a Chain Selector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/prometheus/client_golang v1.21.0
 	github.com/prometheus/client_model v0.6.1
+	github.com/smartcontractkit/chain-selectors v1.0.34
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250321174931-193fcd25d0c1
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250322131411-c7a8d6a077bf
 	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250326142120-b155bad9aee1

--- a/go.sum
+++ b/go.sum
@@ -411,6 +411,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/smartcontractkit/chain-selectors v1.0.34 h1:MJ17OGu8+jjl426pcKrJkCf3fePb3eCreuAnUA3RBj4=
+github.com/smartcontractkit/chain-selectors v1.0.34/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250321174931-193fcd25d0c1 h1:dS08UZqETvqzocj6EczwB71wPIXTEGTFdSrG6TgtJCc=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250321174931-193fcd25d0c1/go.mod h1:18NDrjzBU3W0cWtVELBc5/C+ICNQ5dODAMKeeMwgVgw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250322131411-c7a8d6a077bf h1:K0Hs+zp5KAC2JowMIRi2HP4xxt5VVY34fclsbrIG398=

--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -146,16 +146,9 @@ type verifiedCachedClient struct {
 	client.ReaderWriter
 }
 
-func IsKnownChainID(chainID string) bool {
-	switch chainID {
-	case
-		client.MainnetGenesisHash,
-		client.TestnetGenesisHash,
-		client.DevnetGenesisHash:
-		return true
-	default:
-		return false
-	}
+func isValid32ByteBase58String(chainID string) bool {
+	_, err := solanago.PublicKeyFromBase58(chainID)
+	return err == nil
 }
 
 func (v *verifiedCachedClient) verifyChainID(ctx context.Context) (bool, error) {
@@ -178,13 +171,14 @@ func (v *verifiedCachedClient) verifyChainID(ctx context.Context) (bool, error) 
 		return v.chainIDVerified, fmt.Errorf("failed to fetch ChainID in verifiedCachedClient: %w", err)
 	}
 
-	if IsKnownChainID(v.expectedChainID) {
+	// Check if configured chain ID could be a genesis hash
+	if isValid32ByteBase58String(v.expectedChainID) {
 		if v.chainID != v.expectedChainID {
 			v.chainIDVerified = false
 			return v.chainIDVerified, fmt.Errorf("client returned mismatched chain id (expected: %s, got: %s): %s", v.expectedChainID, v.chainID, v.nodeURL)
 		}
 	} else {
-		v.lggr.Warnf("Configured chainID %s does not match genesis hash for mainnet, testnet, or devnet. "+
+		v.lggr.Warnf("Configured chainID %s is not a valid genesis hash (must be a base58-encoded 32-byte string)."+
 			"Assuming localnet setup and skipping verification.", v.expectedChainID)
 	}
 

--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -178,7 +178,7 @@ func (v *verifiedCachedClient) verifyChainID(ctx context.Context) (bool, error) 
 		return v.chainIDVerified, fmt.Errorf("failed to fetch ChainID in verifiedCachedClient: %w", err)
 	}
 
-	_, err = chainsel.GetChainDetailsByChainIDAndFamily(v.expectedChainID, "solana")
+	_, err = chainsel.GetChainDetailsByChainIDAndFamily(v.expectedChainID, chainsel.FamilySolana)
 	if err != nil {
 		v.chainIDVerified = false
 		return v.chainIDVerified, err

--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -93,6 +93,7 @@ func NewChain(cfg *config.TOMLConfig, opts ChainOpts) (Chain, error) {
 		return nil, fmt.Errorf("cannot create new chain with ID %s: chain is disabled", *cfg.ChainID)
 	}
 
+	// Use genesis hash for known ChainIDs
 	chainID := *cfg.ChainID
 	switch chainID {
 	case "devnet":
@@ -137,11 +138,24 @@ type verifiedCachedClient struct {
 	chainID         string
 	expectedChainID string
 	nodeURL         string
+	lggr            logger.Logger
 
 	chainIDVerified     bool
 	chainIDVerifiedLock sync.RWMutex
 
 	client.ReaderWriter
+}
+
+func IsKnownChainID(chainID string) bool {
+	switch chainID {
+	case
+		client.MainnetGenesisHash,
+		client.TestnetGenesisHash,
+		client.DevnetGenesisHash:
+		return true
+	default:
+		return false
+	}
 }
 
 func (v *verifiedCachedClient) verifyChainID(ctx context.Context) (bool, error) {
@@ -164,12 +178,14 @@ func (v *verifiedCachedClient) verifyChainID(ctx context.Context) (bool, error) 
 		return v.chainIDVerified, fmt.Errorf("failed to fetch ChainID in verifiedCachedClient: %w", err)
 	}
 
-	// if this is localnet, allow any chain ID as long as it's not spoofing an official network
-	if v.expectedChainID != "localnet" {
+	if IsKnownChainID(v.expectedChainID) {
 		if v.chainID != v.expectedChainID {
 			v.chainIDVerified = false
 			return v.chainIDVerified, fmt.Errorf("client returned mismatched chain id (expected: %s, got: %s): %s", v.expectedChainID, v.chainID, v.nodeURL)
 		}
+	} else {
+		v.lggr.Warnf("Configured chainID %s does not match genesis hash for mainnet, testnet, or devnet. "+
+			"Assuming localnet setup and skipping verification.", v.expectedChainID)
 	}
 
 	v.chainIDVerified = true
@@ -528,6 +544,7 @@ func (c *chain) verifiedClient(node *config.Node) (client.ReaderWriter, error) {
 		cl = &verifiedCachedClient{
 			nodeURL:         url,
 			expectedChainID: c.id,
+			lggr:            logger.Named(c.lggr, "verifiedCachedClient"),
 		}
 		// create client
 		cl.ReaderWriter, err = client.NewClient(url, c.cfg, DefaultRequestTimeout, logger.Named(c.lggr, "Client."+*node.Name))

--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gagliardetto/solana-go/programs/system"
 	"github.com/gagliardetto/solana-go/rpc"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/chains"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -138,7 +139,6 @@ type verifiedCachedClient struct {
 	chainID         string
 	expectedChainID string
 	nodeURL         string
-	lggr            logger.Logger
 
 	chainIDVerified     bool
 	chainIDVerifiedLock sync.RWMutex
@@ -146,9 +146,16 @@ type verifiedCachedClient struct {
 	client.ReaderWriter
 }
 
-func isValid32ByteBase58String(chainID string) bool {
-	_, err := solanago.PublicKeyFromBase58(chainID)
-	return err == nil
+func IsKnownChainID(chainID string) bool {
+	switch chainID {
+	case
+		client.MainnetGenesisHash,
+		client.TestnetGenesisHash,
+		client.DevnetGenesisHash:
+		return true
+	default:
+		return false
+	}
 }
 
 func (v *verifiedCachedClient) verifyChainID(ctx context.Context) (bool, error) {
@@ -171,15 +178,17 @@ func (v *verifiedCachedClient) verifyChainID(ctx context.Context) (bool, error) 
 		return v.chainIDVerified, fmt.Errorf("failed to fetch ChainID in verifiedCachedClient: %w", err)
 	}
 
-	// Check if configured chain ID could be a genesis hash
-	if isValid32ByteBase58String(v.expectedChainID) {
+	_, err = chainsel.GetChainDetailsByChainIDAndFamily(v.expectedChainID, "solana")
+	if err != nil {
+		v.chainIDVerified = false
+		return v.chainIDVerified, err
+	}
+
+	if IsKnownChainID(v.expectedChainID) {
 		if v.chainID != v.expectedChainID {
 			v.chainIDVerified = false
 			return v.chainIDVerified, fmt.Errorf("client returned mismatched chain id (expected: %s, got: %s): %s", v.expectedChainID, v.chainID, v.nodeURL)
 		}
-	} else {
-		v.lggr.Warnf("Configured chainID %s is not a valid genesis hash (must be a base58-encoded 32-byte string)."+
-			"Assuming localnet setup and skipping verification.", v.expectedChainID)
 	}
 
 	v.chainIDVerified = true
@@ -538,7 +547,6 @@ func (c *chain) verifiedClient(node *config.Node) (client.ReaderWriter, error) {
 		cl = &verifiedCachedClient{
 			nodeURL:         url,
 			expectedChainID: c.id,
-			lggr:            logger.Named(c.lggr, "verifiedCachedClient"),
 		}
 		// create client
 		cl.ReaderWriter, err = client.NewClient(url, c.cfg, DefaultRequestTimeout, logger.Named(c.lggr, "Client."+*node.Name))

--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -178,12 +178,6 @@ func (v *verifiedCachedClient) verifyChainID(ctx context.Context) (bool, error) 
 		return v.chainIDVerified, fmt.Errorf("failed to fetch ChainID in verifiedCachedClient: %w", err)
 	}
 
-	_, err = chainsel.GetChainDetailsByChainIDAndFamily(v.expectedChainID, chainsel.FamilySolana)
-	if err != nil {
-		v.chainIDVerified = false
-		return v.chainIDVerified, err
-	}
-
 	if IsKnownChainID(v.expectedChainID) {
 		if v.chainID != v.expectedChainID {
 			v.chainIDVerified = false
@@ -280,6 +274,12 @@ func (v *verifiedCachedClient) GetAccountInfoWithOpts(ctx context.Context, addr 
 func newChain(id string, cfg *config.TOMLConfig, ks core.Keystore, lggr logger.Logger, ds sqlutil.DataSource) (*chain, error) {
 	lggr = logger.Named(lggr, "Chain")
 	lggr = logger.With(lggr, "chainID", id, "chain", "solana")
+
+	_, err := chainsel.GetChainDetailsByChainIDAndFamily(id, chainsel.FamilySolana)
+	if err != nil {
+		return nil, err
+	}
+
 	var ch = chain{
 		stopCh:      make(services.StopChan),
 		id:          id,

--- a/pkg/solana/chain_test.go
+++ b/pkg/solana/chain_test.go
@@ -208,7 +208,7 @@ func TestSolanaChain_VerifiedClients(t *testing.T) {
 			_, err = c.ChainID(t.Context())
 			// expect error from id mismatch (even if using a cached client) when performing RPC calls
 			assert.Error(t, err)
-			assert.Equal(t, fmt.Sprintf("client returned mismatched chain id (expected: %s, got: %s): %s", invalidGenesisHash, tc.genesisHash, node.URL), err.Error())
+			assert.Equal(t, fmt.Sprintf("invalid chain id %s for solana", invalidGenesisHash), err.Error())
 		})
 	}
 }

--- a/pkg/solana/chain_test.go
+++ b/pkg/solana/chain_test.go
@@ -201,13 +201,14 @@ func TestSolanaChain_VerifiedClients(t *testing.T) {
 			assert.Equal(t, uint64(1234), slot)
 
 			node.URL = config.MustParseURL(mockServer.URL + "/mismatch")
-			testChain.id = "incorrect"
+			invalidGenesisHash := "7eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d"
+			testChain.id = invalidGenesisHash
 			c, err = testChain.verifiedClient(node)
 			assert.NoError(t, err)
 			_, err = c.ChainID(t.Context())
 			// expect error from id mismatch (even if using a cached client) when performing RPC calls
 			assert.Error(t, err)
-			assert.Equal(t, fmt.Sprintf("client returned mismatched chain id (expected: %s, got: %s): %s", "incorrect", tc.genesisHash, node.URL), err.Error())
+			assert.Equal(t, fmt.Sprintf("client returned mismatched chain id (expected: %s, got: %s): %s", invalidGenesisHash, tc.genesisHash, node.URL), err.Error())
 		})
 	}
 }


### PR DESCRIPTION
### Description
Verify ChainID matches a chain selector, and only compare against the client if the chainID is for mainnet, testnet, or devnet.

Ticket: https://smartcontract-it.atlassian.net/browse/NONEVM-1502
