### PR TITLE
Root Cause of Multiple Registered Filters

### DIFF
--- a/pkg/solana/chainreader/chain_reader.go
+++ b/pkg/solana/chainreader/chain_reader.go
@@ -635,7 +635,9 @@ func (s *ContractReaderService) addEventRead(
 	)
 
 	s.shouldStartLP = true
-	reader.SetFilter(toLPFilter(readDefinition.ChainSpecificName, pf, subkeys.subKeys[:], eventDef))
+	if err := reader.SetFilter(toLPFilter(readDefinition.ChainSpecificName, pf, subkeys.subKeys[:], eventDef)); err != nil {
+		return err
+	}
 
 	s.bdRegistry.AddReader(namespace, genericName, reader)
 	s.lookup.addReadNameForContract(namespace, genericName, []read{{readName: genericName, useParams: false}})

--- a/pkg/solana/chainreader/chain_reader_test.go
+++ b/pkg/solana/chainreader/chain_reader_test.go
@@ -592,6 +592,83 @@ func TestSolanaChainReaderService_GetLatestValue(t *testing.T) {
 	})
 }
 
+func TestSolanaChainReaderService_DatabaseBloat(t *testing.T) {
+	// For every service start, new filters are created from the provided config. This can result in database bloat
+	// over long periods of time and add unnecessary load to LogPoller. This test attempts to quantify and limit bloat
+	// caused by restarts.
+
+	ctx := t.Context()
+	lggr := logger.Nop()
+	mAccts := new(mockedMultipleAccountGetter)
+	mEvts := mocks.NewEventsReader(t)
+	pubKey1 := solana.NewWallet().PublicKey()
+	pubKey2 := solana.NewWallet().PublicKey()
+	bindCallCount := 5
+	restartCount := 10
+
+	boolType := codec.IdlType{}
+	require.NoError(t, boolType.UnmarshalJSON([]byte("\"bool\"")))
+
+	cfg := config.ContractReader{
+		Namespaces: map[string]config.ChainContractReader{
+			"myChainReader": {
+				IDL: codec.IDL{
+					Accounts: []codec.IdlTypeDef{{Name: "myAccount",
+						Type: codec.IdlTypeDefTy{
+							Kind:   codec.IdlTypeDefTyKindStruct,
+							Fields: &[]codec.IdlField{}}}},
+					Events: []codec.IdlEvent{
+						{Name: "myEvent", Fields: []codec.IdlEventField{{Name: "a", Type: boolType}}},
+					},
+				},
+				Reads: map[string]config.ReadDefinition{
+					"myRead": {
+						ChainSpecificName: "myEvent",
+						ReadType:          config.Event,
+						EventDefinitions: &config.EventDefinitions{
+							IndexedField0: &config.IndexedField{
+								OffChainPath: "A.B",
+								OnChainPath:  "A.B",
+							},
+							PollingFilter: &config.PollingFilter{},
+						}}}}},
+		AddressShareGroups: nil,
+	}
+
+	mEvts.EXPECT().Start(mock.Anything).Return(nil).Maybe()
+	mEvts.EXPECT().Ready().Return(nil).Maybe()
+	mEvts.EXPECT().HasFilter(mock.Anything, mock.Anything).Return(false).Maybe()
+
+	filters := []string{}
+
+	mEvts.EXPECT().RegisterFilter(mock.Anything, mock.Anything).Run(func(_ context.Context, filter logpoller.Filter) {
+		filters = append(filters, filter.Name)
+	}).Return(nil).Maybe()
+
+	for range restartCount {
+		svc, err := chainreader.NewContractReaderService(
+			lggr,
+			mAccts,
+			cfg, mEvts,
+		)
+
+		require.NoError(t, err)
+		require.NoError(t, svc.Start(ctx))
+
+		// calling bind multiple times here simulates multiple uses of the contract reader service where bind might be
+		// called before GetLatestValue or QueryKey
+		for range bindCallCount {
+			require.NoError(t, svc.Bind(ctx, []types.BoundContract{{Address: pubKey1.String(), Name: "myChainReader"}}))
+			require.NoError(t, svc.Bind(ctx, []types.BoundContract{{Address: pubKey2.String(), Name: "myChainReader"}}))
+		}
+
+		require.NoError(t, svc.Close())
+	}
+
+	// TODO: implement cleanup routine to reduce database bloat
+	assert.Len(t, filters, restartCount*2, "registered filter count should match the total restarts multiplied by bound contracts")
+}
+
 func newTestIDLAndCodec(t *testing.T) (string, codec.IDL, types.RemoteCodec) {
 	t.Helper()
 

--- a/pkg/solana/chainreader/event_read_binding.go
+++ b/pkg/solana/chainreader/event_read_binding.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/gagliardetto/solana-go"
-	"github.com/google/uuid"
 
 	commoncodec "github.com/smartcontractkit/chainlink-common/pkg/codec"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -115,7 +114,7 @@ func (b *eventReadBinding) Register(ctx context.Context) error {
 		return nil
 	}
 
-	newName := fmt.Sprintf("%s.%s.%s", b.namespace, b.genericName, uuid.NewString())
+	newName := fmt.Sprintf("%s.%s", b.namespace, b.genericName)
 	b.filter.SetName(newName)
 
 	return b.filter.Register(ctx, b.reader)
@@ -137,7 +136,7 @@ func (b *eventReadBinding) update(ctx context.Context) error {
 		return nil
 	}
 
-	newName := fmt.Sprintf("%s.%s.%s", b.namespace, b.genericName, uuid.NewString())
+	newName := fmt.Sprintf("%s.%s", b.namespace, b.genericName)
 
 	return b.filter.Update(ctx, b.reader, newName)
 }
@@ -190,12 +189,17 @@ func (b *eventReadBinding) SetModifier(modifier commoncodec.Modifier) {
 	b.modifier = modifier
 }
 
-func (b *eventReadBinding) SetFilter(filter logpoller.Filter) {
+func (b *eventReadBinding) SetFilter(filter logpoller.Filter) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	b.filter.SetFilter(filter)
+	if err := b.filter.SetFilter(filter); err != nil {
+		return err
+	}
+
 	b.eventSig = filter.EventSig
+
+	return nil
 }
 
 func (b *eventReadBinding) CreateType(forEncoding bool) (any, error) {

--- a/pkg/solana/chainreader/filter.go
+++ b/pkg/solana/chainreader/filter.go
@@ -2,8 +2,13 @@ package chainreader
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -16,6 +21,7 @@ type syncedFilter struct {
 	mu         sync.RWMutex
 	addressSet bool
 	filter     logpoller.Filter
+	hash       string
 
 	dirty bool
 }
@@ -33,7 +39,7 @@ func (r *syncedFilter) Update(ctx context.Context, registrar filterRegistrar, up
 	}
 
 	oldName := r.filter.Name
-	r.filter.Name = updatedName
+	r.setName(updatedName)
 
 	if err := r.register(ctx, registrar); err != nil {
 		return err
@@ -98,11 +104,20 @@ func (r *syncedFilter) unregister(ctx context.Context, registrar filterRegistrar
 	return nil
 }
 
-func (r *syncedFilter) SetFilter(filter logpoller.Filter) {
+func (r *syncedFilter) SetFilter(filter logpoller.Filter) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	r.filter = filter
+
+	hash, err := filterHash(r.filter)
+	if err != nil {
+		return err
+	}
+
+	r.hash = hash
+
+	return nil
 }
 
 func (r *syncedFilter) SetName(name string) {
@@ -113,7 +128,7 @@ func (r *syncedFilter) SetName(name string) {
 }
 
 func (r *syncedFilter) setName(name string) {
-	r.filter.Name = name
+	r.filter.Name = fmt.Sprintf("%s.%s", name, r.hash)
 }
 
 func (r *syncedFilter) SetAddress(address solana.PublicKey) {
@@ -161,4 +176,48 @@ func (e FilterError) Error() string {
 
 func (e FilterError) Unwrap() error {
 	return e.Err
+}
+
+func filterHash(filter logpoller.Filter) (string, error) {
+	hasher := sha256.New()
+
+	if err := errors.Join(
+		onlyError(hasher.Write, putUint64(filter.ID)),
+		onlyError(hasher.Write, filter.Address.ToSolana().Bytes()),
+		onlyError(hasher.Write, []byte(filter.EventName)),
+		onlyError(hasher.Write, []byte(filter.EventSig.String())),
+		onlyError(hasher.Write, putUint64(filter.StartingBlock)), // not sure if we should include this
+		onlyError(hasher.Write, []byte(filter.SubkeyPaths.String())),
+		onlyError(hasher.Write, putUint64(filter.Retention)),
+		onlyError(hasher.Write, putUint64(filter.MaxLogsKept)),
+		onlyError(hasher.Write, putUint64(binBool(filter.IsDeleted))),
+		onlyError(hasher.Write, putUint64(binBool(filter.IsBackfilled))),
+		onlyError(hasher.Write, putUint64(binBool(filter.IncludeReverted))),
+	); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum([]byte{})), nil
+}
+
+func putUint64[T uint8 | int64 | int32 | time.Duration](val T) []byte {
+	buf := make([]byte, 8)
+
+	binary.BigEndian.PutUint64(buf, uint64(val))
+
+	return buf
+}
+
+func binBool(val bool) uint8 {
+	if val {
+		return 1
+	}
+
+	return 0
+}
+
+func onlyError(fnc func([]byte) (int, error), val []byte) error {
+	_, err := fnc(val)
+
+	return err
 }

--- a/pkg/solana/logpoller/types.go
+++ b/pkg/solana/logpoller/types.go
@@ -108,6 +108,16 @@ func (p SubKeyPaths) Equal(o SubKeyPaths) bool {
 	return slices.EqualFunc(p, o, slices.Equal)
 }
 
+func (p SubKeyPaths) String() string {
+	var groups []string
+
+	for _, subgroup := range p {
+		groups = append(groups, strings.Join(subgroup, ":"))
+	}
+
+	return strings.Join(groups, ";")
+}
+
 const EventSignatureLength = 8
 
 type EventSignature [EventSignatureLength]byte


### PR DESCRIPTION
### Description
When a node restarts and `Bind` is called on a `ContractReader` instance, depending on the config a new log poller filter is registered. This registered filter may be a direct copy of an existing filter, but the name is different. There is no process that removes unused filters and over time/restarts filters accumulate in the database, often pulling the same data from blocks and adding load to log poller.

This PR adds a test to simulate the filter accumulation over multiple restarts and quantify the problem.

[NONEVM-1627](https://smartcontract-it.atlassian.net/browse/NONEVM-1627)
<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->


[NONEVM-1627]: https://smartcontract-it.atlassian.net/browse/NONEVM-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ