### PR TITLE
Setup postgres db before running unit tests & interface tests

### DIFF
--- a/.github/actions/get-core-ref/action.yml
+++ b/.github/actions/get-core-ref/action.yml
@@ -1,0 +1,25 @@
+name: Get Core Refs from PR
+description: Extracts "core ref:" tag in PR to use as a custom ref, returns as output
+
+outputs:
+  core-ref:
+    description: chainlink git ref from PR body
+    value: ${{ steps.extract.outputs.core_ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Extract core ref
+      if: ${{ github.event_name == 'pull_request' }}
+      id: extract
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        comment="$(gh pr view https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --json body -q '.body')"
+        # shellcheck disable=SC2086
+        core_ref="$(echo $comment | grep -oP 'core ref: \K\S+' || true)"
+        if [ -z "$core_ref" ]; then
+          core_ref="develop"
+        fi
+        echo "core_ref=${core_ref}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/setup-testdb/action.yml
+++ b/.github/actions/setup-testdb/action.yml
@@ -1,0 +1,40 @@
+name: Setup Test DB
+description: Setup Chainlink Test DB with schema defined in chainlink repo
+inputs:
+  core-ref:
+    description: The chainlink ref which contains the schema we want to test against
+    default: 'develop'
+outputs:
+  cl-db-url:
+    description: The value to set CL_DATABASE_URL to while running tests
+    value: ${{ steps.setup-postgres.outputs.database-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Postgres
+      id: setup-postgres
+      uses: smartcontractkit/.github/actions/setup-postgres@13b05e8b4e11a8c4402f8034daaf9a4332032dc7 # v1.0.0
+      with:
+        tmpfs: 'true'
+    # This is considered untrusted code from the POV of chainlink-solana, but this is safe as long as we:
+    # - Only call this from workflows with read-only git permissions set
+    # and
+    # - Unset all secrets passed to this action by workflows calling it, before running "go run ./core/store/cmd/preparetest"
+    # codeql[actions/untrusted-checkout]: disable
+    - name: Checkout chainlink
+      uses: actions/checkout@v4
+      with:
+        repository: smartcontractkit/chainlink
+        ref: ${{ inputs.core-ref || 'develop' }}
+        path: chainlink
+    - name: Prepare Test Schema
+      run: |
+        unset GRAFANA_INTERNAL_TENANT_ID
+        unset GRAFANA_INTERNAL_BASIC_AUTH
+        unset GRAFANA_INTERNAL_HOST
+        cd chainlink
+        go run ./core/store/cmd/preparetest
+      shell: bash
+      env:
+        CL_DATABASE_URL: ${{ steps.setup-postgres.outputs.database-url }}

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -200,15 +200,11 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Get core ref from PR body
-        if: github.event_name == 'pull_request'
-        run: |
-          comment="$(gh pr view https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --json body -q '.body')"
-          # shellcheck disable=SC2086
-          core_ref="$(echo $comment | grep -oP 'core ref: \K\S+' || true)"
-          if [ -n "$core_ref" ]; then
-            echo "CUSTOM_CORE_REF=${core_ref}" >> "${GITHUB_ENV}"
-          fi
+      - name: Checkout the repo
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - name: Get core ref
+        id: get-core-ref
+        uses: ./.github/actions/get-core-ref
       - name: Check if image exists
         id: check-image
         uses: smartcontractkit/chainlink-github-actions/docker/image-exists@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
@@ -223,7 +219,7 @@ jobs:
         with:
           should_checkout: true
           cl_repo: smartcontractkit/chainlink
-          cl_ref: ${{ env.CUSTOM_CORE_REF || github.event.inputs.cl_branch_ref }}
+          cl_ref: ${{ steps.get-core-ref.outputs.core-ref || github.event.inputs.cl_branch_ref }}
           dep_solana_sha: ${{ github.event.pull_request.head.sha }}
           push_tag: ${{ env.CL_ECR }}:solana.${{ github.sha }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -283,15 +283,6 @@ jobs:
           this-job-name: E2E Custom Run Smoke Tests
           test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
         continue-on-error: true
-      - name: Get core ref from PR body
-        if: github.event_name == 'pull_request'
-        run: |
-          comment="$(gh pr view https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --json body -q '.body')"
-          # shellcheck disable=SC2086
-          core_ref="$(echo $comment | grep -oP 'core ref: \K\S+' || true)"
-          if [ -n "$core_ref" ]; then
-            echo "CUSTOM_CORE_REF=${core_ref}" >> "${GITHUB_ENV}"
-          fi
       - name: Checkout the repo
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Install Solana CLI # required for ensuring the local test validator is configured correctly
@@ -366,15 +357,6 @@ jobs:
           this-job-name: E2E Program Upgrade Tests
           test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
         continue-on-error: true
-      - name: Get core ref from PR body
-        if: github.event_name == 'pull_request'
-        run: |
-          comment="$(gh pr view https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --json body -q '.body')"
-          # shellcheck disable=SC2086
-          core_ref="$(echo $comment | grep -oP 'core ref: \K\S+' || true)"
-          if [ -n "$core_ref" ]; then
-            echo "CUSTOM_CORE_REF=${core_ref}" >> "${GITHUB_ENV}"
-          fi
       - name: Checkout the repo
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Install Solana CLI # required for ensuring the local test validator is configured correctly

--- a/.github/workflows/e2e_testnet_daily.yml
+++ b/.github/workflows/e2e_testnet_daily.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           should_checkout: true
           cl_repo: smartcontractkit/chainlink
-          cl_ref: ${{ env.CUSTOM_CORE_REF || github.event.inputs.cl_branch_ref }}
+          cl_ref: ${{ github.event.inputs.cl_branch_ref }}
           dep_solana_sha: ${{ github.event.pull_request.head.sha }}
           push_tag: ${{ env.CL_ECR }}:solana.${{ github.sha }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   relay_run_unit_tests:
     name: Relay Run Unit Tests
+    permissions:
+      contents: read
+      actions: read
+    env:
+      DB_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
     runs-on: ubuntu-latest-8cores-32GB
     steps:
       - name: Collect Metrics
@@ -48,11 +53,23 @@ jobs:
         run: go test -run=xxx ./... # check compilation across tests + relayer / monitoring go code without running
       - name: Build
         run: go build -v ./pkg/...
+      - name: Get core ref
+        id: get-ref
+        uses: ./.github/actions/get-core-ref
+      - name: Setup Test DB
+        id: setup-testdb
+        uses: ./.github/actions/setup-testdb
+        with:
+          core-ref: ${{ steps.get-ref.outputs.core-ref }}
       - name: Test
+        env:
+          CL_DATABASE_URL: ${{ steps.setup-testdb.outputs.cl-db-url }}
         run: |
           set -o pipefail
           go test ./pkg/... -json -tags integration -covermode=atomic -coverpkg=./... -coverprofile=integration_coverage.txt 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci
       - name: Test with the race detector enabled
+        env:
+          CL_DATABASE_URL: ${{ steps.setup-testdb.outputs.cl-db-url }}
         run: go test ./pkg/... -v -race -count=10 -timeout=15m -covermode=atomic -coverpkg=./... -coverprofile=race_coverage.txt
       - name: Upload Go test results
         if: always()

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,6 +119,9 @@ jobs:
 
   relay_run_interface_tests:
     name: Relay Run Interface Tests
+    permissions:
+      contents: read
+      actions: read
     runs-on: ubuntu-latest-8cores-32GB
     needs: [get_projectserum_version, build_wrapped_anchor_image]
     steps:
@@ -156,7 +159,23 @@ jobs:
       - name: Install Solana CLI
         run: ../scripts/install-solana-ci.sh
 
+      - name: Setup Postgres
+        uses: smartcontractkit/.github/actions/setup-postgres@13b05e8b4e11a8c4402f8034daaf9a4332032dc7 # v1.0.0
+        with:
+          tmpfs: 'true'
+
+      - name: Get core ref
+        id: get-core-ref
+        uses: ./.github/actions/get-core-ref
+
+      - name: Setup Test DB
+        uses: ./.github/actions/setup-testdb
+        id: setup-testdb
+        with:
+          core-ref: ${{ steps.get-core-ref.outputs.core-ref }}
       - name: Test Relay Interfaces
+        env:
+          CL_DATABASE_URL: ${{ steps.setup-testdb.outputs.cl-db-url }}
         run: |
           set -eoux pipefail
           # compile artifacts

--- a/pkg/solana/logpoller/observability_test.go
+++ b/pkg/solana/logpoller/observability_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	ioprometheusclient "github.com/prometheus/client_model/go"
-	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,6 +15,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/sqltest"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
+
 	"github.com/smartcontractkit/chainlink-framework/metrics"
 )
 
@@ -26,6 +27,7 @@ func TestShouldPublishDurationInCaseOfError(t *testing.T) {
 	ctx := t.Context()
 	orm := createObservedORM(t, "testChainID")
 	t.Cleanup(func() { resetMetrics(*orm) })
+
 	require.Equal(t, 0, testutil.CollectAndCount(orm.queryDuration))
 
 	// Cancel ctx to force error
@@ -59,6 +61,7 @@ func TestMetricsAreProperlyPopulatedWithLabels(t *testing.T) {
 
 func TestNotPublishingDatasetSizeInCaseOfError(t *testing.T) {
 	orm := createObservedORM(t, chainID)
+	t.Cleanup(func() { resetMetrics(*orm) })
 
 	_, err := withObservedQueryAndResults(orm, "errorQuery", func() ([]string, error) { return nil, fmt.Errorf("error") })
 	require.Error(t, err)
@@ -69,6 +72,8 @@ func TestNotPublishingDatasetSizeInCaseOfError(t *testing.T) {
 
 func TestMetricsAreProperlyPopulatedForWrites(t *testing.T) {
 	orm := createObservedORM(t, chainID)
+	t.Cleanup(func() { resetMetrics(*orm) })
+
 	require.NoError(t, withObservedExec(orm, "execQuery", metrics.Create, func() error { return nil }))
 	require.Error(t, withObservedExec(orm, "execQuery", metrics.Create, func() error { return fmt.Errorf("error") }))
 	require.Equal(t, 2, counterFromHistogramByLabels(t, orm.queryDuration, chainFamily, chainID, "execQuery", "create"))
@@ -79,6 +84,8 @@ func TestCountersAreProperlyPopulatedForWrites(t *testing.T) {
 
 	ctx := t.Context()
 	orm := createObservedORM(t, chainID)
+	t.Cleanup(func() { resetMetrics(*orm) })
+
 	filterID, err := orm.InsertFilter(t.Context(), newRandomFilter(t))
 	require.NoError(t, err)
 
@@ -86,15 +93,16 @@ func TestCountersAreProperlyPopulatedForWrites(t *testing.T) {
 
 	// First insert 10 logs
 	require.NoError(t, orm.InsertLogs(ctx, logs[:10]))
-	assert.Equal(t, float64(10), testutil.ToFloat64(orm.logsInserted.WithLabelValues("solana", chainID)))
+	assert.Equal(t, float64(10), testutil.ToFloat64(metrics.PromLpLogsInserted.WithLabelValues(chainFamily, chainID)))
+	assert.Equal(t, float64(10), testutil.ToFloat64(orm.logsInserted.WithLabelValues(chainFamily, chainID)))
 
 	// Insert 5 more logs
 	require.NoError(t, orm.InsertLogs(ctx, logs[10:15]))
-	assert.Equal(t, float64(15), testutil.ToFloat64(orm.logsInserted.WithLabelValues("solana", chainID)))
+	assert.Equal(t, float64(15), testutil.ToFloat64(orm.logsInserted.WithLabelValues(chainFamily, chainID)))
 
 	// Insert 5 more logs
 	require.NoError(t, orm.InsertLogs(ctx, logs[15:]))
-	assert.Equal(t, float64(20), testutil.ToFloat64(orm.logsInserted.WithLabelValues("solana", chainID)))
+	assert.Equal(t, float64(20), testutil.ToFloat64(orm.logsInserted.WithLabelValues(chainFamily, chainID)))
 }
 
 func generateRandomLogs(t *testing.T, filterID int64, count int) []types.Log {

--- a/pkg/solana/logpoller/orm_test.go
+++ b/pkg/solana/logpoller/orm_test.go
@@ -465,14 +465,13 @@ func TestPruneLogsForFilter(t *testing.T) {
 }
 
 func sanitize(expected, actual *types.Log) {
-	// TODO: override ScanLocation with custom TimestamptzCodec?
-	// See: https://github.com/jackc/pgx/issues/2117
-	actual.CreatedAt = actual.CreatedAt.UTC().Round(0)
-	actual.BlockTimestamp = actual.BlockTimestamp.UTC().Round(0)
+	actual.CreatedAt = actual.CreatedAt.UTC().Truncate(time.Millisecond)
+	actual.BlockTimestamp = actual.BlockTimestamp.UTC().Truncate(time.Millisecond)
 
 	// fill in fields populated by db write itself
 	expected.ID = actual.ID
 	expected.CreatedAt = actual.CreatedAt
+	expected.BlockTimestamp = expected.BlockTimestamp.UTC().Truncate(time.Millisecond)
 
 	// These are not returned by FilteredLogs
 	actual.SequenceNum = expected.SequenceNum


### PR DESCRIPTION
### Description

Set up postgres db, along with sql migrations from core repo before running relay unit tests & interface tests.
This will enable all tests which were previously being skipped due to `sqltest.SkipInMemory()`

Also:
 - refactored parsing of "core ref" from PR Body into an action that's used in 3 places.
 - fixed 2 tests which were failing: one due to a subtlety with timestamp conversion which causes it to fail when run in CI (was passing locally, I believe due to lack of a realtime clock in local env). The other was just broken, and nobody noticed since it was previously being skipped in CI.
 
JIRA:  [NONEVM-872](https://smartcontract-it.atlassian.net/browse/NONEVM-872)

[NONEVM-872]: https://smartcontract-it.atlassian.net/browse/NONEVM-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ