### PR TITLE
BCFR-1212 fix bind race, bind noop, unbind fixed

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 nodejs 18.20.2
 yarn 1.22.19
 rust 1.59.0
-golang 1.24.0
+golang 1.24.1
 golangci-lint 1.64.5
 actionlint 1.6.22
 shellcheck 0.8.0

--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"time"
 
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
@@ -147,10 +146,7 @@ func (s *ContractReaderService) Close() error {
 	return s.StopOnce(ServiceName, func() error {
 		s.wg.Wait()
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-
-		return s.bdRegistry.UnregisterAll(ctx)
+		return nil
 	})
 }
 
@@ -342,6 +338,10 @@ func (s *ContractReaderService) QueryKey(ctx context.Context, contract types.Bou
 // part of a share group.
 func (s *ContractReaderService) Bind(ctx context.Context, bindings []types.BoundContract) error {
 	for idx := range bindings {
+		if s.lookup.hasAddress(bindings[idx].Name, bindings[idx].Address) {
+			continue
+		}
+
 		if err := s.bdRegistry.Bind(ctx, s.reader, &bindings[idx]); err != nil {
 			return err
 		}

--- a/pkg/solana/chainreader/event_read_binding.go
+++ b/pkg/solana/chainreader/event_read_binding.go
@@ -460,13 +460,6 @@ func (b *eventReadBinding) unsetBinding() {
 	b.bound = false
 }
 
-func (b *eventReadBinding) registered() bool {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
-	return b.registerCalled
-}
-
 func (b *eventReadBinding) wrapDecoderForValuer(log *logpoller.Log) func(context.Context, any) error {
 	return func(ctx context.Context, returnVal any) error {
 		return b.decodeLog(ctx, log, returnVal)

--- a/pkg/solana/chainreader/event_read_binding.go
+++ b/pkg/solana/chainreader/event_read_binding.go
@@ -67,26 +67,19 @@ func newEventReadBinding(
 }
 
 func (b *eventReadBinding) Bind(ctx context.Context, address solana.PublicKey) error {
-	if b.isBound() {
-		// we are changing contract address reference, so we need to unregister old filter if it exists
-		if err := b.Unregister(ctx); err != nil {
-			return err
-		}
-	}
-
-	// filter isn't required here because the event can also be polled for by the contractBinding common filter.
-	if b.filter != nil {
-		b.filter.SetName(fmt.Sprintf("%s.%s.%s", b.namespace, b.genericName, uuid.NewString()))
-		b.filter.SetAddress(address)
-	}
-
 	b.setBinding(address)
 
-	if b.registered() {
-		return b.Register(ctx)
+	if b.filter == nil {
+		return nil
 	}
 
-	return nil
+	b.filter.SetAddress(address)
+
+	if !b.filter.Dirty() {
+		return nil
+	}
+
+	return b.update(ctx)
 }
 
 func (b *eventReadBinding) Unbind(ctx context.Context) error {
@@ -94,25 +87,28 @@ func (b *eventReadBinding) Unbind(ctx context.Context) error {
 		return nil
 	}
 
-	if b.filter != nil {
-		b.filter.SetAddress(solana.PublicKey{})
-		b.filter.SetName("")
+	if b.filter == nil {
+		return nil
+	}
+
+	if err := b.Unregister(ctx); err != nil {
+		return err
 	}
 
 	b.unsetBinding()
 
-	return b.Unregister(ctx)
+	return nil
 }
 
 func (b *eventReadBinding) Register(ctx context.Context) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.registerCalled = true
+
 	if b.filter == nil {
 		return nil
 	}
-
-	b.registerCalled = true
 
 	// can't be true before filters params are set so there is no race with a bad filter outcome
 	if !b.bound {
@@ -120,6 +116,27 @@ func (b *eventReadBinding) Register(ctx context.Context) error {
 	}
 
 	return b.filter.Register(ctx, b.reader)
+}
+
+func (b *eventReadBinding) update(ctx context.Context) error {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.filter == nil {
+		return nil
+	}
+
+	if !b.bound {
+		return nil
+	}
+
+	if !b.registerCalled {
+		return nil
+	}
+
+	newName := fmt.Sprintf("%s.%s.%s", b.namespace, b.genericName, uuid.NewString())
+
+	return b.filter.Update(ctx, b.reader, newName)
 }
 
 func (b *eventReadBinding) Unregister(ctx context.Context) error {

--- a/pkg/solana/chainreader/event_read_binding_test.go
+++ b/pkg/solana/chainreader/event_read_binding_test.go
@@ -1,6 +1,7 @@
 package chainreader
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -17,6 +18,67 @@ import (
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/codec"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 )
+
+func TestBind(t *testing.T) {
+	address1 := solana.NewWallet().PublicKey()
+	address2 := solana.NewWallet().PublicKey()
+
+	subkeys := newIndexedSubkeys()
+	subkeys.addForIndex("A", "W", 0)
+	subkeys.addForIndex("B", "X", 1)
+	subkeys.addForIndex("C", "Y", 2)
+	subkeys.addForIndex("D", "Z", 3)
+
+	readDef := config.ReadDefinition{}
+	pollerConf := config.PollingFilter{}
+
+	t.Run("Bind twice is noop", func(t *testing.T) {
+		t.Parallel()
+
+		lpSource := new(mocks.EventsReader)
+
+		lpSource.EXPECT().HasFilter(mock.Anything, mock.Anything).Return(false)
+		lpSource.EXPECT().RegisterFilter(mock.Anything, mock.Anything).Return(nil).Twice() // 1 per address 1 and 1 per address2
+
+		reader := newEventReadBinding(namespace, genericName, subkeys, lpSource, readDef, pollerConf)
+		ctx := t.Context()
+
+		reader.Register(ctx)
+		require.NoError(t, reader.Bind(ctx, address1))
+		require.NoError(t, reader.Bind(ctx, address1))
+		require.NoError(t, reader.Bind(ctx, address1))
+
+		require.NoError(t, reader.Bind(ctx, address2))
+		lpSource.AssertExpectations(t)
+	})
+
+	t.Run("Unbind works correctly", func(t *testing.T) {
+		t.Parallel()
+
+		lpSource := new(mocks.EventsReader)
+
+		reader := newEventReadBinding(namespace, genericName, subkeys, lpSource, readDef, pollerConf)
+		ctx := t.Context()
+
+		reader.Register(ctx)
+
+		var ret bool
+		lpSource.EXPECT().HasFilter(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, str string) bool {
+			return ret
+		})
+
+		lpSource.EXPECT().RegisterFilter(mock.Anything, mock.Anything).Return(nil).Once()
+		require.NoError(t, reader.Bind(ctx, address1))
+
+		ret = true
+		lpSource.AssertExpectations(t)
+
+		lpSource.EXPECT().UnregisterFilter(mock.Anything, mock.Anything).Return(nil).Once()
+		require.NoError(t, reader.Unbind(ctx))
+
+		lpSource.AssertExpectations(t)
+	})
+}
 
 func TestGetLatestValue(t *testing.T) {
 	t.Parallel()

--- a/pkg/solana/chainreader/event_read_binding_test.go
+++ b/pkg/solana/chainreader/event_read_binding_test.go
@@ -43,7 +43,7 @@ func TestBind(t *testing.T) {
 		reader := newEventReadBinding(namespace, genericName, subkeys, lpSource, readDef, pollerConf)
 		ctx := t.Context()
 
-		reader.Register(ctx)
+		require.NoError(t, reader.Register(ctx))
 		require.NoError(t, reader.Bind(ctx, address1))
 		require.NoError(t, reader.Bind(ctx, address1))
 		require.NoError(t, reader.Bind(ctx, address1))
@@ -60,7 +60,7 @@ func TestBind(t *testing.T) {
 		reader := newEventReadBinding(namespace, genericName, subkeys, lpSource, readDef, pollerConf)
 		ctx := t.Context()
 
-		reader.Register(ctx)
+		require.NoError(t, reader.Register(ctx))
 
 		var ret bool
 		lpSource.EXPECT().HasFilter(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, str string) bool {

--- a/pkg/solana/chainreader/filter.go
+++ b/pkg/solana/chainreader/filter.go
@@ -85,7 +85,6 @@ func (r *syncedFilter) Unregister(ctx context.Context, registrar filterRegistrar
 
 func (r *syncedFilter) unregister(ctx context.Context, registrar filterRegistrar, name string) error {
 	if !registrar.HasFilter(ctx, name) {
-		fmt.Println("333")
 		return nil
 	}
 

--- a/pkg/solana/chainreader/filter.go
+++ b/pkg/solana/chainreader/filter.go
@@ -16,16 +16,43 @@ type syncedFilter struct {
 	mu         sync.RWMutex
 	addressSet bool
 	filter     logpoller.Filter
+
+	dirty bool
 }
 
 func newSyncedFilter() *syncedFilter {
 	return &syncedFilter{}
 }
 
-func (r *syncedFilter) Register(ctx context.Context, registrar filterRegistrar) error {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+func (r *syncedFilter) Update(ctx context.Context, registrar filterRegistrar, updatedName string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
+	if !r.dirty {
+		return nil
+	}
+
+	oldName := r.filter.Name
+	r.filter.Name = updatedName
+
+	if err := r.register(ctx, registrar); err != nil {
+		return err
+	}
+
+	// filter updated successfully, it's not dirty anymore
+	r.dirty = false
+
+	return r.unregister(ctx, registrar, oldName)
+}
+
+func (r *syncedFilter) Register(ctx context.Context, registrar filterRegistrar) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.register(ctx, registrar)
+}
+
+func (r *syncedFilter) register(ctx context.Context, registrar filterRegistrar) error {
 	if !registrar.HasFilter(ctx, r.filter.Name) {
 		if err := registrar.RegisterFilter(ctx, r.filter); err != nil {
 			return FilterError{
@@ -43,11 +70,26 @@ func (r *syncedFilter) Unregister(ctx context.Context, registrar filterRegistrar
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	if !registrar.HasFilter(ctx, r.filter.Name) {
+	err := r.unregister(ctx, registrar, r.filter.Name)
+	if err != nil {
+		return err
+	}
+
+	r.setAddress(solana.PublicKey{})
+	r.setName("")
+
+	r.dirty = false
+
+	return nil
+}
+
+func (r *syncedFilter) unregister(ctx context.Context, registrar filterRegistrar, name string) error {
+	if !registrar.HasFilter(ctx, name) {
+		fmt.Println("333")
 		return nil
 	}
 
-	if err := registrar.UnregisterFilter(ctx, r.filter.Name); err != nil {
+	if err := registrar.UnregisterFilter(ctx, name); err != nil {
 		return FilterError{
 			Err:    fmt.Errorf("%w: %s", types.ErrInternal, err.Error()),
 			Action: "unregister",
@@ -69,6 +111,11 @@ func (r *syncedFilter) SetName(name string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	r.setName(name)
+}
+
+func (r *syncedFilter) setName(name string) {
+	r.dirty = true
 	r.filter.Name = name
 }
 
@@ -76,7 +123,18 @@ func (r *syncedFilter) SetAddress(address solana.PublicKey) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	r.setAddress(address)
+}
+
+func (r *syncedFilter) setAddress(address solana.PublicKey) {
 	r.addressSet = true
+
+	pkAddress := logpoller.PublicKey(address)
+	if r.filter.Address == pkAddress {
+		return
+	}
+
+	r.dirty = true
 	r.filter.Address = logpoller.PublicKey(address)
 }
 
@@ -85,6 +143,13 @@ func (r *syncedFilter) AddressSet() bool {
 	defer r.mu.RUnlock()
 
 	return r.addressSet
+}
+
+func (r *syncedFilter) Dirty() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.dirty
 }
 
 type FilterError struct {

--- a/pkg/solana/chainreader/lookup.go
+++ b/pkg/solana/chainreader/lookup.go
@@ -75,6 +75,27 @@ func (l *lookup) bindAddressForContract(contract, address string) {
 	}
 }
 
+func (l *lookup) hasAddress(contract, address string) bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	for _, reads := range l.contractReadNames[contract] {
+		readIdentifier := ""
+		if len(reads) > 0 {
+			readIdentifier = types.BoundContract{
+				Address: address,
+				Name:    contract,
+			}.ReadIdentifier(reads[0].readName)
+		}
+
+		if val, ok := l.readIdentifiers[readIdentifier]; ok && val.address == address {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (l *lookup) unbindAddressForContract(contract, address string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()


### PR DESCRIPTION
core ref: d6dc628e37584d513c9c14846f1ad22907019a88

[JIRA ticket](https://smartcontract-it.atlassian.net/browse/BCFR-1212)
- Event Bind registers filters before unregisters
- Event Unbind used to set empty name before call unregister (so it didn't remove filters)
- Bind the same address twice is noop
- CR Close() doesn't remove filters