### PR TITLE
use pnpm in build artifacts action

### DIFF
--- a/.github/actions/build-wrapped-anchor-image/action.yml
+++ b/.github/actions/build-wrapped-anchor-image/action.yml
@@ -11,7 +11,7 @@ runs:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
 
     - name: Get ProjectSerum Version
-      uses: ./github/actions/projectserum_version
+      uses: ./.github/actions/projectserum_version
       id: get-version
 
     - name: cache docker build image

--- a/.github/actions/build-wrapped-anchor-image/action.yml
+++ b/.github/actions/build-wrapped-anchor-image/action.yml
@@ -16,10 +16,10 @@ runs:
 
     - name: cache docker build image
       id: cache-image
-        uses: actions/cache@v4
-        with:
-          path: contracts/docker-build.tar
-          key: ${{ inputs.runner-os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
+      uses: actions/cache@v4
+      with:
+        path: contracts/docker-build.tar
+        key: ${{ inputs.runner-os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
 
     - name: build & save image
       if: steps.cache-image.outputs.cache-hit != 'true'

--- a/.github/actions/build-wrapped-anchor-image/action.yml
+++ b/.github/actions/build-wrapped-anchor-image/action.yml
@@ -1,0 +1,30 @@
+name: Build Wrapped Anchor Image
+description: Builds anchor image with pnpm and w/out yarn
+inputs:
+  runner-os:
+    description: the operating system 
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+
+    - name: Get ProjectSerum Version
+      uses: ./github/actions/projectserum_version
+      id: get-version
+
+    - name: cache docker build image
+      id: cache-image
+        uses: actions/cache@v4
+        with:
+          path: contracts/docker-build.tar
+          key: ${{ runner.os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
+
+    - name: build & save image
+      if: steps.cache-image.outputs.cache-hit != 'true'
+      run: |
+        cd contracts
+        docker buildx build . -t chainlink-solana:build --build-arg ANCHOR_CLI=${{ steps.get-version.outputs.projectserum_version }}
+        docker save chainlink-solana > docker-build.tar
+        cd ../

--- a/.github/actions/build-wrapped-anchor-image/action.yml
+++ b/.github/actions/build-wrapped-anchor-image/action.yml
@@ -19,7 +19,7 @@ runs:
         uses: actions/cache@v4
         with:
           path: contracts/docker-build.tar
-          key: ${{ runner.os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
+          key: ${{ inputs.runner-os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
 
     - name: build & save image
       if: steps.cache-image.outputs.cache-hit != 'true'

--- a/.github/actions/build-wrapped-anchor-image/action.yml
+++ b/.github/actions/build-wrapped-anchor-image/action.yml
@@ -23,6 +23,7 @@ runs:
 
     - name: build & save image
       if: steps.cache-image.outputs.cache-hit != 'true'
+      shell: bash
       run: |
         cd contracts
         docker buildx build . -t chainlink-solana:build --build-arg ANCHOR_CLI=${{ steps.get-version.outputs.projectserum_version }}

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -37,7 +37,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: contracts/docker-build.tar
-        key: ${{ runner.os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
+        key: ${{ inputs.runner-os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
     
     - name: load cached image
       run: |

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -10,6 +10,9 @@ inputs:
   image-version:
     required: false
     description: docker image version/tag to use for build
+  runner-os:
+    description: the operating system 
+    required: true
 
 runs:
   using: composite
@@ -19,32 +22,74 @@ runs:
       with:
         repository: smartcontractkit/chainlink-solana
         ref: ${{ inputs.ref }}
+    
+    - name: Get ProjectSerum Version
+      uses: ./github/actions/projectserum_version
+      id: get-version
+      
+    - name: Build Wrapped Anchor Image
+      uses: ./github/actions/build-wrapped-anchor-image
+      with:
+        runner-os: ${{ inputs.runner-os }}
 
-    # temporary docker run to build artifacts
-    - name: Docker Builder
-      if: ${{ inputs.image != '' && inputs.image-version != '' }}
-      env:
-        image: ${{ inputs.image }}
-        image_version: ${{ inputs.image-version }}
+    - name: cache docker build image
+      id: cache-image
+      uses: actions/cache@v4
+      with:
+        path: contracts/docker-build.tar
+        key: ${{ runner.os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
+    
+    - name: load cached image
+      run: |
+        docker load --input contracts/docker-build.tar
+    
+    - name: Build Artifacts
       shell: bash
       run: |
         # start container
-        docker run -d -v $(pwd):/repo --name build-container "${image}":"${image_version}" tail -f /dev/null
+        docker run -d -v $(pwd):/repo --name build-container chainlink-solana:build tail -f /dev/null
         # generate go bindings
         docker exec build-container bash -c "/repo/scripts/build-contract-artifacts-action.sh"
         # check go bindings
         git diff --stat --exit-code
         # build with keys
         docker exec build-container bash -c "\
-          export RUSTUP_HOME=\"/root/.rustup\" &&\
-          cd /repo &&\
-          ./scripts/programs-keys-gen.sh &&\
-          cd ./contracts &&\
-          anchor build &&\
-          chown -R $(id -u):$(id -g) /repo"
+        export RUSTUP_HOME=\"/root/.rustup\" &&\
+        cd /repo &&\
+        ./scripts/programs-keys-gen.sh &&\
+        cd ./contracts &&\
+        anchor build &&\
+        chown -R $(id -u):$(id -g) /repo"
         # clean up the container
         docker stop build-container
         docker rm build-container
+
+
+    # # temporary docker run to build artifacts
+    # - name: Docker Builder
+    #   if: ${{ inputs.image != '' && inputs.image-version != '' }}
+    #   env:
+    #     image: ${{ inputs.image }}
+    #     image_version: ${{ inputs.image-version }}
+    #   shell: bash
+    #   run: |
+    #     # start container
+    #     docker run -d -v $(pwd):/repo --name build-container "${image}":"${image_version}" tail -f /dev/null
+    #     # generate go bindings
+    #     docker exec build-container bash -c "/repo/scripts/build-contract-artifacts-action.sh"
+    #     # check go bindings
+    #     git diff --stat --exit-code
+    #     # build with keys
+    #     docker exec build-container bash -c "\
+    #       export RUSTUP_HOME=\"/root/.rustup\" &&\
+    #       cd /repo &&\
+    #       ./scripts/programs-keys-gen.sh &&\
+    #       cd ./contracts &&\
+    #       anchor build &&\
+    #       chown -R $(id -u):$(id -g) /repo"
+    #     # clean up the container
+    #     docker stop build-container
+    #     docker rm build-container
 
     #save the contracts artifacts
     - name: Upload Artifacts

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -24,11 +24,11 @@ runs:
         ref: ${{ inputs.ref }}
     
     - name: Get ProjectSerum Version
-      uses: ./github/actions/projectserum_version
+      uses: ./.github/actions/projectserum_version
       id: get-version
       
     - name: Build Wrapped Anchor Image
-      uses: ./github/actions/build-wrapped-anchor-image
+      uses: ./.github/actions/build-wrapped-anchor-image
       with:
         runner-os: ${{ inputs.runner-os }}
 

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -65,33 +65,6 @@ runs:
         docker stop build-container
         docker rm build-container
 
-
-    # # temporary docker run to build artifacts
-    # - name: Docker Builder
-    #   if: ${{ inputs.image != '' && inputs.image-version != '' }}
-    #   env:
-    #     image: ${{ inputs.image }}
-    #     image_version: ${{ inputs.image-version }}
-    #   shell: bash
-    #   run: |
-    #     # start container
-    #     docker run -d -v $(pwd):/repo --name build-container "${image}":"${image_version}" tail -f /dev/null
-    #     # generate go bindings
-    #     docker exec build-container bash -c "/repo/scripts/build-contract-artifacts-action.sh"
-    #     # check go bindings
-    #     git diff --stat --exit-code
-    #     # build with keys
-    #     docker exec build-container bash -c "\
-    #       export RUSTUP_HOME=\"/root/.rustup\" &&\
-    #       cd /repo &&\
-    #       ./scripts/programs-keys-gen.sh &&\
-    #       cd ./contracts &&\
-    #       anchor build &&\
-    #       chown -R $(id -u):$(id -g) /repo"
-    #     # clean up the container
-    #     docker stop build-container
-    #     docker rm build-container
-
     #save the contracts artifacts
     - name: Upload Artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -40,6 +40,7 @@ runs:
         key: ${{ inputs.runner-os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
     
     - name: load cached image
+      shell: bash
       run: |
         docker load --input contracts/docker-build.tar
     

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
         with:
+          runner-os: ${{ runner.os }}
           image: backpackapp/build
           image-version: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
 

--- a/.github/workflows/e2e_testnet_daily.yml
+++ b/.github/workflows/e2e_testnet_daily.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
         with:
+          runner-os: ${{ runner.os }}
           image: backpackapp/build
           image-version: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
 

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
         with:
+          runner-os: ${{ runner.os }}
           image: backpackapp/build
           image-version: ${{ needs.get-projectserum-version.outputs.projectserum_version }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,30 +23,13 @@ jobs:
         uses: ./.github/actions/projectserum_version
 
   build_wrapped_anchor_image:  
-    - name: build contract test image
-      runs-on: ubuntu-latest
-      steps:
-        - name: build image
-          uses: ./.github/actions/build-wrapped-anchor-image
-          with:
-            runner-os: ${{ inputs.runner-os }}
-
     name: build contract test image
     runs-on: ubuntu-latest
-    needs: [get_projectserum_version]
     steps:
-    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-    - name: cache docker build image
-      id: cache-image
-      uses: actions/cache@v4
-      with:
-        path: contracts/docker-build.tar
-        key: ${{ runner.os }}-docker-pnpm-build-${{ needs.get_projectserum_version.outputs.projectserum_version }}-${{ hashFiles('**/Cargo.lock') }}
-    - name: build & save image
-      if: steps.cache-image.outputs.cache-hit != 'true'
-      run: |
-        docker buildx build . -t chainlink-solana:build --build-arg ANCHOR_CLI=${{ needs.get_projectserum_version.outputs.projectserum_version }}
-        docker save chainlink-solana > docker-build.tar
+      - name: build image
+        uses: ./.github/actions/build-wrapped-anchor-image
+        with:
+          runner-os: ${{ inputs.runner-os }}
 
   rust_run_anchor_tests:
     name: Rust Run Anchor Tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,15 @@ jobs:
         id: psversion
         uses: ./.github/actions/projectserum_version
 
-  build_wrapped_anchor_image:
+  build_wrapped_anchor_image:  
+    - name: build contract test image
+      runs-on: ubuntu-latest
+      steps:
+        - name: build image
+          uses: ./.github/actions/build-wrapped-anchor-image
+          with:
+            runner-os: ${{ inputs.runner-os }}
+
     name: build contract test image
     runs-on: ubuntu-latest
     needs: [get_projectserum_version]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
     name: build contract test image
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the repo
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: build image
         uses: ./.github/actions/build-wrapped-anchor-image
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
       - name: build image
         uses: ./.github/actions/build-wrapped-anchor-image
         with:
-          runner-os: ${{ inputs.runner-os }}
+          runner-os: ${{ runner.os }}
 
   rust_run_anchor_tests:
     name: Rust Run Anchor Tests

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
         with:
+          runner-os: ${{ runner.os }}
           image: backpackapp/build
           image-version: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
 

--- a/scripts/build-contract-artifacts-action.sh
+++ b/scripts/build-contract-artifacts-action.sh
@@ -33,7 +33,7 @@ go install github.com/gagliardetto/anchor-go@v0.2.3
 
 # initial build
 cd "${CONTRACTS}"
-yarn install --frozen-lockfile
+pnpm install --frozen-lockfile
 anchor build
 
 # generate contract artifacts


### PR DESCRIPTION
### Description

core ref: b715d575b344fc3cda6de006c68104d658b5cdd2

^ needs to be used because chainlink core hasn't been updated yet for another PR

scripts/build-contract-artifacts-action.sh used yarn instead of pnpm. yarn does not have a lock file, and it hoists dependencies in a way such that the solana/web3.js version was more recent and that pulled in solana/codecs-numbers which then enforced a higher node.js engine version (see https://github.com/smartcontractkit/chainlink-solana/pull/1209) . 

this change uses pnpm instead of yarn, since it shouldn't be used in the first place. 

we refactor the job to use the wrapped backpack image which has pnpm installed instead of yarn.

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
