### PR TITLE
Added cache to BlockHistoryEstimator to support larger block ranges

### DIFF
--- a/pkg/solana/config/config.go
+++ b/pkg/solana/config/config.go
@@ -79,30 +79,30 @@ type Config interface {
 }
 
 type Chain struct {
-	BlockTime                 *config.Duration
-	BalancePollPeriod           *config.Duration
-	ConfirmPollPeriod           *config.Duration
-	OCR2CachePollPeriod         *config.Duration
-	OCR2CacheTTL                *config.Duration
-	TxTimeout                   *config.Duration
-	TxRetryTimeout              *config.Duration
-	TxConfirmTimeout            *config.Duration
-	TxExpirationRebroadcast     *bool
-	TxRetentionTimeout          *config.Duration
-	SkipPreflight               *bool
-	Commitment                  *string
-	MaxRetries                  *int64
-	FeeEstimatorMode            *string
-	ComputeUnitPriceMax         *uint64
-	ComputeUnitPriceMin         *uint64
-	ComputeUnitPriceDefault     *uint64
-	FeeBumpPeriod               *config.Duration
-	BlockHistoryPollPeriod      *config.Duration
-	BlockHistorySize            *uint64
+	BlockTime                  *config.Duration
+	BalancePollPeriod          *config.Duration
+	ConfirmPollPeriod          *config.Duration
+	OCR2CachePollPeriod        *config.Duration
+	OCR2CacheTTL               *config.Duration
+	TxTimeout                  *config.Duration
+	TxRetryTimeout             *config.Duration
+	TxConfirmTimeout           *config.Duration
+	TxExpirationRebroadcast    *bool
+	TxRetentionTimeout         *config.Duration
+	SkipPreflight              *bool
+	Commitment                 *string
+	MaxRetries                 *int64
+	FeeEstimatorMode           *string
+	ComputeUnitPriceMax        *uint64
+	ComputeUnitPriceMin        *uint64
+	ComputeUnitPriceDefault    *uint64
+	FeeBumpPeriod              *config.Duration
+	BlockHistoryPollPeriod     *config.Duration
+	BlockHistorySize           *uint64
 	BlockHistoryCacheLoadBatch *uint64
-	ComputeUnitLimitDefault     *uint32
-	EstimateComputeUnitLimit    *bool
-	LogPollerStartingLookback *config.Duration
+	ComputeUnitLimitDefault    *uint32
+	EstimateComputeUnitLimit   *bool
+	LogPollerStartingLookback  *config.Duration
 }
 
 func (c *Chain) SetDefaults() {

--- a/pkg/solana/config/config.go
+++ b/pkg/solana/config/config.go
@@ -25,15 +25,16 @@ var defaultConfigSet = Chain{
 	MaxRetries:              ptr(int64(0)), // max number of retries (default = 0). when config.MaxRetries < 0), interpreted as MaxRetries = nil and rpc node will do a reasonable number of retries
 
 	// fee estimator
-	FeeEstimatorMode:         ptr("fixed"), // "fixed" or "blockhistory"
-	ComputeUnitPriceMax:      ptr(uint64(1_000)),
-	ComputeUnitPriceMin:      ptr(uint64(0)),
-	ComputeUnitPriceDefault:  ptr(uint64(0)),
-	FeeBumpPeriod:            config.MustNewDuration(3 * time.Second), // WARNING: If FeeBumpPeriod is shorter than blockhash expiration, multiple valid transactions can exist in parallel. This can result in higher costs and can cause unexpected behaviors if contracts do not de-dupe txs. Set to 0 to disable fee bumping.
-	BlockHistoryPollPeriod:   config.MustNewDuration(5 * time.Second),
-	BlockHistorySize:         ptr(uint64(1)),       // 1: uses latest block; >1: Uses multiple blocks, where n is number of blocks. DISCLAIMER: 1:1 ratio between n and RPC calls.
-	ComputeUnitLimitDefault:  ptr(uint32(200_000)), // set to 0 to disable adding compute unit limit
-	EstimateComputeUnitLimit: ptr(false),           // set to false to disable compute unit limit estimation
+	FeeEstimatorMode:           ptr("fixed"), // "fixed" or "blockhistory"
+	ComputeUnitPriceMax:        ptr(uint64(1_000)),
+	ComputeUnitPriceMin:        ptr(uint64(0)),
+	ComputeUnitPriceDefault:    ptr(uint64(0)),
+	FeeBumpPeriod:              config.MustNewDuration(3 * time.Second), // WARNING: If FeeBumpPeriod is shorter than blockhash expiration, multiple valid transactions can exist in parallel. This can result in higher costs and can cause unexpected behaviors if contracts do not de-dupe txs. Set to 0 to disable fee bumping.
+	BlockHistoryPollPeriod:     config.MustNewDuration(5 * time.Second),
+	BlockHistorySize:           ptr(uint64(1)),       // 1: uses latest block; >1: Uses multiple blocks, where n is number of blocks.
+	BlockHistoryCacheLoadBatch: ptr(uint64(20)),      // set to the number of blocks that should be loaded into the cache every poll period if BlockHistorySize > 1. Ensure this value is greater than the number of blocks that would be produced between each BlockHistoryPollPeriod to avoid block gaps. BlockHistorySize is used instead if BlockHistorySize <  BlockHistoryCacheLoadBatch.
+	ComputeUnitLimitDefault:    ptr(uint32(200_000)), // set to 0 to disable adding compute unit limit
+	EstimateComputeUnitLimit:   ptr(false),           // set to false to disable compute unit limit estimation
 }
 
 type Config interface {
@@ -58,32 +59,34 @@ type Config interface {
 	FeeBumpPeriod() time.Duration
 	BlockHistoryPollPeriod() time.Duration
 	BlockHistorySize() uint64
+	BlockHistoryCacheLoadBatch() uint64
 	ComputeUnitLimitDefault() uint32
 	EstimateComputeUnitLimit() bool
 }
 
 type Chain struct {
-	BalancePollPeriod        *config.Duration
-	ConfirmPollPeriod        *config.Duration
-	OCR2CachePollPeriod      *config.Duration
-	OCR2CacheTTL             *config.Duration
-	TxTimeout                *config.Duration
-	TxRetryTimeout           *config.Duration
-	TxConfirmTimeout         *config.Duration
-	TxExpirationRebroadcast  *bool
-	TxRetentionTimeout       *config.Duration
-	SkipPreflight            *bool
-	Commitment               *string
-	MaxRetries               *int64
-	FeeEstimatorMode         *string
-	ComputeUnitPriceMax      *uint64
-	ComputeUnitPriceMin      *uint64
-	ComputeUnitPriceDefault  *uint64
-	FeeBumpPeriod            *config.Duration
-	BlockHistoryPollPeriod   *config.Duration
-	BlockHistorySize         *uint64
-	ComputeUnitLimitDefault  *uint32
-	EstimateComputeUnitLimit *bool
+	BalancePollPeriod          *config.Duration
+	ConfirmPollPeriod          *config.Duration
+	OCR2CachePollPeriod        *config.Duration
+	OCR2CacheTTL               *config.Duration
+	TxTimeout                  *config.Duration
+	TxRetryTimeout             *config.Duration
+	TxConfirmTimeout           *config.Duration
+	TxExpirationRebroadcast    *bool
+	TxRetentionTimeout         *config.Duration
+	SkipPreflight              *bool
+	Commitment                 *string
+	MaxRetries                 *int64
+	FeeEstimatorMode           *string
+	ComputeUnitPriceMax        *uint64
+	ComputeUnitPriceMin        *uint64
+	ComputeUnitPriceDefault    *uint64
+	FeeBumpPeriod              *config.Duration
+	BlockHistoryPollPeriod     *config.Duration
+	BlockHistorySize           *uint64
+	BlockHistoryCacheLoadBatch *uint64
+	ComputeUnitLimitDefault    *uint32
+	EstimateComputeUnitLimit   *bool
 }
 
 func (c *Chain) SetDefaults() {
@@ -143,6 +146,9 @@ func (c *Chain) SetDefaults() {
 	}
 	if c.BlockHistorySize == nil {
 		c.BlockHistorySize = defaultConfigSet.BlockHistorySize
+	}
+	if c.BlockHistoryCacheLoadBatch == nil {
+		c.BlockHistoryCacheLoadBatch = defaultConfigSet.BlockHistoryCacheLoadBatch
 	}
 	if c.ComputeUnitLimitDefault == nil {
 		c.ComputeUnitLimitDefault = defaultConfigSet.ComputeUnitLimitDefault

--- a/pkg/solana/config/config.go
+++ b/pkg/solana/config/config.go
@@ -29,16 +29,16 @@ var defaultConfigSet = Chain{
 	MaxRetries:              ptr(int64(0)), // max number of retries (default = 0). when config.MaxRetries < 0), interpreted as MaxRetries = nil and rpc node will do a reasonable number of retries
 
 	// fee estimator
-	FeeEstimatorMode:           ptr("fixed"), // "fixed" or "blockhistory"
-	ComputeUnitPriceMax:        ptr(uint64(1_000)),
-	ComputeUnitPriceMin:        ptr(uint64(0)),
-	ComputeUnitPriceDefault:    ptr(uint64(0)),
-	FeeBumpPeriod:              config.MustNewDuration(3 * time.Second), // WARNING: If FeeBumpPeriod is shorter than blockhash expiration, multiple valid transactions can exist in parallel. This can result in higher costs and can cause unexpected behaviors if contracts do not de-dupe txs. Set to 0 to disable fee bumping.
-	BlockHistoryPollPeriod:     config.MustNewDuration(5 * time.Second),
-	BlockHistorySize:           ptr(uint64(1)),       // 1: uses latest block; >1: Uses multiple blocks, where n is number of blocks.
-	BlockHistoryCacheLoadBatch: ptr(uint64(20)),      // set to the number of blocks that should be loaded into the cache every poll period if BlockHistorySize > 1. Ensure this value is greater than the number of blocks that would be produced between each BlockHistoryPollPeriod to avoid block gaps. BlockHistorySize is used instead if BlockHistorySize <  BlockHistoryCacheLoadBatch.
-	ComputeUnitLimitDefault:    ptr(uint32(200_000)), // set to 0 to disable adding compute unit limit
-	EstimateComputeUnitLimit:   ptr(false),           // set to false to disable compute unit limit estimation
+	FeeEstimatorMode:          ptr("fixed"), // "fixed" or "blockhistory"
+	ComputeUnitPriceMax:       ptr(uint64(1_000)),
+	ComputeUnitPriceMin:       ptr(uint64(0)),
+	ComputeUnitPriceDefault:   ptr(uint64(0)),
+	FeeBumpPeriod:             config.MustNewDuration(3 * time.Second), // WARNING: If FeeBumpPeriod is shorter than blockhash expiration, multiple valid transactions can exist in parallel. This can result in higher costs and can cause unexpected behaviors if contracts do not de-dupe txs. Set to 0 to disable fee bumping.
+	BlockHistoryPollPeriod:    config.MustNewDuration(5 * time.Second),
+	BlockHistorySize:          ptr(uint64(1)),       // set to the number of blocks estimations should be made over. 1: uses latest block; >1: Uses multiple blocks, where n is number of blocks.
+	BlockHistoryBatchLoadSize: ptr(uint64(20)),      // set to the number of blocks that should be loaded into the cache every poll period if BlockHistorySize > 1. Ensure this value is greater than the number of blocks that would be produced between each BlockHistoryPollPeriod to avoid block gaps. BlockHistorySize is used instead if BlockHistorySize <  BlockHistoryBatchLoadSize.
+	ComputeUnitLimitDefault:   ptr(uint32(200_000)), // set to 0 to disable adding compute unit limit
+	EstimateComputeUnitLimit:  ptr(false),           // set to false to disable compute unit limit estimation
 
 	// log poller
 	LogPollerStartingLookback: config.MustNewDuration(24 * time.Hour),
@@ -70,7 +70,7 @@ type Config interface {
 	FeeBumpPeriod() time.Duration
 	BlockHistoryPollPeriod() time.Duration
 	BlockHistorySize() uint64
-	BlockHistoryCacheLoadBatch() uint64
+	BlockHistoryBatchLoadSize() uint64
 	ComputeUnitLimitDefault() uint32
 	EstimateComputeUnitLimit() bool
 
@@ -79,30 +79,30 @@ type Config interface {
 }
 
 type Chain struct {
-	BlockTime                  *config.Duration
-	BalancePollPeriod          *config.Duration
-	ConfirmPollPeriod          *config.Duration
-	OCR2CachePollPeriod        *config.Duration
-	OCR2CacheTTL               *config.Duration
-	TxTimeout                  *config.Duration
-	TxRetryTimeout             *config.Duration
-	TxConfirmTimeout           *config.Duration
-	TxExpirationRebroadcast    *bool
-	TxRetentionTimeout         *config.Duration
-	SkipPreflight              *bool
-	Commitment                 *string
-	MaxRetries                 *int64
-	FeeEstimatorMode           *string
-	ComputeUnitPriceMax        *uint64
-	ComputeUnitPriceMin        *uint64
-	ComputeUnitPriceDefault    *uint64
-	FeeBumpPeriod              *config.Duration
-	BlockHistoryPollPeriod     *config.Duration
-	BlockHistorySize           *uint64
-	BlockHistoryCacheLoadBatch *uint64
-	ComputeUnitLimitDefault    *uint32
-	EstimateComputeUnitLimit   *bool
-	LogPollerStartingLookback  *config.Duration
+	BlockTime                 *config.Duration
+	BalancePollPeriod         *config.Duration
+	ConfirmPollPeriod         *config.Duration
+	OCR2CachePollPeriod       *config.Duration
+	OCR2CacheTTL              *config.Duration
+	TxTimeout                 *config.Duration
+	TxRetryTimeout            *config.Duration
+	TxConfirmTimeout          *config.Duration
+	TxExpirationRebroadcast   *bool
+	TxRetentionTimeout        *config.Duration
+	SkipPreflight             *bool
+	Commitment                *string
+	MaxRetries                *int64
+	FeeEstimatorMode          *string
+	ComputeUnitPriceMax       *uint64
+	ComputeUnitPriceMin       *uint64
+	ComputeUnitPriceDefault   *uint64
+	FeeBumpPeriod             *config.Duration
+	BlockHistoryPollPeriod    *config.Duration
+	BlockHistorySize          *uint64
+	BlockHistoryBatchLoadSize *uint64
+	ComputeUnitLimitDefault   *uint32
+	EstimateComputeUnitLimit  *bool
+	LogPollerStartingLookback *config.Duration
 }
 
 func (c *Chain) SetDefaults() {
@@ -166,8 +166,8 @@ func (c *Chain) SetDefaults() {
 	if c.BlockHistorySize == nil {
 		c.BlockHistorySize = defaultConfigSet.BlockHistorySize
 	}
-	if c.BlockHistoryCacheLoadBatch == nil {
-		c.BlockHistoryCacheLoadBatch = defaultConfigSet.BlockHistoryCacheLoadBatch
+	if c.BlockHistoryBatchLoadSize == nil {
+		c.BlockHistoryBatchLoadSize = defaultConfigSet.BlockHistoryBatchLoadSize
 	}
 	if c.ComputeUnitLimitDefault == nil {
 		c.ComputeUnitLimitDefault = defaultConfigSet.ComputeUnitLimitDefault

--- a/pkg/solana/config/mocks/config.go
+++ b/pkg/solana/config/mocks/config.go
@@ -67,6 +67,51 @@ func (_c *Config_BalancePollPeriod_Call) RunAndReturn(run func() time.Duration) 
 	return _c
 }
 
+// BlockHistoryCacheLoadBatch provides a mock function with no fields
+func (_m *Config) BlockHistoryCacheLoadBatch() uint64 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for BlockHistoryCacheLoadBatch")
+	}
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func() uint64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	return r0
+}
+
+// Config_BlockHistoryCacheLoadBatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BlockHistoryCacheLoadBatch'
+type Config_BlockHistoryCacheLoadBatch_Call struct {
+	*mock.Call
+}
+
+// BlockHistoryCacheLoadBatch is a helper method to define mock.On call
+func (_e *Config_Expecter) BlockHistoryCacheLoadBatch() *Config_BlockHistoryCacheLoadBatch_Call {
+	return &Config_BlockHistoryCacheLoadBatch_Call{Call: _e.mock.On("BlockHistoryCacheLoadBatch")}
+}
+
+func (_c *Config_BlockHistoryCacheLoadBatch_Call) Run(run func()) *Config_BlockHistoryCacheLoadBatch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Config_BlockHistoryCacheLoadBatch_Call) Return(_a0 uint64) *Config_BlockHistoryCacheLoadBatch_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_BlockHistoryCacheLoadBatch_Call) RunAndReturn(run func() uint64) *Config_BlockHistoryCacheLoadBatch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // BlockHistoryPollPeriod provides a mock function with no fields
 func (_m *Config) BlockHistoryPollPeriod() time.Duration {
 	ret := _m.Called()

--- a/pkg/solana/config/mocks/config.go
+++ b/pkg/solana/config/mocks/config.go
@@ -67,12 +67,12 @@ func (_c *Config_BalancePollPeriod_Call) RunAndReturn(run func() time.Duration) 
 	return _c
 }
 
-// BlockHistoryCacheLoadBatch provides a mock function with no fields
-func (_m *Config) BlockHistoryCacheLoadBatch() uint64 {
+// BlockHistoryBatchLoadSize provides a mock function with no fields
+func (_m *Config) BlockHistoryBatchLoadSize() uint64 {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for BlockHistoryCacheLoadBatch")
+		panic("no return value specified for BlockHistoryBatchLoadSize")
 	}
 
 	var r0 uint64
@@ -85,29 +85,29 @@ func (_m *Config) BlockHistoryCacheLoadBatch() uint64 {
 	return r0
 }
 
-// Config_BlockHistoryCacheLoadBatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BlockHistoryCacheLoadBatch'
-type Config_BlockHistoryCacheLoadBatch_Call struct {
+// Config_BlockHistoryBatchLoadSize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BlockHistoryBatchLoadSize'
+type Config_BlockHistoryBatchLoadSize_Call struct {
 	*mock.Call
 }
 
-// BlockHistoryCacheLoadBatch is a helper method to define mock.On call
-func (_e *Config_Expecter) BlockHistoryCacheLoadBatch() *Config_BlockHistoryCacheLoadBatch_Call {
-	return &Config_BlockHistoryCacheLoadBatch_Call{Call: _e.mock.On("BlockHistoryCacheLoadBatch")}
+// BlockHistoryBatchLoadSize is a helper method to define mock.On call
+func (_e *Config_Expecter) BlockHistoryBatchLoadSize() *Config_BlockHistoryBatchLoadSize_Call {
+	return &Config_BlockHistoryBatchLoadSize_Call{Call: _e.mock.On("BlockHistoryBatchLoadSize")}
 }
 
-func (_c *Config_BlockHistoryCacheLoadBatch_Call) Run(run func()) *Config_BlockHistoryCacheLoadBatch_Call {
+func (_c *Config_BlockHistoryBatchLoadSize_Call) Run(run func()) *Config_BlockHistoryBatchLoadSize_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *Config_BlockHistoryCacheLoadBatch_Call) Return(_a0 uint64) *Config_BlockHistoryCacheLoadBatch_Call {
+func (_c *Config_BlockHistoryBatchLoadSize_Call) Return(_a0 uint64) *Config_BlockHistoryBatchLoadSize_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Config_BlockHistoryCacheLoadBatch_Call) RunAndReturn(run func() uint64) *Config_BlockHistoryCacheLoadBatch_Call {
+func (_c *Config_BlockHistoryBatchLoadSize_Call) RunAndReturn(run func() uint64) *Config_BlockHistoryBatchLoadSize_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/solana/config/toml.go
+++ b/pkg/solana/config/toml.go
@@ -193,6 +193,15 @@ func setFromChain(c, f *Chain) {
 	if f.BlockHistorySize != nil {
 		c.BlockHistorySize = f.BlockHistorySize
 	}
+	if f.BlockHistoryCacheLoadBatch != nil {
+		c.BlockHistoryCacheLoadBatch = f.BlockHistoryCacheLoadBatch
+	}
+	if f.ComputeUnitLimitDefault != nil {
+		c.ComputeUnitLimitDefault = f.ComputeUnitLimitDefault
+	}
+	if f.EstimateComputeUnitLimit != nil {
+		c.EstimateComputeUnitLimit = f.EstimateComputeUnitLimit
+	}
 }
 
 func (c *TOMLConfig) ValidateConfig() (err error) {
@@ -298,6 +307,10 @@ func (c *TOMLConfig) BlockHistoryPollPeriod() time.Duration {
 
 func (c *TOMLConfig) BlockHistorySize() uint64 {
 	return *c.Chain.BlockHistorySize
+}
+
+func (c *TOMLConfig) BlockHistoryCacheLoadBatch() uint64 {
+	return *c.Chain.BlockHistoryCacheLoadBatch
 }
 
 func (c *TOMLConfig) ComputeUnitLimitDefault() uint32 {

--- a/pkg/solana/config/toml.go
+++ b/pkg/solana/config/toml.go
@@ -199,8 +199,8 @@ func setFromChain(c, f *Chain) {
 	if f.LogPollerStartingLookback != nil {
 		c.LogPollerStartingLookback = f.LogPollerStartingLookback
 	}
-	if f.BlockHistoryCacheLoadBatch != nil {
-		c.BlockHistoryCacheLoadBatch = f.BlockHistoryCacheLoadBatch
+	if f.BlockHistoryBatchLoadSize != nil {
+		c.BlockHistoryBatchLoadSize = f.BlockHistoryBatchLoadSize
 	}
 	if f.ComputeUnitLimitDefault != nil {
 		c.ComputeUnitLimitDefault = f.ComputeUnitLimitDefault
@@ -323,8 +323,8 @@ func (c *TOMLConfig) BlockHistorySize() uint64 {
 	return *c.Chain.BlockHistorySize
 }
 
-func (c *TOMLConfig) BlockHistoryCacheLoadBatch() uint64 {
-	return *c.Chain.BlockHistoryCacheLoadBatch
+func (c *TOMLConfig) BlockHistoryBatchLoadSize() uint64 {
+	return *c.Chain.BlockHistoryBatchLoadSize
 }
 
 func (c *TOMLConfig) ComputeUnitLimitDefault() uint32 {

--- a/pkg/solana/fees/block_history.go
+++ b/pkg/solana/fees/block_history.go
@@ -117,7 +117,7 @@ func (bhe *blockHistoryEstimator) readRawPrice() uint64 {
 func (bhe *blockHistoryEstimator) calculatePrice(ctx context.Context) error {
 	switch {
 	case bhe.cfg.BlockHistorySize() > 1:
-		if err := bhe.populateCache(ctx, bhe.cfg.BlockHistoryCacheLoadBatch(), bhe.cfg.BlockHistorySize()); err != nil {
+		if err := bhe.populateCache(ctx, bhe.cfg.BlockHistoryBatchLoadSize(), bhe.cfg.BlockHistorySize()); err != nil {
 			return fmt.Errorf("failed to populate cache: %w", err)
 		}
 		return bhe.calculatePriceFromMultipleBlocks(bhe.cfg.BlockHistorySize())

--- a/pkg/solana/fees/block_history.go
+++ b/pkg/solana/fees/block_history.go
@@ -54,7 +54,7 @@ func NewBlockHistoryEstimator(c func(context.Context) (client.ReaderWriter, erro
 		cfg:    cfg,
 		lgr:    lgr,
 		price:  cfg.ComputeUnitPriceDefault(), // use default value
-		cache:  blockMedianCache{medianMap: make(map[uint64]ComputeUnitPrice)},
+		cache:  blockMedianCache{storedBlockRange: make([]uint64, 0, cfg.BlockHistorySize()), medianMap: make(map[uint64]ComputeUnitPrice, cfg.BlockHistorySize())},
 	}, nil
 }
 
@@ -188,7 +188,8 @@ func (bhe *blockHistoryEstimator) calculatePriceFromMultipleBlocks(desiredBlockC
 		return fmt.Errorf("failed to calculate price from avg of medians: %w", err)
 	}
 
-	// Update the current price to the calculated average (avg of medians of the last desiredBlockCount)
+	// Update the current price to the calculated average
+	// The calculated average could be over a smaller range of blocks than desiredBlockCount if cache is partially filled during startup
 	bhe.lock.Lock()
 	bhe.price = uint64(avgOfMedians)
 	bhe.lock.Unlock()
@@ -209,7 +210,7 @@ func (bhe *blockHistoryEstimator) populateCache(ctx context.Context, loadBatch, 
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	// Fetch the latest slot
+	// Fetch the latest slot for processed commitment
 	currentSlot, err := c.SlotHeight(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get current slot: %w", err)
@@ -221,7 +222,7 @@ func (bhe *blockHistoryEstimator) populateCache(ctx context.Context, loadBatch, 
 	}
 	startSlot := currentSlot - batch + 1
 
-	// Fetch the last confirmed block slots
+	// Fetch the latest slots with blocks for the configured commitment level
 	confirmedSlots, err := c.GetBlocksWithLimit(ctx, startSlot, batch)
 	if err != nil {
 		return fmt.Errorf("failed to get blocks with limit: %w", err)

--- a/pkg/solana/fees/block_history.go
+++ b/pkg/solana/fees/block_history.go
@@ -3,6 +3,8 @@ package fees
 import (
 	"context"
 	"fmt"
+	"math"
+	"slices"
 	"sync"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -28,6 +30,14 @@ type blockHistoryEstimator struct {
 
 	price uint64
 	lock  sync.RWMutex
+
+	cache   blockMedianCache
+	cacheMu sync.RWMutex
+}
+
+type blockMedianCache struct {
+	storedBlockRange []uint64
+	medianMap        map[uint64]ComputeUnitPrice // block num to median
 }
 
 // NewBlockHistoryEstimator creates a new fee estimator that parses historical fees from a fetched block
@@ -44,6 +54,7 @@ func NewBlockHistoryEstimator(c func(context.Context) (client.ReaderWriter, erro
 		cfg:    cfg,
 		lgr:    lgr,
 		price:  cfg.ComputeUnitPriceDefault(), // use default value
+		cache:  blockMedianCache{medianMap: make(map[uint64]ComputeUnitPrice)},
 	}, nil
 }
 
@@ -106,7 +117,10 @@ func (bhe *blockHistoryEstimator) readRawPrice() uint64 {
 func (bhe *blockHistoryEstimator) calculatePrice(ctx context.Context) error {
 	switch {
 	case bhe.cfg.BlockHistorySize() > 1:
-		return bhe.calculatePriceFromMultipleBlocks(ctx, bhe.cfg.BlockHistorySize())
+		if err := bhe.populateCache(ctx, bhe.cfg.BlockHistoryCacheLoadBatch(), bhe.cfg.BlockHistorySize()); err != nil {
+			return fmt.Errorf("failed to populate cache: %w", err)
+		}
+		return bhe.calculatePriceFromMultipleBlocks(bhe.cfg.BlockHistorySize())
 	default:
 		return bhe.calculatePriceFromLatestBlock(ctx)
 	}
@@ -155,7 +169,40 @@ func (bhe *blockHistoryEstimator) calculatePriceFromLatestBlock(ctx context.Cont
 	return nil
 }
 
-func (bhe *blockHistoryEstimator) calculatePriceFromMultipleBlocks(ctx context.Context, desiredBlockCount uint64) error {
+func (bhe *blockHistoryEstimator) calculatePriceFromMultipleBlocks(desiredBlockCount uint64) error {
+	bhe.cacheMu.RLock()
+	defer bhe.cacheMu.RUnlock()
+	blockMedians := make([]ComputeUnitPrice, 0, desiredBlockCount)
+
+	if len(bhe.cache.medianMap) == 0 {
+		return errNoComputeUnitPriceCollected
+	}
+
+	for _, median := range bhe.cache.medianMap {
+		blockMedians = append(blockMedians, median)
+	}
+
+	// Calculate avg from medians of the blocks.
+	avgOfMedians, err := mathutil.Avg(blockMedians...)
+	if err != nil {
+		return fmt.Errorf("failed to calculate price from avg of medians: %w", err)
+	}
+
+	// Update the current price to the calculated average (avg of medians of the last desiredBlockCount)
+	bhe.lock.Lock()
+	bhe.price = uint64(avgOfMedians)
+	bhe.lock.Unlock()
+
+	bhe.lgr.Debugw("BlockHistoryEstimator: updated",
+		"computeUnitPriceAvg", avgOfMedians,
+		"numBlocks", len(blockMedians),
+	)
+
+	return nil
+}
+
+func (bhe *blockHistoryEstimator) populateCache(ctx context.Context, loadBatch, desiredBlockCount uint64) error {
+	batch := uint64(math.Min(float64(loadBatch), float64(desiredBlockCount)))
 	// fetch client
 	c, err := bhe.client(ctx)
 	if err != nil {
@@ -169,13 +216,13 @@ func (bhe *blockHistoryEstimator) calculatePriceFromMultipleBlocks(ctx context.C
 	}
 
 	// Determine the starting slot for fetching blocks
-	if currentSlot < desiredBlockCount {
+	if currentSlot < batch {
 		return fmt.Errorf("current slot is less than desired block count")
 	}
-	startSlot := currentSlot - desiredBlockCount + 1
+	startSlot := currentSlot - batch + 1
 
 	// Fetch the last confirmed block slots
-	confirmedSlots, err := c.GetBlocksWithLimit(ctx, startSlot, desiredBlockCount)
+	confirmedSlots, err := c.GetBlocksWithLimit(ctx, startSlot, batch)
 	if err != nil {
 		return fmt.Errorf("failed to get blocks with limit: %w", err)
 	}
@@ -183,13 +230,19 @@ func (bhe *blockHistoryEstimator) calculatePriceFromMultipleBlocks(ctx context.C
 	// limit concurrency (avoid hitting rate limits)
 	semaphore := make(chan struct{}, 10)
 	var wg sync.WaitGroup
-	var mu sync.Mutex
-	blockMedians := make([]ComputeUnitPrice, 0, desiredBlockCount)
 
 	// Iterate over the confirmed slots in reverse order to fetch most recent blocks first
 	// Iterate until we run out of slots
 	for i := len(*confirmedSlots) - 1; i >= 0; i-- {
 		slot := (*confirmedSlots)[i]
+
+		// If median already exists for slot, skip fetching block
+		bhe.cacheMu.RLock()
+		_, exists := bhe.cache.medianMap[slot]
+		bhe.cacheMu.RUnlock()
+		if exists {
+			continue
+		}
 
 		wg.Add(1)
 		go func(s uint64) {
@@ -229,38 +282,30 @@ func (bhe *blockHistoryEstimator) calculatePriceFromMultipleBlocks(ctx context.C
 				return
 			}
 
-			// Append the median compute unit price if we haven't reached our desiredBlockCount
-			mu.Lock()
-			defer mu.Unlock()
-			if uint64(len(blockMedians)) < desiredBlockCount {
-				blockMedians = append(blockMedians, blockMedian)
-			}
+			// Store the block median price in cache
+			bhe.cacheMu.Lock()
+			bhe.cache.medianMap[s] = blockMedian
+			bhe.cache.storedBlockRange = append(bhe.cache.storedBlockRange, s)
+			bhe.cacheMu.Unlock()
 		}(slot)
 	}
 
 	wg.Wait()
 
-	if len(blockMedians) == 0 {
-		return errNoComputeUnitPriceCollected
+	bhe.cacheMu.Lock()
+	defer bhe.cacheMu.Unlock()
+	excessBlocks := uint64(len(bhe.cache.storedBlockRange)) - desiredBlockCount
+	// Return early if block median cache does not exceed the desired block count
+	if excessBlocks <= 0 {
+		return nil
 	}
-
-	// Calculate avg from medians of the blocks.
-	avgOfMedians, err := mathutil.Avg(blockMedians...)
-	if err != nil {
-		return fmt.Errorf("failed to calculate price from avg of medians: %w", err)
+	// Sort stored block nums (oldest to newest)
+	slices.Sort(bhe.cache.storedBlockRange)
+	// Clear out the oldest blocks that exceed the desired block count
+	for i := range excessBlocks {
+		slot := bhe.cache.storedBlockRange[i]
+		delete(bhe.cache.medianMap, slot)
 	}
-
-	// Update the current price to the calculated average (avg of medians of the last desiredBlockCount)
-	bhe.lock.Lock()
-	bhe.price = uint64(avgOfMedians)
-	bhe.lock.Unlock()
-
-	bhe.lgr.Debugw("BlockHistoryEstimator: updated",
-		"computeUnitPriceMedian", avgOfMedians,
-		"latestSlot", currentSlot,
-		"numBlocks", len(blockMedians),
-		"pricesCollected", blockMedians,
-	)
-
+	bhe.cache.storedBlockRange = bhe.cache.storedBlockRange[excessBlocks:]
 	return nil
 }

--- a/pkg/solana/fees/block_history.go
+++ b/pkg/solana/fees/block_history.go
@@ -294,8 +294,8 @@ func (bhe *blockHistoryEstimator) populateCache(ctx context.Context, loadBatch, 
 
 	bhe.cacheMu.Lock()
 	defer bhe.cacheMu.Unlock()
-	excessBlocks := uint64(len(bhe.cache.storedBlockRange)) - desiredBlockCount
-	// Return early if block median cache does not exceed the desired block count
+	excessBlocks := len(bhe.cache.storedBlockRange) - int(desiredBlockCount) //nolint:gosec // block history size cannot reasonably exceed int max
+	// Return early if cache size does not exceed the desired block count
 	if excessBlocks <= 0 {
 		return nil
 	}

--- a/pkg/solana/fees/block_history_test.go
+++ b/pkg/solana/fees/block_history_test.go
@@ -223,6 +223,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		cfg := cfgmock.NewConfig(t)
 		tmpMin := uint64(multipleBlocksAvg) + 100 // Set min higher than the avg price
 		setupConfigMock(cfg, defaultPrice, tmpMin, pollPeriod, depth)
+		cfg.On("ComputeUnitPriceMin").Return(tmpMin)
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
 		// Wait for estimator to populate the cache and calculate the latest price
@@ -230,7 +231,6 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 
 		// Compute unit price should be floored at min
 		require.NoError(t, estimator.calculatePriceFromMultipleBlocks(depth), "Failed to calculate price with price below min")
-		cfg.On("ComputeUnitPriceMin").Return(tmpMin)
 		assert.Equal(t, tmpMin, estimator.BaseComputeUnitPrice(), "Price should be floored at min")
 	})
 
@@ -239,6 +239,8 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		cfg := cfgmock.NewConfig(t)
 		tmpMax := uint64(multipleBlocksAvg) - 100 // Set tmpMax lower than the avg price
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
+		cfg.On("ComputeUnitPriceMax").Return(tmpMax)
+		cfg.On("ComputeUnitPriceMin").Return(minPrice)
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
 		// Wait for estimator to populate the cache and calculate the latest price
@@ -246,8 +248,6 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 
 		// Compute unit price should be capped at max
 		require.NoError(t, estimator.calculatePriceFromMultipleBlocks(depth), "Failed to calculate price with price above max")
-		cfg.On("ComputeUnitPriceMax").Return(tmpMax)
-		cfg.On("ComputeUnitPriceMin").Return(minPrice)
 		assert.Equal(t, tmpMax, estimator.BaseComputeUnitPrice(), "Price should be capped at max")
 	})
 
@@ -260,6 +260,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		}
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
+		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		estimator := initializeEstimator(ctx, t, rwFailLoader, cfg, logger.Test(t))
 
 		// Wait for estimator to populate the cache and calculate the latest price
@@ -267,7 +268,6 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 
 		// Price should remain unchanged
 		require.Error(t, estimator.calculatePriceFromMultipleBlocks(depth), "Expected error when getting client fails")
-		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
 	})
 
@@ -277,6 +277,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		rwLoader := func(ctx context.Context) (client.ReaderWriter, error) { return rw, nil }
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
+		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		rw.On("SlotHeight", mock.Anything).Return(uint64(0), fmt.Errorf("failed to get current slot")) // Mock SlotHeight returning error
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
@@ -285,7 +286,6 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 
 		// Price should remain unchanged
 		require.Error(t, estimator.calculatePriceFromMultipleBlocks(depth), "Expected error when getting current slot fails")
-		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
 	})
 
@@ -295,6 +295,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		rwLoader := func(ctx context.Context) (client.ReaderWriter, error) { return rw, nil }
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
+		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		rw.On("SlotHeight", mock.Anything).Return(depth-1, nil) // Mock SlotHeight returning less than desiredBlockCount
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
@@ -303,7 +304,6 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 
 		// Price should remain unchanged
 		require.Error(t, estimator.calculatePriceFromMultipleBlocks(depth), "Expected error when current slot is less than desired block count")
-		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
 	})
 
@@ -313,6 +313,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		rwLoader := func(ctx context.Context) (client.ReaderWriter, error) { return rw, nil }
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
+		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		rw.On("SlotHeight", mock.Anything).Return(testSlots[len(testSlots)-1], nil)
 		rw.On("GetBlocksWithLimit", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil, fmt.Errorf("failed to get blocks with limit")) // Mock GetBlocksWithLimit returning error
@@ -323,7 +324,6 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 
 		// Price should remain unchanged
 		require.Error(t, estimator.calculatePriceFromMultipleBlocks(depth), "Expected error when getting blocks with limit fails")
-		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
 	})
 
@@ -333,6 +333,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		rwLoader := func(ctx context.Context) (client.ReaderWriter, error) { return rw, nil }
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
+		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		rw.On("SlotHeight", mock.Anything).Return(testSlots[len(testSlots)-1], nil)
 		emptyBlocks := rpc.BlocksResult{} // No blocks with compute unit prices
 		rw.On("GetBlocksWithLimit", mock.Anything, mock.Anything, mock.Anything).
@@ -344,7 +345,6 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 
 		// Price should remain unchanged
 		require.EqualError(t, estimator.calculatePriceFromMultipleBlocks(depth), errNoComputeUnitPriceCollected.Error(), "Expected error when no compute unit prices are collected")
-		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
 	})
 }
@@ -355,6 +355,7 @@ func setupConfigMock(cfg *cfgmock.Config, defaultPrice uint64, minPrice uint64, 
 	cfg.On("ComputeUnitPriceMin").Return(minPrice).Maybe()
 	cfg.On("BlockHistoryPollPeriod").Return(pollPeriod).Once()
 	cfg.On("BlockHistorySize").Return(depth)
+	cfg.On("BlockHistoryCacheLoadBatch").Return(uint64(20)).Maybe()
 }
 
 // initializeEstimator initializes, starts, and ensures cleanup of the BlockHistoryEstimator.

--- a/pkg/solana/fees/block_history_test.go
+++ b/pkg/solana/fees/block_history_test.go
@@ -174,8 +174,8 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 
 	// Extract slots and compute unit prices from the blocks
 	// We'll consider the last 'BlockHistorySize' blocks
-	var testSlots []uint64
-	var testPrices []ComputeUnitPrice
+	testSlots := make([]uint64, 0, len(testBlocks))
+	testPrices := make([]ComputeUnitPrice, 0, len(testBlocks))
 	startIndex := len(testBlocks) - int(depth)
 	testBlocks = testBlocks[startIndex:]
 	for _, block := range testBlocks {
@@ -216,6 +216,39 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		// Calculated avg price should be equal to the one extracted manually from the blocks.
 		require.NoError(t, estimator.calculatePriceFromMultipleBlocks(depth))
 		assert.Equal(t, uint64(multipleBlocksAvg), estimator.BaseComputeUnitPrice())
+	})
+
+	t.Run("Successful Estimation with partial cache fill", func(t *testing.T) {
+		// lgr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
+		partialCacheRW := clientmock.NewReaderWriter(t)
+		partialCacheRWLoader := func(ctx context.Context) (client.ReaderWriter, error) { return partialCacheRW, nil }
+		partialCacheRW.On("SlotHeight", mock.Anything).Return(testSlots[len(testSlots)-1], nil)
+		testSlotsResult := rpc.BlocksResult(testSlots[1:])
+		partialCacheRW.On("GetBlocksWithLimit", mock.Anything, mock.Anything, mock.Anything).
+			Return(&testSlotsResult, nil)
+		for i, slot := range testSlots {
+			// Skip mocking the oldest block fetch because of partial load
+			if i == 0 {
+				continue
+			}
+			partialCacheRW.On("GetBlock", mock.Anything, slot).Return(testBlocks[i], nil).Once()
+		}
+
+		// Setup
+		cfg := cfgmock.NewConfig(t)
+		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
+		cfg.On("ComputeUnitPriceMax").Return(maxPrice).Maybe()
+		cfg.On("BlockHistoryCacheLoadBatch").Return(uint64(len(testBlocks)-1)) // Set cache load batch smaller than depth to simulate partial cache
+		estimator := initializeEstimator(ctx, t, partialCacheRWLoader, cfg, logger.Test(t))
+
+		// tests.AssertLogEventually(t, logs, "BlockHistoryEstimator: updated") // wait for first run loop to finish
+		// Wait for estimator to populate the cache and calculate the latest price
+		waitForEstimation(t, estimator, pollPeriod)
+
+		// Calculated avg price should be equal to the one extracted manually from the blocks.
+		require.NoError(t, estimator.calculatePriceFromMultipleBlocks(depth))
+		// Avg of block medians for the 2 latest blocks only due to partial cache fill
+		assert.Equal(t, uint64(30250), estimator.BaseComputeUnitPrice())
 	})
 
 	t.Run("Min Gate: Price Should Be Floored at Min", func(t *testing.T) {

--- a/pkg/solana/fees/block_history_test.go
+++ b/pkg/solana/fees/block_history_test.go
@@ -238,7 +238,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
 		cfg.On("ComputeUnitPriceMax").Return(maxPrice).Maybe()
-		cfg.On("BlockHistoryCacheLoadBatch").Return(uint64(len(testBlocks) - 1)) // Set cache load batch smaller than depth to simulate partial cache
+		cfg.On("BlockHistoryBatchLoadSize").Return(uint64(len(testBlocks) - 1)) // Set cache load batch smaller than depth to simulate partial cache
 		estimator := initializeEstimator(ctx, t, partialCacheRWLoader, cfg, logger.Test(t))
 
 		// tests.AssertLogEventually(t, logs, "BlockHistoryEstimator: updated") // wait for first run loop to finish
@@ -388,7 +388,7 @@ func setupConfigMock(cfg *cfgmock.Config, defaultPrice uint64, minPrice uint64, 
 	cfg.On("ComputeUnitPriceMin").Return(minPrice).Maybe()
 	cfg.On("BlockHistoryPollPeriod").Return(pollPeriod).Once()
 	cfg.On("BlockHistorySize").Return(depth)
-	cfg.On("BlockHistoryCacheLoadBatch").Return(uint64(20)).Maybe()
+	cfg.On("BlockHistoryBatchLoadSize").Return(uint64(20)).Maybe()
 }
 
 // initializeEstimator initializes, starts, and ensures cleanup of the BlockHistoryEstimator.

--- a/pkg/solana/fees/block_history_test.go
+++ b/pkg/solana/fees/block_history_test.go
@@ -238,7 +238,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
 		cfg.On("ComputeUnitPriceMax").Return(maxPrice).Maybe()
-		cfg.On("BlockHistoryCacheLoadBatch").Return(uint64(len(testBlocks)-1)) // Set cache load batch smaller than depth to simulate partial cache
+		cfg.On("BlockHistoryCacheLoadBatch").Return(uint64(len(testBlocks) - 1)) // Set cache load batch smaller than depth to simulate partial cache
 		estimator := initializeEstimator(ctx, t, partialCacheRWLoader, cfg, logger.Test(t))
 
 		// tests.AssertLogEventually(t, logs, "BlockHistoryEstimator: updated") // wait for first run loop to finish

--- a/pkg/solana/fees/block_history_test.go
+++ b/pkg/solana/fees/block_history_test.go
@@ -207,11 +207,14 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		// Setup
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
+		cfg.On("ComputeUnitPriceMax").Return(maxPrice).Maybe()
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
+		// Wait for estimator to populate the cache and calculate the latest price
+		waitForEstimation(t, estimator, pollPeriod)
+
 		// Calculated avg price should be equal to the one extracted manually from the blocks.
-		require.NoError(t, estimator.calculatePrice(ctx))
-		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
+		require.NoError(t, estimator.calculatePriceFromMultipleBlocks(depth))
 		assert.Equal(t, uint64(multipleBlocksAvg), estimator.BaseComputeUnitPrice())
 	})
 
@@ -222,8 +225,11 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		setupConfigMock(cfg, defaultPrice, tmpMin, pollPeriod, depth)
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
+		// Wait for estimator to populate the cache and calculate the latest price
+		waitForEstimation(t, estimator, pollPeriod)
+
 		// Compute unit price should be floored at min
-		require.NoError(t, estimator.calculatePrice(ctx), "Failed to calculate price with price below min")
+		require.NoError(t, estimator.calculatePriceFromMultipleBlocks(depth), "Failed to calculate price with price below min")
 		cfg.On("ComputeUnitPriceMin").Return(tmpMin)
 		assert.Equal(t, tmpMin, estimator.BaseComputeUnitPrice(), "Price should be floored at min")
 	})
@@ -235,8 +241,11 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
+		// Wait for estimator to populate the cache and calculate the latest price
+		waitForEstimation(t, estimator, pollPeriod)
+
 		// Compute unit price should be capped at max
-		require.NoError(t, estimator.calculatePrice(ctx), "Failed to calculate price with price above max")
+		require.NoError(t, estimator.calculatePriceFromMultipleBlocks(depth), "Failed to calculate price with price above max")
 		cfg.On("ComputeUnitPriceMax").Return(tmpMax)
 		cfg.On("ComputeUnitPriceMin").Return(minPrice)
 		assert.Equal(t, tmpMax, estimator.BaseComputeUnitPrice(), "Price should be capped at max")
@@ -253,8 +262,11 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
 		estimator := initializeEstimator(ctx, t, rwFailLoader, cfg, logger.Test(t))
 
+		// Wait for estimator to populate the cache and calculate the latest price
+		waitForEstimation(t, estimator, pollPeriod)
+
 		// Price should remain unchanged
-		require.Error(t, estimator.calculatePrice(ctx), "Expected error when getting client fails")
+		require.Error(t, estimator.calculatePriceFromMultipleBlocks(depth), "Expected error when getting client fails")
 		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
 	})
@@ -268,8 +280,11 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		rw.On("SlotHeight", mock.Anything).Return(uint64(0), fmt.Errorf("failed to get current slot")) // Mock SlotHeight returning error
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
+		// Wait for estimator to populate the cache and calculate the latest price
+		waitForEstimation(t, estimator, pollPeriod)
+
 		// Price should remain unchanged
-		require.Error(t, estimator.calculatePrice(ctx), "Expected error when getting current slot fails")
+		require.Error(t, estimator.calculatePriceFromMultipleBlocks(depth), "Expected error when getting current slot fails")
 		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
 	})
@@ -283,8 +298,11 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		rw.On("SlotHeight", mock.Anything).Return(depth-1, nil) // Mock SlotHeight returning less than desiredBlockCount
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
+		// Wait for estimator to populate the cache and calculate the latest price
+		waitForEstimation(t, estimator, pollPeriod)
+
 		// Price should remain unchanged
-		require.Error(t, estimator.calculatePrice(ctx), "Expected error when current slot is less than desired block count")
+		require.Error(t, estimator.calculatePriceFromMultipleBlocks(depth), "Expected error when current slot is less than desired block count")
 		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
 	})
@@ -300,8 +318,11 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 			Return(nil, fmt.Errorf("failed to get blocks with limit")) // Mock GetBlocksWithLimit returning error
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
+		// Wait for estimator to populate the cache and calculate the latest price
+		waitForEstimation(t, estimator, pollPeriod)
+
 		// Price should remain unchanged
-		require.Error(t, estimator.calculatePrice(ctx), "Expected error when getting blocks with limit fails")
+		require.Error(t, estimator.calculatePriceFromMultipleBlocks(depth), "Expected error when getting blocks with limit fails")
 		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
 	})
@@ -318,8 +339,11 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 			Return(&emptyBlocks, nil)
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t))
 
+		// Wait for estimator to populate the cache and calculate the latest price
+		waitForEstimation(t, estimator, pollPeriod)
+
 		// Price should remain unchanged
-		require.EqualError(t, estimator.calculatePrice(ctx), errNoComputeUnitPriceCollected.Error(), "Expected error when no compute unit prices are collected")
+		require.EqualError(t, estimator.calculatePriceFromMultipleBlocks(depth), errNoComputeUnitPriceCollected.Error(), "Expected error when no compute unit prices are collected")
 		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
 	})
@@ -328,7 +352,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 // setupConfigMock configures the Config mock with necessary return values.
 func setupConfigMock(cfg *cfgmock.Config, defaultPrice uint64, minPrice uint64, pollPeriod time.Duration, depth uint64) {
 	cfg.On("ComputeUnitPriceDefault").Return(defaultPrice).Once()
-	cfg.On("ComputeUnitPriceMin").Return(minPrice).Once()
+	cfg.On("ComputeUnitPriceMin").Return(minPrice).Maybe()
 	cfg.On("BlockHistoryPollPeriod").Return(pollPeriod).Once()
 	cfg.On("BlockHistorySize").Return(depth)
 }
@@ -354,4 +378,11 @@ func readMultipleBlocksFromFile(t *testing.T, filePath string) []*rpc.GetBlockRe
 	var testBlocks []*rpc.GetBlockResult
 	require.NoError(t, json.Unmarshal(testBlocksData, &testBlocks))
 	return testBlocks
+}
+
+func waitForEstimation(t *testing.T, estimator *blockHistoryEstimator, pollPeriod time.Duration) {
+	// Wait for estimator to populate the cache and calculate the latest price
+	require.Eventually(t, func() bool {
+		return estimator.BaseComputeUnitPrice() != 0
+	}, 2*pollPeriod, 1*time.Second)
 }

--- a/pkg/solana/fees/block_history_test.go
+++ b/pkg/solana/fees/block_history_test.go
@@ -219,7 +219,6 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 	})
 
 	t.Run("Successful Estimation with partial cache fill", func(t *testing.T) {
-		// lgr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
 		partialCacheRW := clientmock.NewReaderWriter(t)
 		partialCacheRWLoader := func(ctx context.Context) (client.ReaderWriter, error) { return partialCacheRW, nil }
 		partialCacheRW.On("SlotHeight", mock.Anything).Return(testSlots[len(testSlots)-1], nil)
@@ -241,7 +240,6 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		cfg.On("BlockHistoryBatchLoadSize").Return(uint64(len(testBlocks) - 1)) // Set cache load batch smaller than depth to simulate partial cache
 		estimator := initializeEstimator(ctx, t, partialCacheRWLoader, cfg, logger.Test(t))
 
-		// tests.AssertLogEventually(t, logs, "BlockHistoryEstimator: updated") // wait for first run loop to finish
 		// Wait for estimator to populate the cache and calculate the latest price
 		waitForEstimation(t, estimator, pollPeriod)
 
@@ -379,6 +377,62 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		// Price should remain unchanged
 		require.EqualError(t, estimator.calculatePriceFromMultipleBlocks(depth), errNoComputeUnitPriceCollected.Error(), "Expected error when no compute unit prices are collected")
 		assert.Equal(t, defaultPrice, estimator.BaseComputeUnitPrice())
+	})
+
+	t.Run("Cache successfully cleared of excess blocks", func(t *testing.T) {
+		block1Slot := testSlots[0]
+		block2Slot := testSlots[1]
+		block3Slot := testSlots[2]
+		olderEstimate := uint64(58750) // median price of oldest 2 blocks
+		newerEstimate := uint64(30250) // median price of latest 2 blocks
+		cleanCacheRw := clientmock.NewReaderWriter(t)
+		cleanCacheRWLoader := func(ctx context.Context) (client.ReaderWriter, error) { return cleanCacheRw, nil }
+		// Return second to last block as highest block
+		cleanCacheRw.On("SlotHeight", mock.Anything).Return(testSlots[len(testSlots)-2], nil).Once()
+		// Return the oldest 2 blocks when get blocks is first called
+		testSlotsResult := rpc.BlocksResult(testSlots[:2])
+		cleanCacheRw.On("GetBlocksWithLimit", mock.Anything, mock.Anything, mock.Anything).
+			Return(&testSlotsResult, nil).Once()
+		for i, slot := range testSlots {
+			cleanCacheRw.On("GetBlock", mock.Anything, slot).Return(testBlocks[i], nil).Once()
+		}
+
+		// Setup
+		cfg := cfgmock.NewConfig(t)
+		smallerDepth := len(testSlots)-1
+		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, uint64(smallerDepth))
+		cfg.On("ComputeUnitPriceMax").Return(maxPrice).Maybe()
+		estimator := initializeEstimator(ctx, t, cleanCacheRWLoader, cfg, logger.Test(t))
+
+		// Wait for estimator to estimate price on the older 2 blocks
+		require.Eventually(t, func() bool {
+			return estimator.BaseComputeUnitPrice() == olderEstimate
+		}, 2*pollPeriod, 1*time.Second)
+
+		estimator.cacheMu.RLock()
+		require.Len(t, estimator.cache.storedBlockRange, smallerDepth)
+		require.Len(t, estimator.cache.medianMap, smallerDepth)
+		require.Contains(t, estimator.cache.medianMap, block1Slot)
+		require.Contains(t, estimator.cache.medianMap, block2Slot)
+		estimator.cacheMu.RUnlock()
+
+		// Return second to last block as highest block
+		cleanCacheRw.On("SlotHeight", mock.Anything).Return(testSlots[len(testSlots)-1], nil)
+		// Return the latest 2 blocks when get blocks is called again
+		testSlotsResult = rpc.BlocksResult(testSlots[1:])
+		cleanCacheRw.On("GetBlocksWithLimit", mock.Anything, mock.Anything, mock.Anything).
+			Return(&testSlotsResult, nil)
+
+		// Wait for estimator to estimate price on the latest 2 blocks
+		require.Eventually(t, func() bool {
+			return estimator.BaseComputeUnitPrice() == newerEstimate
+		}, 2*pollPeriod, 1*time.Second)
+		estimator.cacheMu.RLock()
+		require.Len(t, estimator.cache.storedBlockRange, smallerDepth)
+		require.Len(t, estimator.cache.medianMap, smallerDepth)
+		require.Contains(t, estimator.cache.medianMap, block2Slot)
+		require.Contains(t, estimator.cache.medianMap, block3Slot)
+		estimator.cacheMu.RUnlock()
 	})
 }
 

--- a/pkg/solana/fees/block_history_test.go
+++ b/pkg/solana/fees/block_history_test.go
@@ -399,7 +399,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 
 		// Setup
 		cfg := cfgmock.NewConfig(t)
-		smallerDepth := len(testSlots)-1
+		smallerDepth := len(testSlots) - 1
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, uint64(smallerDepth))
 		cfg.On("ComputeUnitPriceMax").Return(maxPrice).Maybe()
 		estimator := initializeEstimator(ctx, t, cleanCacheRWLoader, cfg, logger.Test(t))

--- a/pkg/solana/fees/multiple_blocks_data.json
+++ b/pkg/solana/fees/multiple_blocks_data.json
@@ -1,765 +1,558 @@
 [
-    {
-        "blockHeight": 322941572,
-        "blockTime": 1729614372,
-        "blockhash": "feicppK3Qo2FBg8jdgB1tfK1DgesVPpWJaYqe6KeJr3",
-        "parentSlot": 334737293,
-        "previousBlockhash": "4yh9KU9Jh74LKQnQ9WontD3R78vwMN6HJZgrmptRTFF1",
-        "transactions": [
+  {
+    "blockHeight": 322941570,
+    "blockTime": 1729614372,
+    "blockhash": "GwYG5jWPe6rDcDPSjSx9eZYafhyzFBtq4DWxrARbtkzE",
+    "parentSlot": 334737291,
+    "previousBlockhash": "73UuT6UQ3m7nmjHEDeKf25GczouaoYwXDfxp7XNpGHvc",
+    "transactions": [
+      {
+        "meta": {
+          "computeUnitsConsumed": 57566,
+          "err": null,
+          "fee": 18500,
+          "innerInstructions": [],
+          "loadedAddresses": {
+            "readonly": [],
+            "writable": []
+          },
+          "logMessages": [
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program DEALERKFspSo5RoXNnKAhRPhTcvJeqeEgAgZsNSjCx5E invoke [1]",
+            "Program log: Instruction: NoMoreBets",
+            "Program log: No more bets Game=2 Room=1 Round=237054",
+            "Program DEALERKFspSo5RoXNnKAhRPhTcvJeqeEgAgZsNSjCx5E consumed 57266 of 99700 compute units",
+            "Program DEALERKFspSo5RoXNnKAhRPhTcvJeqeEgAgZsNSjCx5E success"
+          ],
+          "postBalances": [13286006513, 38398320, 1, 1141440, 1],
+          "postTokenBalances": [],
+          "preBalances": [13286025013, 38398320, 1, 1141440, 1],
+          "preTokenBalances": [],
+          "rewards": null,
+          "status": {
+            "Ok": null
+          }
+        },
+        "transaction": [
+          "Aef6wC7jRUTSNJXXPLJw0YeH45V1fx8kYYkOvNLC6iUr55AStfDtGemsMHH+zGHQQF10g8Y3E8FjDdFeibQ4NQGAAQADBVB7N1RPyFFY4Pn4YTVsKAguI+0DJvc7Z5uKk6etXSbnfJWH+tSdYzJGFjobJRj9Y2doBbsZJ+JTVQEI4AoxLmUDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAALWrWEoOURXC2vUy8WwOTJzcLkiAxyCUKcIGMGT5tKbpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAsDCDiNujvgsnGZ6wnJFW60pr9pcjELc320ORuzveVwMCAAkDWA8CAAAAAAACAAUCoIYBAAMDAQAEFGoZ+H2TJ3uOAgABAP6dAwAAAAAAAA==",
+          "base64"
+        ],
+        "version": 0
+      },
+      {
+        "meta": {
+          "computeUnitsConsumed": 291351,
+          "err": null,
+          "fee": 45000,
+          "innerInstructions": [
             {
-                "meta": {
-                    "computeUnitsConsumed": 22600,
-                    "err": null,
-                    "fee": 6750,
-                    "innerInstructions": [],
-                    "loadedAddresses": {
-                        "readonly": [
-                            "445GcRLAJ64DcxSRbvQTkbwXgWUyubAxzQUQ2wL73KLS",
-                            "7jA4ZSGwaBxXk5EmPKDCSc5RtZNHxyoxy22iQt3D2mH9",
-                            "AqZSmo7tVgPrZ72kSpRugN8pTCBTHovw65qPikP15dmK",
-                            "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX"
-                        ],
-                        "writable": [
-                            "CuzxxETyjZkGVJmUv4zJTjoo4YE5HHdNm4AT4krtTikY"
-                        ]
-                    },
-                    "logMessages": [
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program FTN6rgbaaxwT8mpRuC55EFTwpHB3BwnHJ91Lqv4ZVCfW invoke [1]",
-                        "Program log: Instruction: SetInternalOraclePrice",
-                        "Program FTN6rgbaaxwT8mpRuC55EFTwpHB3BwnHJ91Lqv4ZVCfW consumed 22300 of 34700 compute units",
-                        "Program return: FTN6rgbaaxwT8mpRuC55EFTwpHB3BwnHJ91Lqv4ZVCfW AA==",
-                        "Program FTN6rgbaaxwT8mpRuC55EFTwpHB3BwnHJ91Lqv4ZVCfW success"
-                    ],
-                    "postBalances": [
-                        1863073661,
-                        1,
-                        1398960,
-                        1,
-                        1224960,
-                        3953280,
-                        7683840,
-                        5400960,
-                        1823520
-                    ],
-                    "postTokenBalances": [],
-                    "preBalances": [
-                        1863080411,
-                        1,
-                        1398960,
-                        1,
-                        1224960,
-                        3953280,
-                        7683840,
-                        5400960,
-                        1823520
-                    ],
-                    "preTokenBalances": [],
-                    "returnData": {
-                        "data": [
-                            "AA==",
-                            "base64"
-                        ],
-                        "programId": "FTN6rgbaaxwT8mpRuC55EFTwpHB3BwnHJ91Lqv4ZVCfW"
-                    },
-                    "rewards": null,
-                    "status": {
-                        "Ok": null
-                    }
+              "index": 2,
+              "instructions": [
+                {
+                  "accounts": [0, 16],
+                  "data": "E2Q9zzc4R2iaLevUw2X7cLTkbBVrWmiQ9",
+                  "programIdIndex": 13,
+                  "stackHeight": 2
                 },
-                "transaction": [
-                    "ASi6iVtIvMdRzyIJxtqANGA7FFjexa1HKjOB+OwdNVW+ZSko6KdkcI9IBVKOKxDWzlzFNEKrBaSa2gFJYVvbEg+AAQADBIn4KAbn3G4U/vI6/PldcVdaWYxXKb6hSfwgARhZpSMyAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAADWxJOzRzwVxFMMLoXkLPkHDGXItrzVXGtEhgeVwvx2xQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7NgDbutA7R6axo0upp2G1R3Nm/HVuehCxfGWRTmWBtsDAQAJA1DDAAAAAAAAAQAFAriIAAACBwAFBgcECAMsrqAPqOifeswiyfUFAAAAAPj////HNwEAAAAAAEXK9QUAAAAAI9IXZwAAAAABzBIKNsGNjLvVYQePGI4eEj5reCdpo+kg4cTMI9VWuzMBugQCAQaI",
-                    "base64"
-                ],
-                "version": 0
+                {
+                  "accounts": [18, 16, 6, 19, 15, 10, 20],
+                  "data": "Br5D4BFTnYxBdSg1axvxcf9baAFWqFkKmpAgAZaoLywX21ZkSb5vNcThm7CNP5fcvU9M2LympdnfE1k1vvGAE7g63c2pHvRPep6tb6fG",
+                  "programIdIndex": 13,
+                  "stackHeight": 2
+                },
+                {
+                  "accounts": [
+                    18, 16, 6, 3, 8, 5, 2, 13, 13, 13, 13, 1, 1, 7, 7, 13, 13,
+                    13, 12, 17, 13
+                  ],
+                  "data": "25ozmx8ZeodPjkGWfGoWpyio",
+                  "programIdIndex": 13,
+                  "stackHeight": 2
+                },
+                {
+                  "accounts": [17],
+                  "data": "PXKJYD315JEJDZYu7uztGwNqJPWdMxX1YhMhxZ12P71JHzNYSAW4ZjTg8vU4McWGd5CniSJsmGbT9PmyMGxrcugi17iMyXtKpuHGbw4eKvZMRS2XyfrXhy1tYVephWJSp56S2Kvwmfr2tTYdLP6Ekm4gD6sKqp2b26AcKBhPZ18Wy8rjZ7djZzkDSbRQ1d4ACBCr6f3bQMKpd7ECrcTq1hRE1gdTfA7rjZgTQ6uxGcQirSUw2py1AazRVGgyZsQ6bXieS2yaQJUiyWWE8giXGWwgTMc7P4WJChMtJNfngnZkfaLV4cxztQ3qW7vtNVxkt44hvpf4eqQ7WcXQ9Y4nvvP9zhgPeyGZtyrSx2ZaWU1XbybpwEPBYSzvTRJ6eSkr9Q1RwqLAXX49qCoZUkiLLDWnSr3YYunbL2km8vAkNjKXhabv7emnG2fb55djgdJSLeVsrr2tpSCFtGNcCUUGMaWQz3y6bdxk3w4TmwtvtSpe2BULBSRht4SVPgjeVzsZhpbVfn1jNURXypLQr6vY8cAQ9N1dQggbsDzivfxJtTftR34x3uuJ5AtbiN8CPVgwN6DfFxHUwtTbGvdoAyspGZRjydGf33HnEh5vZ6uBYfwqH6Q8DhQrBt8DSin7LSoMWceumCsRrtf9GMrotSRTs9FLREqftgrwwo2YE52KPUVVAuhS7tvs5esXJZ21p5HXhsosBjNKGcFJa6VpvaVToWWGLRLRqW3RruqVwyNPp1VdS56LCdpArZWoR22b9qydb8nwznYZUTYm6fC5s5Etc5KUYBgFie73HPvzYyLuSLQWoyHJJzM7foRtZTy5HmZTk3j7RVxVN6MjVozinHZSemN1cmDLxgNxu5tqdSCyYnSmNb4xjDcpbuLtdxKLn7YShicb6zbJPuym1eeBdvwwduNQTdPN1hqwx3oq578XXTffYuRqETBXVLe68sNyLdkPSrSe7AFXA8tq9AmeS3uwFZrj8xdydr6yFSuiAgwqLdv4oh3iEGbB2aXButAuByTdYgECyGBKAu91PMRUyXDyLNV4QeL614jMteRi68J7T86NqsPGh6a99Esdr3pvfUnGWT",
+                  "programIdIndex": 13,
+                  "stackHeight": 3
+                },
+                {
+                  "accounts": [18, 16, 6],
+                  "data": "VB9m5Wo7Scv",
+                  "programIdIndex": 13,
+                  "stackHeight": 2
+                },
+                {
+                  "accounts": [0, 18, 16, 3, 4, 9, 17, 13],
+                  "data": "2DfZaYcLBaxHdYEouV5TACdQE4wR7h8X5LM4nLj",
+                  "programIdIndex": 13,
+                  "stackHeight": 2
+                },
+                {
+                  "accounts": [0, 4],
+                  "data": "3Bxs4b9KUfinEREw",
+                  "programIdIndex": 9,
+                  "stackHeight": 3
+                },
+                {
+                  "accounts": [17],
+                  "data": "2tEc5NHNMxEKCXQhSkjtRweNdy2Dz2fhtec9qs6GuDHWQJhSRh2afUA9syJg71zpQMLctCKF3Q1dEwhgrBxBQWHTxk8njpxtfmUpMFHtAxEDkqi3Yq5xa1iuWpYs7vxQLVng12duTjTeNM1c7TwyaFEH3qYoYZfj7iUWPpFz1hRrKZmiqfuQ9HkFQmwJhZP94HuSj58TzS16dpE5VgMD4TdgVd2K7jt99GPdj9vgA44SuJW89i5RSWhR",
+                  "programIdIndex": 13,
+                  "stackHeight": 3
+                }
+              ]
+            }
+          ],
+          "loadedAddresses": {
+            "readonly": [],
+            "writable": []
+          },
+          "logMessages": [
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program hnxiNKTc515NHvuq5fEUAc62dWkEu3m623FbwemWNJd invoke [1]",
+            "Program log: Instruction: ExecuteOrder",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [2]",
+            "Program log: Instruction: CheckRole",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 2120 of 774275 compute units",
+            "Program return: hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT AQ==",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [2]",
+            "Program log: Instruction: SetPricesFromPriceFeed",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 15055 of 760625 compute units",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [2]",
+            "Program log: Instruction: ExecuteOrder",
+            "Program log: [Order] pre-execute: DistributePositionImpactReport { duration_in_seconds: 10, distribution_amount: 0, next_position_impact_pool_amount: 4288 }",
+            "Program log: [Position] increased: IncreasePositionReport { params: IncreasePositionParams { collateral_increment_amount: 50000000, size_delta_usd: 10000000000000000000000, acceptable_price: None, prices: Prices { index_token_price: 66959500000000000, long_token_price: 99990000000000, short_token_price: 99990000000000 } }, execution: ExecutionParams { price_impact_value: -74720565254250000, price_impact_amount: -2, size_delta_in_tokens: 149342, execution_price: 66960399619664930 }, collateral_delta_amount: 49929993, fees: PositionFees { base: Fees { fee_receiver_amount: 49004, fee_amount_for_pool: 21003 }, borrowing: BorrowingFee { amount: 0, amount_for_receiver: 0 }, funding: FundingFees { amount: 0, claimable_long_token_amount: 0, claimable_short_token_amount: 0 } }, borrowing: UpdateBorrowingReport { duration_in_seconds: 10, next_cumulative_borrowing_factor_for_long: 3181618323149899003, next_cumulative_borrowing_factor_for_short: 371849625775569617 }, funding: UpdateFundingReport { duration_in_seconds: 10, next_funding_factor_per_second: 1000000000000, delta_funding_amount_per_size: [1000100011, 0, 1000100011, 0], delta_claimable_funding_amount_per_size: [0, 62648402552, 0, 62648402552] }, claimble_funding_long_token_amount: 0, claimble_funding_short_token_amount: 0 }",
+            "Program log: [Position] executed with trade_id=311420885",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [3]",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 5005 of 571069 compute units",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 172595 of 735303 compute units",
+            "Program return: hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT AAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [2]",
+            "Program log: Instruction: ClearAllPrices",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 6077 of 551674 compute units",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [2]",
+            "Program log: Instruction: RemoveOrder",
+            "Program 11111111111111111111111111111111 invoke [3]",
+            "Program 11111111111111111111111111111111 success",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [3]",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 5005 of 515321 compute units",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 29155 of 538897 compute units",
+            "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
+            "Program hnxiNKTc515NHvuq5fEUAc62dWkEu3m623FbwemWNJd consumed 291051 of 799700 compute units",
+            "Program hnxiNKTc515NHvuq5fEUAc62dWkEu3m623FbwemWNJd success"
+          ],
+          "postBalances": [
+            8655559087, 2039280, 2951040, 0, 6890171460, 1461600, 10767120,
+            2039280, 17873280, 1, 1823520, 1, 934087680, 1141440, 1141440,
+            1141440, 42706560, 0, 1000000000, 249919680, 1823520
+          ],
+          "postTokenBalances": [
+            {
+              "accountIndex": 1,
+              "mint": "Brn3Z9BbjWUVydnMuzcyxCMc1RL4LA9Bt9zGEdWsAfMx",
+              "owner": "4cTohP5nfJzNpkYWXbR4pnLKHZsu4PzMiLxu6zKoDu3q",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "617044033210",
+                "decimals": 6,
+                "uiAmount": 617044.03321,
+                "uiAmountString": "617044.03321"
+              }
             },
             {
-                "meta": {
-                    "computeUnitsConsumed": 221052,
-                    "err": null,
-                    "fee": 5000,
-                    "innerInstructions": [],
-                    "loadedAddresses": {
-                        "readonly": [],
-                        "writable": []
-                    },
-                    "logMessages": [
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program 5Wvu3L3vVkQi2RPA12sTbzFTPgzgim5kQc3iRHFVw6zZ invoke [1]",
-                        "Program data: Ag== CgAAAA== AAAAAA== JKKgAAAAAAA= AAAAAAAAAAA= AAAAAAAAAAA= FGmJ/v////8= LUMc6+I2Gj8= exSuR+F6hD8= /Knx0k1iQD8= obYVAA== jOYdAA== ZAAAAA== lHUZAA== AAAAAA== AQ== JNIXZw== jq/zEw== Bg==",
-                        "Program data: Ag== CgAAAA== AAAAAA== JaKgAAAAAAA= AAAAAAAAAAA= AAAAAAAAAAA= EClG/v////8= LUMc6+I2Gj8= exSuR+F6hD8= /Knx0k1iQD8= obYVAA== jOYdAA== ZAAAAA== cHsZAA== AAAAAA== AQ== JNIXZw== jq/zEw== Bw==",
-                        "Program data: Ag== CgAAAA== AAAAAA== U6KgAAAAAAA= AAAAAAAAAAA= AAAAAAAAAAA= XMZyAQAAAAA= LUMc6+I2Gj8= exSuR+F6hD8= /Knx0k1iQD8= obYVAA== jOYdAA== ZAAAAA== 0GsZAA== AAAAAA== AQ== JNIXZw== jq/zEw== AA==",
-                        "Program data: Ag== CgAAAA== AAAAAA== VKKgAAAAAAA= AAAAAAAAAAA= AAAAAAAAAAA= gKe9AQAAAAA= LUMc6+I2Gj8= exSuR+F6hD8= /Knx0k1iQD8= obYVAA== jOYdAA== ZAAAAA== rHEZAA== AAAAAA== AQ== JNIXZw== jq/zEw== AQ==",
-                        "Program 5Wvu3L3vVkQi2RPA12sTbzFTPgzgim5kQc3iRHFVw6zZ consumed 220902 of 299850 compute units",
-                        "Program 5Wvu3L3vVkQi2RPA12sTbzFTPgzgim5kQc3iRHFVw6zZ success"
-                    ],
-                    "postBalances": [
-                        4679560814,
-                        3062400,
-                        2616960,
-                        2561280,
-                        17205120,
-                        3507840,
-                        2171520,
-                        2394240,
-                        2394240,
-                        3062400,
-                        14922240,
-                        2616960,
-                        41258880,
-                        294714240,
-                        254958720,
-                        1,
-                        2171520,
-                        1141440,
-                        2616960,
-                        1,
-                        4788480
-                    ],
-                    "postTokenBalances": [],
-                    "preBalances": [
-                        4679565814,
-                        3062400,
-                        2616960,
-                        2561280,
-                        17205120,
-                        3507840,
-                        2171520,
-                        2394240,
-                        2394240,
-                        3062400,
-                        14922240,
-                        2616960,
-                        41258880,
-                        294714240,
-                        254958720,
-                        1,
-                        2171520,
-                        1141440,
-                        2616960,
-                        1,
-                        4788480
-                    ],
-                    "preTokenBalances": [],
-                    "rewards": null,
-                    "status": {
-                        "Ok": null
-                    }
-                },
-                "transaction": [
-                    "AV4VCiOq3qg8APSdU5bAo92aWNVFS/lkvEgpUjHQsSvqqhDnbTsx4fXZ5aSn47isTJu5QnUQsqr+Mvqe4Jq3JAMBAAYVBsCSmrs4MdR1vi9ob3KDNVVbfOI5Ttjxm6oiDBEAYIMRfzaHC5fmOJINERTEVzCi2M0GBwG8fXTbM10qi7aqDhZWXG8uIMLlsVjZG3OCqLp0nGSuRVmFY4BQhfPXnbT1Jj56U/EoKsXt0rqePSwZ84ViW5p7zdgYwE2FdMsK0WMgsMzHI19xSJIw14xZrC0x2dD1sa+gErb9TnxI3Wm9uC+y97w+8OuyBo4y1oMP4KWcuxLj8vEiT2s0NzucnpAmOmc92DqDflB7pasp+nHEDtm462R3ls2yRc4T3CJ3bCw+QvDCVamvNNQR6pBxMim8AmWOLp8JxhaB2AoedrGB5YdvzvsPsSXl+7sx0OjVOvILbRHbhwQbrtzEiBCrAI8zlHCda1GWNn8R/3V1zTaiIWJL3OL+JO/jdyvzxPGCJuizR5NRxTL8e/xfbviRUPx1xsPOfDxHuJYWj6g73ulXc7u2rR5KPkhV7vCVyaDaOLSj8/uhaOE+fi0v96T2iyg91O/LiHifAWf8IR63ZJ7SAir9Q0hPQILLWsTQCmmxkw7qfyihluX9vqVaUZ2lGBYjC2NJSXSWFTtHE3b1cxGMrfm+4PLuJTqcmpIMKndcDrxE7DpWH66U650KNU8AdzAmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3dqdhe5cdGqU7VGMTH9oQbgmWmTced2WrsJcd01NWAUMZiHEmjDjI4Eoqqnhhi/SdCFw5wmMeN9MyHRDIuMCugBKI+dL7siRkEOi6cWS05MjJ5NOLA6ilF5KwatsvK9MDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAL1S4p2hMh10ZHB4YkBjxoT8OtxbhfzwXCPF9sgX39bI6ZMJgji4ZK1YPaGMMVpO6XD7J2OOTkI4YqLbvj50JiQCEwAFAuCTBAAREwASEAMMBA4LAgkBBQ0HCAYKFA89IwAAAAABAAAAJgAAANBrGQAAAAAAZAAAAAAAAAAkoqAAAAAAAKxxGQAAAAAAZAAAAAAAAAAloqAAAAAAAA==",
-                    "base64"
-                ],
-                "version": "legacy"
+              "accountIndex": 7,
+              "mint": "Brn3Z9BbjWUVydnMuzcyxCMc1RL4LA9Bt9zGEdWsAfMx",
+              "owner": "5tJ6aNLxSbB6RmzUhmr4mgDVeLb2XQY8auCmFE4t3AE7",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "3186483152",
+                "decimals": 6,
+                "uiAmount": 3186.483152,
+                "uiAmountString": "3186.483152"
+              }
             }
-        ]
-    },
-    {
-        "blockHeight": 322941574,
-        "blockTime": 1729614373,
-        "blockhash": "8nFMCT3CRjgw3MmkF2yg3JmrBW6pUAW4ku6Wo3ynQU8q",
-        "parentSlot": 334737295,
-        "previousBlockhash": "mf3EYQu5S39S9i6vzYpvPMqEDFm4rQLV72GK6YM5xSA",
-        "transactions": [
+          ],
+          "preBalances": [
+            8655501587, 2039280, 2951040, 7245360, 6883028600, 1461600,
+            10767120, 2039280, 17873280, 1, 1823520, 1, 934087680, 1141440,
+            1141440, 1141440, 42706560, 0, 1000000000, 249919680, 1823520
+          ],
+          "preTokenBalances": [
             {
-                "meta": {
-                    "computeUnitsConsumed": 7993,
-                    "err": null,
-                    "fee": 5550,
-                    "innerInstructions": [],
-                    "loadedAddresses": {
-                        "readonly": [],
-                        "writable": []
-                    },
-                    "logMessages": [
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ invoke [1]",
-                        "Program log: Instruction: CloseEncodedVaa",
-                        "Program HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ consumed 2559 of 10700 compute units",
-                        "Program HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ success",
-                        "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ invoke [1]",
-                        "Program log: Instruction: ReclaimRent",
-                        "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ consumed 2567 of 8141 compute units",
-                        "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ success",
-                        "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ invoke [1]",
-                        "Program log: Instruction: ReclaimRent",
-                        "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ consumed 2567 of 5574 compute units",
-                        "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ success"
-                    ],
-                    "postBalances": [
-                        8667037537,
-                        0,
-                        0,
-                        0,
-                        1,
-                        1141440,
-                        1141440
-                    ],
-                    "postTokenBalances": [],
-                    "preBalances": [
-                        8655559087,
-                        1823520,
-                        7836960,
-                        1823520,
-                        1,
-                        1141440,
-                        1141440
-                    ],
-                    "preTokenBalances": [],
-                    "rewards": null,
-                    "status": {
-                        "Ok": null
-                    }
-                },
-                "transaction": [
-                    "AThfMPoLShfmrw+ushgXGpk8rswvL2YuIe/qa/Lxg8ZGk57p10PrphStNVk2vo9Hu0gr06CcaiRK7dITiiNr+gMBAAMH5b3H10gLgqQeyrtL3FmtXNRtBfOx8Aw69wz2FBl8IyIAAE3WGoemJ8CQTfHSj+OBeqeF5Y/eBoVXiT4sy75MeUqJqZd0+9PIfZz3W3vjQ5z5fllTF+zR3cHEEFkK29bU7lWsaF1G+P+k7zY2ekQuBs6kepGfr6Q3wZbBFIKaKUMDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAAy3+rtS96ZIu1sxfZoBi5BXywJHdPr+AebE35jMOFiB8Qu05Q1W/aE9/h8ym405PdJKAUWR4YMWl5QNfDSjjd3s2ANu60DtHprGjS6mnYbVHc2b8dW56ELF8ZZFOZYG2wUEAAUC+CoAAAQACQNQwwAAAAAAAAYCAAIIMN2uxucHmCYFAgADCNrIE8XjWcAWBQIAAQjayBPF41nAFg==",
-                    "base64"
-                ],
-                "version": "legacy"
+              "accountIndex": 1,
+              "mint": "Brn3Z9BbjWUVydnMuzcyxCMc1RL4LA9Bt9zGEdWsAfMx",
+              "owner": "4cTohP5nfJzNpkYWXbR4pnLKHZsu4PzMiLxu6zKoDu3q",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "617044033210",
+                "decimals": 6,
+                "uiAmount": 617044.03321,
+                "uiAmountString": "617044.03321"
+              }
             },
             {
-                "meta": {
-                    "computeUnitsConsumed": 65433,
-                    "err": null,
-                    "fee": 10229,
-                    "innerInstructions": [
-                        {
-                            "index": 2,
-                            "instructions": [
-                                {
-                                    "accounts": [
-                                        7,
-                                        9,
-                                        16
-                                    ],
-                                    "data": "3px3hhrW2tYw",
-                                    "programIdIndex": 13,
-                                    "stackHeight": 2
-                                }
-                            ]
-                        }
-                    ],
-                    "loadedAddresses": {
-                        "readonly": [],
-                        "writable": []
-                    },
-                    "logMessages": [
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f invoke [1]",
-                        "Program log: Instruction: AggregatorSaveResult",
-                        "Program data: Dk7x7N2nVakXYctI6lgFaSU7esDDgap4NL0RL69En9ViObhyAhjwhJCv8xMAAAAAJdIXZwAAAAAAAAAAAAAAAA==",
-                        "Program data: A5o8/ZicmX4XYctI6lgFaSU7esDDgap4NL0RL69En9ViObhyAhjwhAAAZKeztuANAAAAAAAAAAASAAAAkK/zEwAAAAAl0hdnAAAAAAeGZkx0Ab9KcacEE25L4Kkoe2bAxKbzMawGdR5Vi2zCAAAAAA==",
-                        "Program log: P1 2aGsGLsnby48p5vR3vj2PeUTuNbosT1JnPZJrdAcgtTD",
-                        "Program log: MODE_ROUND",
-                        "Program data: m/42h1I1hpQXYctI6lgFaSU7esDDgap4NL0RL69En9ViObhyAhjwhIEzO/v3/Couc0LeJQNiazP9ZncWSlagGUs4WBim/I9yLpYb5MI1Jm8ZkcejXEWao+ZBBPWtC9EHHRS1OzYTtdxL4g2K3PYBBOeNhsdOqJLSAKbpFvVI7Cz9R+CDa6QkrQAAAAAAAAAAi6/zEwAAAAAl0hdnAAAAAA==",
-                        "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
-                        "Program log: Instruction: Transfer",
-                        "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4736 of 193932 compute units",
-                        "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-                        "Program data: lYLi/gDS5xAXYctI6lgFaSU7esDDgap4NL0RL69En9ViObhyAhjwhIEzO/v3/Couc0LeJQNiazP9ZncWSlagGUs4WBim/I9yB4ZmTHQBv0pxpwQTbkvgqSh7ZsDEpvMxrAZ1HlWLbMLIiCi8eTgwk/F0rXyDYo6FCgQ0dik7Uh5QvYVf96Wxm9QwAAAAAAAAi6/zEwAAAAAl0hdnAAAAAA==",
-                        "Program data: cB8z6WFkK/UXYctI6lgFaSU7esDDgap4NL0RL69En9ViObhyAhjwhAAAZKeztuANAAAAAAAAAAASAAAAkK/zEwAAAAAl0hdnAAAAAAEAAAAHhmZMdAG/SnGnBBNuS+CpKHtmwMSm8zGsBnUeVYtswgEAAAAAAGSns7bgDQAAAAAAAAAAEgAAAA==",
-                        "Program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f consumed 65133 of 248699 compute units",
-                        "Program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f success"
-                    ],
-                    "postBalances": [
-                        2326681379184,
-                        5317440,
-                        12089520,
-                        27693840,
-                        5317440,
-                        28193384974,
-                        3480000,
-                        1887264280,
-                        4043760,
-                        27958498209,
-                        1,
-                        1141440,
-                        960737013533,
-                        934087680,
-                        9723120,
-                        3480000,
-                        1201079987
-                    ],
-                    "postTokenBalances": [
-                        {
-                            "accountIndex": 5,
-                            "mint": "So11111111111111111111111111111111111111112",
-                            "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
-                            "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                            "uiTokenAmount": {
-                                "amount": "28191345694",
-                                "decimals": 9,
-                                "uiAmount": 28.191345694,
-                                "uiAmountString": "28.191345694"
-                            }
-                        },
-                        {
-                            "accountIndex": 7,
-                            "mint": "So11111111111111111111111111111111111111112",
-                            "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
-                            "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                            "uiTokenAmount": {
-                                "amount": "1885225000",
-                                "decimals": 9,
-                                "uiAmount": 1.885225,
-                                "uiAmountString": "1.885225"
-                            }
-                        },
-                        {
-                            "accountIndex": 9,
-                            "mint": "So11111111111111111111111111111111111111112",
-                            "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
-                            "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                            "uiTokenAmount": {
-                                "amount": "27956458929",
-                                "decimals": 9,
-                                "uiAmount": 27.956458929,
-                                "uiAmountString": "27.956458929"
-                            }
-                        }
-                    ],
-                    "preBalances": [
-                        2326681389413,
-                        5317440,
-                        12089520,
-                        27693840,
-                        5317440,
-                        28193384974,
-                        3480000,
-                        1887276780,
-                        4043760,
-                        27958485709,
-                        1,
-                        1141440,
-                        960737013533,
-                        934087680,
-                        9723120,
-                        3480000,
-                        1201079987
-                    ],
-                    "preTokenBalances": [
-                        {
-                            "accountIndex": 5,
-                            "mint": "So11111111111111111111111111111111111111112",
-                            "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
-                            "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                            "uiTokenAmount": {
-                                "amount": "28191345694",
-                                "decimals": 9,
-                                "uiAmount": 28.191345694,
-                                "uiAmountString": "28.191345694"
-                            }
-                        },
-                        {
-                            "accountIndex": 7,
-                            "mint": "So11111111111111111111111111111111111111112",
-                            "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
-                            "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                            "uiTokenAmount": {
-                                "amount": "1885237500",
-                                "decimals": 9,
-                                "uiAmount": 1.8852375,
-                                "uiAmountString": "1.8852375"
-                            }
-                        },
-                        {
-                            "accountIndex": 9,
-                            "mint": "So11111111111111111111111111111111111111112",
-                            "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
-                            "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                            "uiTokenAmount": {
-                                "amount": "27956446429",
-                                "decimals": 9,
-                                "uiAmount": 27.956446429,
-                                "uiAmountString": "27.956446429"
-                            }
-                        }
-                    ],
-                    "rewards": null,
-                    "status": {
-                        "Ok": null
-                    }
-                },
-                "transaction": [
-                    "ATk4p1JJWq+4jSJId+6OUZ4aJTE3UBuhcrXdpDvOXGwIqMXRxPpOnhcvDwQep0ZuFiQJl6RACvbuq7NKTca63QoBAAcRE6Und58TTqIUP4M1S3pfMslF0Ya0SPwWMnhhocD3evgHhmZMdAG/SnGnBBNuS+CpKHtmwMSm8zGsBnUeVYtswgrzV+SbIlnlpQ4MqxddLExSM5Ramvt6jpuO7XdscALoF2HLSOpYBWklO3rAw4GqeDS9ES+vRJ/VYjm4cgIY8IQulhvkwjUmbxmRx6NcRZqj5kEE9a0L0QcdFLU7NhO13EviDYrc9gEE542Gx06oktIApukW9UjsLP1H4INrpCStUmax26Ll6OyD4NH6rkUq/iez02PIxieIzIB4HibLITtnTFLBnd7U2kL/ZZ6ODLbBb/Cm38NHyUX2mQ+tZPCbw4EzO/v3/Couc0LeJQNiazP9ZncWSlagGUs4WBim/I9yyIgovHk4MJPxdK18g2KOhQoENHYpO1IeUL2FX/elsZsDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAAaIUcaMaDLwL6WBsb9JG3fKQXdrormItab6uo7jouyQBpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAEG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQ1rzpq7vfDJhKFxPXon6UBvXisIlEW7BFX0X8/2tDO6rd+Y4TDySSxnwCnu9tVNqN6UZapCoVJvnmbykwSG/Aqx7kglPvsN1CPoW5+frlezWwWJ3gBP3Kra2qQ67QcWMPfOuVhDeHyAhhNXy1u0olEHm5pwGY5INaaGrVU/lwZzAwoACQMIUgAAAAAAAAoABQKnzAMACxIDAQAOAAYPCAcNEAMMBAEFCQJtFUMFAEqoM8ABAAAAAAAAZKeztuANAAAAAAAAAAASAAAA4irl+f07kXcVXpSek9h4vf1fKHXBe4JKhVoy/OohnIMAAGSns7bgDQAAAAAAAAAAEgAAAAAAZKeztuANAAAAAAAAAAASAAAA//7/+Q==",
-                    "base64"
-                ],
-                "version": "legacy"
+              "accountIndex": 7,
+              "mint": "Brn3Z9BbjWUVydnMuzcyxCMc1RL4LA9Bt9zGEdWsAfMx",
+              "owner": "5tJ6aNLxSbB6RmzUhmr4mgDVeLb2XQY8auCmFE4t3AE7",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "3186483152",
+                "decimals": 6,
+                "uiAmount": 3186.483152,
+                "uiAmountString": "3186.483152"
+              }
             }
-        ]
-    },
-    {
-        "blockHeight": 322941570,
-        "blockTime": 1729614372,
-        "blockhash": "GwYG5jWPe6rDcDPSjSx9eZYafhyzFBtq4DWxrARbtkzE",
-        "parentSlot": 334737291,
-        "previousBlockhash": "73UuT6UQ3m7nmjHEDeKf25GczouaoYwXDfxp7XNpGHvc",
-        "transactions": [
+          ],
+          "rewards": null,
+          "status": {
+            "Ok": null
+          }
+        },
+        "transaction": [
+          "AT8vuKXKc2oQH9lA2ZXzv08BTiU1btJDX/LnoKuiT/9UHGUQxcCf7L/Gf9IgonHHu6aIydGZFzceYDxRYUEeVwEBAAwV5b3H10gLgqQeyrtL3FmtXNRtBfOx8Aw69wz2FBl8IyIEIt4F5yOPTg51uJQwVbnLsh4lR3GzhyfTNpk3yTGwXQmho04GyUlatBIMrpc3j4Rkqh6EFlH7Bwso01x3AMGbHRc7POX6QBXybmT0h1Ryphz4t2g/dOozcI5q68DqqGJIkrMaRMc6cIi6gMVwht+UUiz1iQYFcliu2zLVqu2+3HBXpvlIpL3Rw31jMfY7i7oVIvVkzeXoPgTmXBqFktqUl7YBP00xpnHJy94coPLSGuboAj05RY6vAKB1AHGtpB7F8UFsvsDsDWf5+gj8dcxK4IdDZYfdpboLZlODSONkF+s19UIMi6Sa9p8tJhG+SLKfoqhjy9ckcbO/v0+F9x5EAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE3WGoemJ8CQTfHSj+OBeqeF5Y/eBoVXiT4sy75MeQMGRm/lIRcy/+ytunLDm+e8jOW7xfcSayxDmzpAAAAABt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKkKctJ9RKqYpLjO5cLEHBRYKXF+Fga2WtQRwhpFaYQE0ApzMzzvril0TwS4u+gququYHMKDI/kmm8fSe8GJ8FHaDLf6u1L3pki7WzF9mgGLkFfLAkd0+v4B5sTfmMw4WIE1qLKeTlZsAujeAehKN2jVN0VsKmG4HEE3hRlR0V16tGFfT9IEtANSjY2Qxcv1zxRdMFatStMhKIUC2xRKeoqWcd736KTvvidB/RV8sGxOWQStEiSZyFDSLPhpR9Okq4XOhWw+eHTSaZ7sBssUAogOTrr6RKW3WJR5h/IyBtnnbu5VrGhdRvj/pO82NnpELgbOpHqRn6+kN8GWwRSCmilDryDy+ji4xzyiIRZ31gM0Rbk6wdomSWgT+KdfMRwMG7IDCwAFAgA1DAALAAkDUMMAAAAAAAAOHwASEBMGCAUDAgQODg4OAQEHBw4ODgcBCBENDA8JChQZcz20GKgg1xQf0hdnAAAAAGSQAQAAAAAAAQ==",
+          "base64"
+        ],
+        "version": "legacy"
+      },
+      {
+        "slot": 0,
+        "blockTime": null,
+        "transaction": [
+          "AVav1GN12c9opW7rYU1/A59HLMe5QIjj6a+Z/rUCvqnO/YdY1/mMapAp7D/5DmAJaTfuZD41IwZSeCzU4AJ/7AkBAAEDC7woLkzel5f0/EL4yhPr5Se3YZ5BBwOM7FJF+6nuuI/aiWaeXiPZMjESvNYGcLB26ybQELagJ8RMFxJzcze2qAdhSB01dHS7fE12JOvTvbPYNV5z0RBD/A2jU4AAAAAAyAFYOytNd5MwWRk3ExDVhQ4DEq1VdE8K6f2ynFXBNycBAgIBAHQMAAAA+a7aDwAAAAAfAR8BHgEdARwBGwEaARkBGAEXARYBFQEUARMBEgERARABDwEOAQ0BDAELAQoBCQEIAQcBBgEFAQQBAwECAQEMDEWyVa5Y+18gpnHWVisk7DZLH7IPNLsKPZOVamACAQFEGUVmAAAAAA==",
+          "base64"
+        ],
+        "meta": {
+          "err": null,
+          "fee": 5000,
+          "preBalances": [8136335627, 88991012, 1],
+          "postBalances": [8136330627, 88991012, 1],
+          "innerInstructions": [],
+          "preTokenBalances": [],
+          "postTokenBalances": [],
+          "logMessages": [
+            "Program Vote111111111111111111111111111111111111111 invoke [1]",
+            "Program Vote111111111111111111111111111111111111111 success"
+          ],
+          "status": {
+            "Ok": null
+          },
+          "rewards": [],
+          "loadedAddresses": {
+            "readonly": [],
+            "writable": []
+          }
+        },
+        "version": "legacy"
+      }
+    ]
+  },
+  {
+    "blockHeight": 322941572,
+    "blockTime": 1729614372,
+    "blockhash": "feicppK3Qo2FBg8jdgB1tfK1DgesVPpWJaYqe6KeJr3",
+    "parentSlot": 334737293,
+    "previousBlockhash": "4yh9KU9Jh74LKQnQ9WontD3R78vwMN6HJZgrmptRTFF1",
+    "transactions": [
+      {
+        "meta": {
+          "computeUnitsConsumed": 22600,
+          "err": null,
+          "fee": 6750,
+          "innerInstructions": [],
+          "loadedAddresses": {
+            "readonly": [
+              "445GcRLAJ64DcxSRbvQTkbwXgWUyubAxzQUQ2wL73KLS",
+              "7jA4ZSGwaBxXk5EmPKDCSc5RtZNHxyoxy22iQt3D2mH9",
+              "AqZSmo7tVgPrZ72kSpRugN8pTCBTHovw65qPikP15dmK",
+              "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX"
+            ],
+            "writable": ["CuzxxETyjZkGVJmUv4zJTjoo4YE5HHdNm4AT4krtTikY"]
+          },
+          "logMessages": [
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program FTN6rgbaaxwT8mpRuC55EFTwpHB3BwnHJ91Lqv4ZVCfW invoke [1]",
+            "Program log: Instruction: SetInternalOraclePrice",
+            "Program FTN6rgbaaxwT8mpRuC55EFTwpHB3BwnHJ91Lqv4ZVCfW consumed 22300 of 34700 compute units",
+            "Program return: FTN6rgbaaxwT8mpRuC55EFTwpHB3BwnHJ91Lqv4ZVCfW AA==",
+            "Program FTN6rgbaaxwT8mpRuC55EFTwpHB3BwnHJ91Lqv4ZVCfW success"
+          ],
+          "postBalances": [
+            1863073661, 1, 1398960, 1, 1224960, 3953280, 7683840, 5400960,
+            1823520
+          ],
+          "postTokenBalances": [],
+          "preBalances": [
+            1863080411, 1, 1398960, 1, 1224960, 3953280, 7683840, 5400960,
+            1823520
+          ],
+          "preTokenBalances": [],
+          "returnData": {
+            "data": ["AA==", "base64"],
+            "programId": "FTN6rgbaaxwT8mpRuC55EFTwpHB3BwnHJ91Lqv4ZVCfW"
+          },
+          "rewards": null,
+          "status": {
+            "Ok": null
+          }
+        },
+        "transaction": [
+          "ASi6iVtIvMdRzyIJxtqANGA7FFjexa1HKjOB+OwdNVW+ZSko6KdkcI9IBVKOKxDWzlzFNEKrBaSa2gFJYVvbEg+AAQADBIn4KAbn3G4U/vI6/PldcVdaWYxXKb6hSfwgARhZpSMyAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAADWxJOzRzwVxFMMLoXkLPkHDGXItrzVXGtEhgeVwvx2xQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7NgDbutA7R6axo0upp2G1R3Nm/HVuehCxfGWRTmWBtsDAQAJA1DDAAAAAAAAAQAFAriIAAACBwAFBgcECAMsrqAPqOifeswiyfUFAAAAAPj////HNwEAAAAAAEXK9QUAAAAAI9IXZwAAAAABzBIKNsGNjLvVYQePGI4eEj5reCdpo+kg4cTMI9VWuzMBugQCAQaI",
+          "base64"
+        ],
+        "version": 0
+      },
+      {
+        "meta": {
+          "computeUnitsConsumed": 221052,
+          "err": null,
+          "fee": 5000,
+          "innerInstructions": [],
+          "loadedAddresses": {
+            "readonly": [],
+            "writable": []
+          },
+          "logMessages": [
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program 5Wvu3L3vVkQi2RPA12sTbzFTPgzgim5kQc3iRHFVw6zZ invoke [1]",
+            "Program data: Ag== CgAAAA== AAAAAA== JKKgAAAAAAA= AAAAAAAAAAA= AAAAAAAAAAA= FGmJ/v////8= LUMc6+I2Gj8= exSuR+F6hD8= /Knx0k1iQD8= obYVAA== jOYdAA== ZAAAAA== lHUZAA== AAAAAA== AQ== JNIXZw== jq/zEw== Bg==",
+            "Program data: Ag== CgAAAA== AAAAAA== JaKgAAAAAAA= AAAAAAAAAAA= AAAAAAAAAAA= EClG/v////8= LUMc6+I2Gj8= exSuR+F6hD8= /Knx0k1iQD8= obYVAA== jOYdAA== ZAAAAA== cHsZAA== AAAAAA== AQ== JNIXZw== jq/zEw== Bw==",
+            "Program data: Ag== CgAAAA== AAAAAA== U6KgAAAAAAA= AAAAAAAAAAA= AAAAAAAAAAA= XMZyAQAAAAA= LUMc6+I2Gj8= exSuR+F6hD8= /Knx0k1iQD8= obYVAA== jOYdAA== ZAAAAA== 0GsZAA== AAAAAA== AQ== JNIXZw== jq/zEw== AA==",
+            "Program data: Ag== CgAAAA== AAAAAA== VKKgAAAAAAA= AAAAAAAAAAA= AAAAAAAAAAA= gKe9AQAAAAA= LUMc6+I2Gj8= exSuR+F6hD8= /Knx0k1iQD8= obYVAA== jOYdAA== ZAAAAA== rHEZAA== AAAAAA== AQ== JNIXZw== jq/zEw== AQ==",
+            "Program 5Wvu3L3vVkQi2RPA12sTbzFTPgzgim5kQc3iRHFVw6zZ consumed 220902 of 299850 compute units",
+            "Program 5Wvu3L3vVkQi2RPA12sTbzFTPgzgim5kQc3iRHFVw6zZ success"
+          ],
+          "postBalances": [
+            4679560814, 3062400, 2616960, 2561280, 17205120, 3507840, 2171520,
+            2394240, 2394240, 3062400, 14922240, 2616960, 41258880, 294714240,
+            254958720, 1, 2171520, 1141440, 2616960, 1, 4788480
+          ],
+          "postTokenBalances": [],
+          "preBalances": [
+            4679565814, 3062400, 2616960, 2561280, 17205120, 3507840, 2171520,
+            2394240, 2394240, 3062400, 14922240, 2616960, 41258880, 294714240,
+            254958720, 1, 2171520, 1141440, 2616960, 1, 4788480
+          ],
+          "preTokenBalances": [],
+          "rewards": null,
+          "status": {
+            "Ok": null
+          }
+        },
+        "transaction": [
+          "AV4VCiOq3qg8APSdU5bAo92aWNVFS/lkvEgpUjHQsSvqqhDnbTsx4fXZ5aSn47isTJu5QnUQsqr+Mvqe4Jq3JAMBAAYVBsCSmrs4MdR1vi9ob3KDNVVbfOI5Ttjxm6oiDBEAYIMRfzaHC5fmOJINERTEVzCi2M0GBwG8fXTbM10qi7aqDhZWXG8uIMLlsVjZG3OCqLp0nGSuRVmFY4BQhfPXnbT1Jj56U/EoKsXt0rqePSwZ84ViW5p7zdgYwE2FdMsK0WMgsMzHI19xSJIw14xZrC0x2dD1sa+gErb9TnxI3Wm9uC+y97w+8OuyBo4y1oMP4KWcuxLj8vEiT2s0NzucnpAmOmc92DqDflB7pasp+nHEDtm462R3ls2yRc4T3CJ3bCw+QvDCVamvNNQR6pBxMim8AmWOLp8JxhaB2AoedrGB5YdvzvsPsSXl+7sx0OjVOvILbRHbhwQbrtzEiBCrAI8zlHCda1GWNn8R/3V1zTaiIWJL3OL+JO/jdyvzxPGCJuizR5NRxTL8e/xfbviRUPx1xsPOfDxHuJYWj6g73ulXc7u2rR5KPkhV7vCVyaDaOLSj8/uhaOE+fi0v96T2iyg91O/LiHifAWf8IR63ZJ7SAir9Q0hPQILLWsTQCmmxkw7qfyihluX9vqVaUZ2lGBYjC2NJSXSWFTtHE3b1cxGMrfm+4PLuJTqcmpIMKndcDrxE7DpWH66U650KNU8AdzAmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3dqdhe5cdGqU7VGMTH9oQbgmWmTced2WrsJcd01NWAUMZiHEmjDjI4Eoqqnhhi/SdCFw5wmMeN9MyHRDIuMCugBKI+dL7siRkEOi6cWS05MjJ5NOLA6ilF5KwatsvK9MDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAL1S4p2hMh10ZHB4YkBjxoT8OtxbhfzwXCPF9sgX39bI6ZMJgji4ZK1YPaGMMVpO6XD7J2OOTkI4YqLbvj50JiQCEwAFAuCTBAAREwASEAMMBA4LAgkBBQ0HCAYKFA89IwAAAAABAAAAJgAAANBrGQAAAAAAZAAAAAAAAAAkoqAAAAAAAKxxGQAAAAAAZAAAAAAAAAAloqAAAAAAAA==",
+          "base64"
+        ],
+        "version": "legacy"
+      }
+    ]
+  },
+  {
+    "blockHeight": 322941574,
+    "blockTime": 1729614373,
+    "blockhash": "8nFMCT3CRjgw3MmkF2yg3JmrBW6pUAW4ku6Wo3ynQU8q",
+    "parentSlot": 334737295,
+    "previousBlockhash": "mf3EYQu5S39S9i6vzYpvPMqEDFm4rQLV72GK6YM5xSA",
+    "transactions": [
+      {
+        "meta": {
+          "computeUnitsConsumed": 7993,
+          "err": null,
+          "fee": 5550,
+          "innerInstructions": [],
+          "loadedAddresses": {
+            "readonly": [],
+            "writable": []
+          },
+          "logMessages": [
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ invoke [1]",
+            "Program log: Instruction: CloseEncodedVaa",
+            "Program HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ consumed 2559 of 10700 compute units",
+            "Program HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ success",
+            "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ invoke [1]",
+            "Program log: Instruction: ReclaimRent",
+            "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ consumed 2567 of 8141 compute units",
+            "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ success",
+            "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ invoke [1]",
+            "Program log: Instruction: ReclaimRent",
+            "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ consumed 2567 of 5574 compute units",
+            "Program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ success"
+          ],
+          "postBalances": [8667037537, 0, 0, 0, 1, 1141440, 1141440],
+          "postTokenBalances": [],
+          "preBalances": [
+            8655559087, 1823520, 7836960, 1823520, 1, 1141440, 1141440
+          ],
+          "preTokenBalances": [],
+          "rewards": null,
+          "status": {
+            "Ok": null
+          }
+        },
+        "transaction": [
+          "AThfMPoLShfmrw+ushgXGpk8rswvL2YuIe/qa/Lxg8ZGk57p10PrphStNVk2vo9Hu0gr06CcaiRK7dITiiNr+gMBAAMH5b3H10gLgqQeyrtL3FmtXNRtBfOx8Aw69wz2FBl8IyIAAE3WGoemJ8CQTfHSj+OBeqeF5Y/eBoVXiT4sy75MeUqJqZd0+9PIfZz3W3vjQ5z5fllTF+zR3cHEEFkK29bU7lWsaF1G+P+k7zY2ekQuBs6kepGfr6Q3wZbBFIKaKUMDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAAy3+rtS96ZIu1sxfZoBi5BXywJHdPr+AebE35jMOFiB8Qu05Q1W/aE9/h8ym405PdJKAUWR4YMWl5QNfDSjjd3s2ANu60DtHprGjS6mnYbVHc2b8dW56ELF8ZZFOZYG2wUEAAUC+CoAAAQACQNQwwAAAAAAAAYCAAIIMN2uxucHmCYFAgADCNrIE8XjWcAWBQIAAQjayBPF41nAFg==",
+          "base64"
+        ],
+        "version": "legacy"
+      },
+      {
+        "meta": {
+          "computeUnitsConsumed": 65433,
+          "err": null,
+          "fee": 10229,
+          "innerInstructions": [
             {
-                "meta": {
-                    "computeUnitsConsumed": 57566,
-                    "err": null,
-                    "fee": 18500,
-                    "innerInstructions": [],
-                    "loadedAddresses": {
-                        "readonly": [],
-                        "writable": []
-                    },
-                    "logMessages": [
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program DEALERKFspSo5RoXNnKAhRPhTcvJeqeEgAgZsNSjCx5E invoke [1]",
-                        "Program log: Instruction: NoMoreBets",
-                        "Program log: No more bets Game=2 Room=1 Round=237054",
-                        "Program DEALERKFspSo5RoXNnKAhRPhTcvJeqeEgAgZsNSjCx5E consumed 57266 of 99700 compute units",
-                        "Program DEALERKFspSo5RoXNnKAhRPhTcvJeqeEgAgZsNSjCx5E success"
-                    ],
-                    "postBalances": [
-                        13286006513,
-                        38398320,
-                        1,
-                        1141440,
-                        1
-                    ],
-                    "postTokenBalances": [],
-                    "preBalances": [
-                        13286025013,
-                        38398320,
-                        1,
-                        1141440,
-                        1
-                    ],
-                    "preTokenBalances": [],
-                    "rewards": null,
-                    "status": {
-                        "Ok": null
-                    }
-                },
-                "transaction": [
-                    "Aef6wC7jRUTSNJXXPLJw0YeH45V1fx8kYYkOvNLC6iUr55AStfDtGemsMHH+zGHQQF10g8Y3E8FjDdFeibQ4NQGAAQADBVB7N1RPyFFY4Pn4YTVsKAguI+0DJvc7Z5uKk6etXSbnfJWH+tSdYzJGFjobJRj9Y2doBbsZJ+JTVQEI4AoxLmUDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAALWrWEoOURXC2vUy8WwOTJzcLkiAxyCUKcIGMGT5tKbpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAsDCDiNujvgsnGZ6wnJFW60pr9pcjELc320ORuzveVwMCAAkDWA8CAAAAAAACAAUCoIYBAAMDAQAEFGoZ+H2TJ3uOAgABAP6dAwAAAAAAAA==",
-                    "base64"
-                ],
-                "version": 0
+              "index": 2,
+              "instructions": [
+                {
+                  "accounts": [7, 9, 16],
+                  "data": "3px3hhrW2tYw",
+                  "programIdIndex": 13,
+                  "stackHeight": 2
+                }
+              ]
+            }
+          ],
+          "loadedAddresses": {
+            "readonly": [],
+            "writable": []
+          },
+          "logMessages": [
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f invoke [1]",
+            "Program log: Instruction: AggregatorSaveResult",
+            "Program data: Dk7x7N2nVakXYctI6lgFaSU7esDDgap4NL0RL69En9ViObhyAhjwhJCv8xMAAAAAJdIXZwAAAAAAAAAAAAAAAA==",
+            "Program data: A5o8/ZicmX4XYctI6lgFaSU7esDDgap4NL0RL69En9ViObhyAhjwhAAAZKeztuANAAAAAAAAAAASAAAAkK/zEwAAAAAl0hdnAAAAAAeGZkx0Ab9KcacEE25L4Kkoe2bAxKbzMawGdR5Vi2zCAAAAAA==",
+            "Program log: P1 2aGsGLsnby48p5vR3vj2PeUTuNbosT1JnPZJrdAcgtTD",
+            "Program log: MODE_ROUND",
+            "Program data: m/42h1I1hpQXYctI6lgFaSU7esDDgap4NL0RL69En9ViObhyAhjwhIEzO/v3/Couc0LeJQNiazP9ZncWSlagGUs4WBim/I9yLpYb5MI1Jm8ZkcejXEWao+ZBBPWtC9EHHRS1OzYTtdxL4g2K3PYBBOeNhsdOqJLSAKbpFvVI7Cz9R+CDa6QkrQAAAAAAAAAAi6/zEwAAAAAl0hdnAAAAAA==",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: Transfer",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4736 of 193932 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program data: lYLi/gDS5xAXYctI6lgFaSU7esDDgap4NL0RL69En9ViObhyAhjwhIEzO/v3/Couc0LeJQNiazP9ZncWSlagGUs4WBim/I9yB4ZmTHQBv0pxpwQTbkvgqSh7ZsDEpvMxrAZ1HlWLbMLIiCi8eTgwk/F0rXyDYo6FCgQ0dik7Uh5QvYVf96Wxm9QwAAAAAAAAi6/zEwAAAAAl0hdnAAAAAA==",
+            "Program data: cB8z6WFkK/UXYctI6lgFaSU7esDDgap4NL0RL69En9ViObhyAhjwhAAAZKeztuANAAAAAAAAAAASAAAAkK/zEwAAAAAl0hdnAAAAAAEAAAAHhmZMdAG/SnGnBBNuS+CpKHtmwMSm8zGsBnUeVYtswgEAAAAAAGSns7bgDQAAAAAAAAAAEgAAAA==",
+            "Program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f consumed 65133 of 248699 compute units",
+            "Program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f success"
+          ],
+          "postBalances": [
+            2326681379184, 5317440, 12089520, 27693840, 5317440, 28193384974,
+            3480000, 1887264280, 4043760, 27958498209, 1, 1141440, 960737013533,
+            934087680, 9723120, 3480000, 1201079987
+          ],
+          "postTokenBalances": [
+            {
+              "accountIndex": 5,
+              "mint": "So11111111111111111111111111111111111111112",
+              "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "28191345694",
+                "decimals": 9,
+                "uiAmount": 28.191345694,
+                "uiAmountString": "28.191345694"
+              }
             },
             {
-                "meta": {
-                    "computeUnitsConsumed": 291351,
-                    "err": null,
-                    "fee": 45000,
-                    "innerInstructions": [
-                        {
-                            "index": 2,
-                            "instructions": [
-                                {
-                                    "accounts": [
-                                        0,
-                                        16
-                                    ],
-                                    "data": "E2Q9zzc4R2iaLevUw2X7cLTkbBVrWmiQ9",
-                                    "programIdIndex": 13,
-                                    "stackHeight": 2
-                                },
-                                {
-                                    "accounts": [
-                                        18,
-                                        16,
-                                        6,
-                                        19,
-                                        15,
-                                        10,
-                                        20
-                                    ],
-                                    "data": "Br5D4BFTnYxBdSg1axvxcf9baAFWqFkKmpAgAZaoLywX21ZkSb5vNcThm7CNP5fcvU9M2LympdnfE1k1vvGAE7g63c2pHvRPep6tb6fG",
-                                    "programIdIndex": 13,
-                                    "stackHeight": 2
-                                },
-                                {
-                                    "accounts": [
-                                        18,
-                                        16,
-                                        6,
-                                        3,
-                                        8,
-                                        5,
-                                        2,
-                                        13,
-                                        13,
-                                        13,
-                                        13,
-                                        1,
-                                        1,
-                                        7,
-                                        7,
-                                        13,
-                                        13,
-                                        13,
-                                        12,
-                                        17,
-                                        13
-                                    ],
-                                    "data": "25ozmx8ZeodPjkGWfGoWpyio",
-                                    "programIdIndex": 13,
-                                    "stackHeight": 2
-                                },
-                                {
-                                    "accounts": [
-                                        17
-                                    ],
-                                    "data": "PXKJYD315JEJDZYu7uztGwNqJPWdMxX1YhMhxZ12P71JHzNYSAW4ZjTg8vU4McWGd5CniSJsmGbT9PmyMGxrcugi17iMyXtKpuHGbw4eKvZMRS2XyfrXhy1tYVephWJSp56S2Kvwmfr2tTYdLP6Ekm4gD6sKqp2b26AcKBhPZ18Wy8rjZ7djZzkDSbRQ1d4ACBCr6f3bQMKpd7ECrcTq1hRE1gdTfA7rjZgTQ6uxGcQirSUw2py1AazRVGgyZsQ6bXieS2yaQJUiyWWE8giXGWwgTMc7P4WJChMtJNfngnZkfaLV4cxztQ3qW7vtNVxkt44hvpf4eqQ7WcXQ9Y4nvvP9zhgPeyGZtyrSx2ZaWU1XbybpwEPBYSzvTRJ6eSkr9Q1RwqLAXX49qCoZUkiLLDWnSr3YYunbL2km8vAkNjKXhabv7emnG2fb55djgdJSLeVsrr2tpSCFtGNcCUUGMaWQz3y6bdxk3w4TmwtvtSpe2BULBSRht4SVPgjeVzsZhpbVfn1jNURXypLQr6vY8cAQ9N1dQggbsDzivfxJtTftR34x3uuJ5AtbiN8CPVgwN6DfFxHUwtTbGvdoAyspGZRjydGf33HnEh5vZ6uBYfwqH6Q8DhQrBt8DSin7LSoMWceumCsRrtf9GMrotSRTs9FLREqftgrwwo2YE52KPUVVAuhS7tvs5esXJZ21p5HXhsosBjNKGcFJa6VpvaVToWWGLRLRqW3RruqVwyNPp1VdS56LCdpArZWoR22b9qydb8nwznYZUTYm6fC5s5Etc5KUYBgFie73HPvzYyLuSLQWoyHJJzM7foRtZTy5HmZTk3j7RVxVN6MjVozinHZSemN1cmDLxgNxu5tqdSCyYnSmNb4xjDcpbuLtdxKLn7YShicb6zbJPuym1eeBdvwwduNQTdPN1hqwx3oq578XXTffYuRqETBXVLe68sNyLdkPSrSe7AFXA8tq9AmeS3uwFZrj8xdydr6yFSuiAgwqLdv4oh3iEGbB2aXButAuByTdYgECyGBKAu91PMRUyXDyLNV4QeL614jMteRi68J7T86NqsPGh6a99Esdr3pvfUnGWT",
-                                    "programIdIndex": 13,
-                                    "stackHeight": 3
-                                },
-                                {
-                                    "accounts": [
-                                        18,
-                                        16,
-                                        6
-                                    ],
-                                    "data": "VB9m5Wo7Scv",
-                                    "programIdIndex": 13,
-                                    "stackHeight": 2
-                                },
-                                {
-                                    "accounts": [
-                                        0,
-                                        18,
-                                        16,
-                                        3,
-                                        4,
-                                        9,
-                                        17,
-                                        13
-                                    ],
-                                    "data": "2DfZaYcLBaxHdYEouV5TACdQE4wR7h8X5LM4nLj",
-                                    "programIdIndex": 13,
-                                    "stackHeight": 2
-                                },
-                                {
-                                    "accounts": [
-                                        0,
-                                        4
-                                    ],
-                                    "data": "3Bxs4b9KUfinEREw",
-                                    "programIdIndex": 9,
-                                    "stackHeight": 3
-                                },
-                                {
-                                    "accounts": [
-                                        17
-                                    ],
-                                    "data": "2tEc5NHNMxEKCXQhSkjtRweNdy2Dz2fhtec9qs6GuDHWQJhSRh2afUA9syJg71zpQMLctCKF3Q1dEwhgrBxBQWHTxk8njpxtfmUpMFHtAxEDkqi3Yq5xa1iuWpYs7vxQLVng12duTjTeNM1c7TwyaFEH3qYoYZfj7iUWPpFz1hRrKZmiqfuQ9HkFQmwJhZP94HuSj58TzS16dpE5VgMD4TdgVd2K7jt99GPdj9vgA44SuJW89i5RSWhR",
-                                    "programIdIndex": 13,
-                                    "stackHeight": 3
-                                }
-                            ]
-                        }
-                    ],
-                    "loadedAddresses": {
-                        "readonly": [],
-                        "writable": []
-                    },
-                    "logMessages": [
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-                        "Program ComputeBudget111111111111111111111111111111 success",
-                        "Program hnxiNKTc515NHvuq5fEUAc62dWkEu3m623FbwemWNJd invoke [1]",
-                        "Program log: Instruction: ExecuteOrder",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [2]",
-                        "Program log: Instruction: CheckRole",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 2120 of 774275 compute units",
-                        "Program return: hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT AQ==",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [2]",
-                        "Program log: Instruction: SetPricesFromPriceFeed",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 15055 of 760625 compute units",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [2]",
-                        "Program log: Instruction: ExecuteOrder",
-                        "Program log: [Order] pre-execute: DistributePositionImpactReport { duration_in_seconds: 10, distribution_amount: 0, next_position_impact_pool_amount: 4288 }",
-                        "Program log: [Position] increased: IncreasePositionReport { params: IncreasePositionParams { collateral_increment_amount: 50000000, size_delta_usd: 10000000000000000000000, acceptable_price: None, prices: Prices { index_token_price: 66959500000000000, long_token_price: 99990000000000, short_token_price: 99990000000000 } }, execution: ExecutionParams { price_impact_value: -74720565254250000, price_impact_amount: -2, size_delta_in_tokens: 149342, execution_price: 66960399619664930 }, collateral_delta_amount: 49929993, fees: PositionFees { base: Fees { fee_receiver_amount: 49004, fee_amount_for_pool: 21003 }, borrowing: BorrowingFee { amount: 0, amount_for_receiver: 0 }, funding: FundingFees { amount: 0, claimable_long_token_amount: 0, claimable_short_token_amount: 0 } }, borrowing: UpdateBorrowingReport { duration_in_seconds: 10, next_cumulative_borrowing_factor_for_long: 3181618323149899003, next_cumulative_borrowing_factor_for_short: 371849625775569617 }, funding: UpdateFundingReport { duration_in_seconds: 10, next_funding_factor_per_second: 1000000000000, delta_funding_amount_per_size: [1000100011, 0, 1000100011, 0], delta_claimable_funding_amount_per_size: [0, 62648402552, 0, 62648402552] }, claimble_funding_long_token_amount: 0, claimble_funding_short_token_amount: 0 }",
-                        "Program log: [Position] executed with trade_id=311420885",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [3]",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 5005 of 571069 compute units",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 172595 of 735303 compute units",
-                        "Program return: hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT AAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [2]",
-                        "Program log: Instruction: ClearAllPrices",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 6077 of 551674 compute units",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [2]",
-                        "Program log: Instruction: RemoveOrder",
-                        "Program 11111111111111111111111111111111 invoke [3]",
-                        "Program 11111111111111111111111111111111 success",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT invoke [3]",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 5005 of 515321 compute units",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT consumed 29155 of 538897 compute units",
-                        "Program hndKzPMrB9Xzs3mwarnPdkSWpZPZN3gLeeNzHDcHotT success",
-                        "Program hnxiNKTc515NHvuq5fEUAc62dWkEu3m623FbwemWNJd consumed 291051 of 799700 compute units",
-                        "Program hnxiNKTc515NHvuq5fEUAc62dWkEu3m623FbwemWNJd success"
-                    ],
-                    "postBalances": [
-                        8655559087,
-                        2039280,
-                        2951040,
-                        0,
-                        6890171460,
-                        1461600,
-                        10767120,
-                        2039280,
-                        17873280,
-                        1,
-                        1823520,
-                        1,
-                        934087680,
-                        1141440,
-                        1141440,
-                        1141440,
-                        42706560,
-                        0,
-                        1000000000,
-                        249919680,
-                        1823520
-                    ],
-                    "postTokenBalances": [
-                        {
-                            "accountIndex": 1,
-                            "mint": "Brn3Z9BbjWUVydnMuzcyxCMc1RL4LA9Bt9zGEdWsAfMx",
-                            "owner": "4cTohP5nfJzNpkYWXbR4pnLKHZsu4PzMiLxu6zKoDu3q",
-                            "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                            "uiTokenAmount": {
-                                "amount": "617044033210",
-                                "decimals": 6,
-                                "uiAmount": 617044.03321,
-                                "uiAmountString": "617044.03321"
-                            }
-                        },
-                        {
-                            "accountIndex": 7,
-                            "mint": "Brn3Z9BbjWUVydnMuzcyxCMc1RL4LA9Bt9zGEdWsAfMx",
-                            "owner": "5tJ6aNLxSbB6RmzUhmr4mgDVeLb2XQY8auCmFE4t3AE7",
-                            "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                            "uiTokenAmount": {
-                                "amount": "3186483152",
-                                "decimals": 6,
-                                "uiAmount": 3186.483152,
-                                "uiAmountString": "3186.483152"
-                            }
-                        }
-                    ],
-                    "preBalances": [
-                        8655501587,
-                        2039280,
-                        2951040,
-                        7245360,
-                        6883028600,
-                        1461600,
-                        10767120,
-                        2039280,
-                        17873280,
-                        1,
-                        1823520,
-                        1,
-                        934087680,
-                        1141440,
-                        1141440,
-                        1141440,
-                        42706560,
-                        0,
-                        1000000000,
-                        249919680,
-                        1823520
-                    ],
-                    "preTokenBalances": [
-                        {
-                            "accountIndex": 1,
-                            "mint": "Brn3Z9BbjWUVydnMuzcyxCMc1RL4LA9Bt9zGEdWsAfMx",
-                            "owner": "4cTohP5nfJzNpkYWXbR4pnLKHZsu4PzMiLxu6zKoDu3q",
-                            "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                            "uiTokenAmount": {
-                                "amount": "617044033210",
-                                "decimals": 6,
-                                "uiAmount": 617044.03321,
-                                "uiAmountString": "617044.03321"
-                            }
-                        },
-                        {
-                            "accountIndex": 7,
-                            "mint": "Brn3Z9BbjWUVydnMuzcyxCMc1RL4LA9Bt9zGEdWsAfMx",
-                            "owner": "5tJ6aNLxSbB6RmzUhmr4mgDVeLb2XQY8auCmFE4t3AE7",
-                            "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                            "uiTokenAmount": {
-                                "amount": "3186483152",
-                                "decimals": 6,
-                                "uiAmount": 3186.483152,
-                                "uiAmountString": "3186.483152"
-                            }
-                        }
-                    ],
-                    "rewards": null,
-                    "status": {
-                        "Ok": null
-                    }
-                },
-                "transaction": [
-                    "AT8vuKXKc2oQH9lA2ZXzv08BTiU1btJDX/LnoKuiT/9UHGUQxcCf7L/Gf9IgonHHu6aIydGZFzceYDxRYUEeVwEBAAwV5b3H10gLgqQeyrtL3FmtXNRtBfOx8Aw69wz2FBl8IyIEIt4F5yOPTg51uJQwVbnLsh4lR3GzhyfTNpk3yTGwXQmho04GyUlatBIMrpc3j4Rkqh6EFlH7Bwso01x3AMGbHRc7POX6QBXybmT0h1Ryphz4t2g/dOozcI5q68DqqGJIkrMaRMc6cIi6gMVwht+UUiz1iQYFcliu2zLVqu2+3HBXpvlIpL3Rw31jMfY7i7oVIvVkzeXoPgTmXBqFktqUl7YBP00xpnHJy94coPLSGuboAj05RY6vAKB1AHGtpB7F8UFsvsDsDWf5+gj8dcxK4IdDZYfdpboLZlODSONkF+s19UIMi6Sa9p8tJhG+SLKfoqhjy9ckcbO/v0+F9x5EAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE3WGoemJ8CQTfHSj+OBeqeF5Y/eBoVXiT4sy75MeQMGRm/lIRcy/+ytunLDm+e8jOW7xfcSayxDmzpAAAAABt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKkKctJ9RKqYpLjO5cLEHBRYKXF+Fga2WtQRwhpFaYQE0ApzMzzvril0TwS4u+gququYHMKDI/kmm8fSe8GJ8FHaDLf6u1L3pki7WzF9mgGLkFfLAkd0+v4B5sTfmMw4WIE1qLKeTlZsAujeAehKN2jVN0VsKmG4HEE3hRlR0V16tGFfT9IEtANSjY2Qxcv1zxRdMFatStMhKIUC2xRKeoqWcd736KTvvidB/RV8sGxOWQStEiSZyFDSLPhpR9Okq4XOhWw+eHTSaZ7sBssUAogOTrr6RKW3WJR5h/IyBtnnbu5VrGhdRvj/pO82NnpELgbOpHqRn6+kN8GWwRSCmilDryDy+ji4xzyiIRZ31gM0Rbk6wdomSWgT+KdfMRwMG7IDCwAFAgA1DAALAAkDUMMAAAAAAAAOHwASEBMGCAUDAgQODg4OAQEHBw4ODgcBCBENDA8JChQZcz20GKgg1xQf0hdnAAAAAGSQAQAAAAAAAQ==",
-                    "base64"
-                ],
-                "version": "legacy"
-            }, 
+              "accountIndex": 7,
+              "mint": "So11111111111111111111111111111111111111112",
+              "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "1885225000",
+                "decimals": 9,
+                "uiAmount": 1.885225,
+                "uiAmountString": "1.885225"
+              }
+            },
             {
-                "slot": 0,
-                "blockTime": null,
-                "transaction": [
-                    "AVav1GN12c9opW7rYU1/A59HLMe5QIjj6a+Z/rUCvqnO/YdY1/mMapAp7D/5DmAJaTfuZD41IwZSeCzU4AJ/7AkBAAEDC7woLkzel5f0/EL4yhPr5Se3YZ5BBwOM7FJF+6nuuI/aiWaeXiPZMjESvNYGcLB26ybQELagJ8RMFxJzcze2qAdhSB01dHS7fE12JOvTvbPYNV5z0RBD/A2jU4AAAAAAyAFYOytNd5MwWRk3ExDVhQ4DEq1VdE8K6f2ynFXBNycBAgIBAHQMAAAA+a7aDwAAAAAfAR8BHgEdARwBGwEaARkBGAEXARYBFQEUARMBEgERARABDwEOAQ0BDAELAQoBCQEIAQcBBgEFAQQBAwECAQEMDEWyVa5Y+18gpnHWVisk7DZLH7IPNLsKPZOVamACAQFEGUVmAAAAAA==",
-                    "base64"
-                ],
-                "meta": {
-                    "err": null,
-                    "fee": 5000,
-                    "preBalances": [
-                        8136335627,
-                        88991012,
-                        1
-                    ],
-                    "postBalances": [
-                        8136330627,
-                        88991012,
-                        1
-                    ],
-                    "innerInstructions": [],
-                    "preTokenBalances": [],
-                    "postTokenBalances": [],
-                    "logMessages": [
-                        "Program Vote111111111111111111111111111111111111111 invoke [1]",
-                        "Program Vote111111111111111111111111111111111111111 success"
-                    ],
-                    "status": {
-                        "Ok": null
-                    },
-                    "rewards": [],
-                    "loadedAddresses": {
-                        "readonly": [],
-                        "writable": []
-                    }
-                },
-                "version": "legacy"
+              "accountIndex": 9,
+              "mint": "So11111111111111111111111111111111111111112",
+              "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "27956458929",
+                "decimals": 9,
+                "uiAmount": 27.956458929,
+                "uiAmountString": "27.956458929"
+              }
             }
-        ]
-    }
+          ],
+          "preBalances": [
+            2326681389413, 5317440, 12089520, 27693840, 5317440, 28193384974,
+            3480000, 1887276780, 4043760, 27958485709, 1, 1141440, 960737013533,
+            934087680, 9723120, 3480000, 1201079987
+          ],
+          "preTokenBalances": [
+            {
+              "accountIndex": 5,
+              "mint": "So11111111111111111111111111111111111111112",
+              "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "28191345694",
+                "decimals": 9,
+                "uiAmount": 28.191345694,
+                "uiAmountString": "28.191345694"
+              }
+            },
+            {
+              "accountIndex": 7,
+              "mint": "So11111111111111111111111111111111111111112",
+              "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "1885237500",
+                "decimals": 9,
+                "uiAmount": 1.8852375,
+                "uiAmountString": "1.8852375"
+              }
+            },
+            {
+              "accountIndex": 9,
+              "mint": "So11111111111111111111111111111111111111112",
+              "owner": "CyZuD7RPDcrqCGbNvLCyqk6Py9cEZTKmNKujfPi3ynDd",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "27956446429",
+                "decimals": 9,
+                "uiAmount": 27.956446429,
+                "uiAmountString": "27.956446429"
+              }
+            }
+          ],
+          "rewards": null,
+          "status": {
+            "Ok": null
+          }
+        },
+        "transaction": [
+          "ATk4p1JJWq+4jSJId+6OUZ4aJTE3UBuhcrXdpDvOXGwIqMXRxPpOnhcvDwQep0ZuFiQJl6RACvbuq7NKTca63QoBAAcRE6Und58TTqIUP4M1S3pfMslF0Ya0SPwWMnhhocD3evgHhmZMdAG/SnGnBBNuS+CpKHtmwMSm8zGsBnUeVYtswgrzV+SbIlnlpQ4MqxddLExSM5Ramvt6jpuO7XdscALoF2HLSOpYBWklO3rAw4GqeDS9ES+vRJ/VYjm4cgIY8IQulhvkwjUmbxmRx6NcRZqj5kEE9a0L0QcdFLU7NhO13EviDYrc9gEE542Gx06oktIApukW9UjsLP1H4INrpCStUmax26Ll6OyD4NH6rkUq/iez02PIxieIzIB4HibLITtnTFLBnd7U2kL/ZZ6ODLbBb/Cm38NHyUX2mQ+tZPCbw4EzO/v3/Couc0LeJQNiazP9ZncWSlagGUs4WBim/I9yyIgovHk4MJPxdK18g2KOhQoENHYpO1IeUL2FX/elsZsDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAAaIUcaMaDLwL6WBsb9JG3fKQXdrormItab6uo7jouyQBpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAEG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQ1rzpq7vfDJhKFxPXon6UBvXisIlEW7BFX0X8/2tDO6rd+Y4TDySSxnwCnu9tVNqN6UZapCoVJvnmbykwSG/Aqx7kglPvsN1CPoW5+frlezWwWJ3gBP3Kra2qQ67QcWMPfOuVhDeHyAhhNXy1u0olEHm5pwGY5INaaGrVU/lwZzAwoACQMIUgAAAAAAAAoABQKnzAMACxIDAQAOAAYPCAcNEAMMBAEFCQJtFUMFAEqoM8ABAAAAAAAAZKeztuANAAAAAAAAAAASAAAA4irl+f07kXcVXpSek9h4vf1fKHXBe4JKhVoy/OohnIMAAGSns7bgDQAAAAAAAAAAEgAAAAAAZKeztuANAAAAAAAAAAASAAAA//7/+Q==",
+          "base64"
+        ],
+        "version": "legacy"
+      }
+    ]
+  }
 ]

--- a/pkg/solana/fees/utils_test.go
+++ b/pkg/solana/fees/utils_test.go
@@ -36,11 +36,11 @@ func TestCalculateFee(t *testing.T) {
 
 func TestParseBlock(t *testing.T) {
 	testBlocks := readMultipleBlocksFromFile(t, "./multiple_blocks_data.json")
-	lastBlock := testBlocks[len(testBlocks)-1]
-	assert.Equal(t, 3, len(lastBlock.Transactions))
+	firstBlock := testBlocks[0]
+	assert.Equal(t, 3, len(firstBlock.Transactions))
 
 	// happy path - filtered for non-vote txs
-	out, err := ParseBlock(lastBlock)
+	out, err := ParseBlock(firstBlock)
 	require.NoError(t, err)
 	assert.Equal(t, len(out.Prices), len(out.Fees))
 	assert.Equal(t, 2, len(out.Prices))


### PR DESCRIPTION
### Context
Solana RPCs do not support fetching blocks in batches. Previously, an RPC call had to be made for each block when fetching the latest `BlockHistorySize` blocks. This was not sustainable if a large `BlockHistorySize` needed to be configured.

### Solution
An in-memory cache was added to store the latest `BlockHistorySize` blocks to avoid refetching ones that are still relevant to estimates. This way only the new blocks that were generated between poll periods need to be fetched and stored in the cache. If the cache contains more blocks than `BlockHistorySize`, the oldest `len(cache) - BlockHistorySize` blocks are removed.

A new config `BlockHistoryBatchLoadSize` was introduced to avoid overloading the RPC on startup when the cache is empty. This config controls how many blocks are fetched each interval. This config is only used if `BlockHistorySize > 1` and if `BlockHistoryBatchLoadSize < BlockHistorySize`. Even if an RPC can handle loading all blocks upfront, it may take longer to process them than they stay relevant for. For example, if processing 150 blocks can take more than 1 min, 150 new blocks could have passed in that time invalidating that work. It's better to load blocks in smaller batches to enable the cache to save resources. Loading in smaller batches also means initial estimations would be on smaller block ranges than `BlockHistorySize` during startup until the cache is filled. If estimations are blocked until the cache is filled, the TXM could be blocked for too long of a period. There isn't a risk of bad estimations for broadcast since blocks are loaded from latest to oldest. The most recent market price would always be used.

### Depends on this PR
Core PR: https://github.com/smartcontractkit/chainlink/pull/17247