### PR TITLE
Add accounts length check to Solana CCIP commit args transform

### DIFF
--- a/pkg/solana/chainwriter/transform_registry.go
+++ b/pkg/solana/chainwriter/transform_registry.go
@@ -119,7 +119,7 @@ func CCIPCommitAccountTransform(ctx context.Context, client client.MultiClient, 
 
 	transformedAccounts := accounts
 	// Remove the global state config from the end of the account list if neither token nor gas price updates are included
-	if len(tokenPriceVals) == 0 && len(gasPriceVals) == 0 {
+	if len(accounts) > 0 && len(tokenPriceVals) == 0 && len(gasPriceVals) == 0 {
 		transformedAccounts = accounts[:len(accounts)-1]
 	}
 

--- a/pkg/solana/chainwriter/transform_registry_test.go
+++ b/pkg/solana/chainwriter/transform_registry_test.go
@@ -472,6 +472,17 @@ func Test_CCIPCommitAccountTransform(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, newAccounts, 1)
 	})
+
+	t.Run("CCIPCommit ArgsTransform no-ops if accounts list is empty", func(t *testing.T) {
+		args := struct {
+			Info ccipocr3.CommitReportInfo
+		}{
+			Info: ccipocr3.CommitReportInfo{},
+		}
+		_, newAccounts, _, err := chainwriter.CCIPCommitAccountTransform(ctx, mc, args, nil, nil, "", 0)
+		require.NoError(t, err)
+		require.Len(t, newAccounts, 0)
+	})
 }
 
 func verifyTxOpts(t *testing.T, options []txmutils.SetTxConfig, exec bool, overhead, userCU, destGasAmount uint32) {


### PR DESCRIPTION
Accounts for the commit method can never be empty but added a sanity length check for out-of-bound exceptions