### PR TITLE
Add bitmap validations

### DIFF
--- a/integration-tests/relayinterface/lookups_test.go
+++ b/integration-tests/relayinterface/lookups_test.go
@@ -318,10 +318,13 @@ func TestAccountLookups(t *testing.T) {
 			IsWritable: chainwriter.MetaBool{BitmapLocation: "Bitmap"},
 		}}
 
-		args := struct{Accounts []*solana.AccountMeta; Bitmap []byte}{
-				Accounts: accounts[:],
-				Bitmap: make([]byte, 3), // invalid bitmap length
-			}
+		args := struct {
+			Accounts []*solana.AccountMeta
+			Bitmap   []byte
+		}{
+			Accounts: accounts[:],
+			Bitmap:   make([]byte, 3), // invalid bitmap length
+		}
 
 		_, err := lookupConfig.AccountLookup.Resolve(args)
 		require.Error(t, err)

--- a/integration-tests/relayinterface/lookups_test.go
+++ b/integration-tests/relayinterface/lookups_test.go
@@ -274,6 +274,58 @@ func TestAccountLookups(t *testing.T) {
 		_, err := lookupConfig.AccountLookup.Resolve(args)
 		require.Contains(t, err.Error(), "invalid value format at path")
 	})
+
+	t.Run("AccountLookup fails if lookup returns more than 64 values and uses bitmap", func(t *testing.T) {
+		accounts := [65]*solana.AccountMeta{}
+
+		for i := 0; i < 65; i++ {
+			accounts[i] = &solana.AccountMeta{
+				PublicKey:  solanautils.GetRandomPubKey(t),
+				IsWritable: true,
+			}
+		}
+
+		lookupConfig := chainwriter.Lookup{AccountLookup: &chainwriter.AccountLookup{
+			Name:       "TestAccount",
+			Location:   "Inner.Accounts.PublicKey",
+			IsSigner:   chainwriter.MetaBool{Value: true},
+			IsWritable: chainwriter.MetaBool{Value: true},
+		}}
+		args := TestAccountArgs{
+			Inner: InnerAccountArgs{
+				Accounts: accounts[:],
+			},
+		}
+		_, err := lookupConfig.AccountLookup.Resolve(args)
+		require.Error(t, err)
+	})
+
+	t.Run("AccountLookup fails if provided bitmap is not 8 bytes", func(t *testing.T) {
+		accounts := [3]*solana.AccountMeta{}
+
+		for i := 0; i < 3; i++ {
+			accounts[i] = &solana.AccountMeta{
+				PublicKey:  solanautils.GetRandomPubKey(t),
+				IsSigner:   (i)%2 == 0,
+				IsWritable: (i)%2 == 0,
+			}
+		}
+
+		lookupConfig := chainwriter.Lookup{AccountLookup: &chainwriter.AccountLookup{
+			Name:       "TestAccount",
+			Location:   "Accounts.PublicKey",
+			IsSigner:   chainwriter.MetaBool{BitmapLocation: "Bitmap"},
+			IsWritable: chainwriter.MetaBool{BitmapLocation: "Bitmap"},
+		}}
+
+		args := struct{Accounts []*solana.AccountMeta; Bitmap []byte}{
+				Accounts: accounts[:],
+				Bitmap: make([]byte, 3), // invalid bitmap length
+			}
+
+		_, err := lookupConfig.AccountLookup.Resolve(args)
+		require.Error(t, err)
+	})
 }
 
 func TestPDALookups(t *testing.T) {

--- a/pkg/solana/chainwriter/lookups.go
+++ b/pkg/solana/chainwriter/lookups.go
@@ -189,6 +189,9 @@ func (al AccountLookup) Resolve(args any) ([]*solana.AccountMeta, error) {
 }
 
 func resolveBitMap(mb MetaBool, args any, length int) ([]bool, error) {
+	if length > 64 {
+		return []bool{}, fmt.Errorf("bitmap cannot have more than 64 flags. provided length: %d", length)
+	}
 	result := make([]bool, length)
 	if mb.BitmapLocation == "" {
 		for i := 0; i < length; i++ {
@@ -206,6 +209,11 @@ func resolveBitMap(mb MetaBool, args any, length int) ([]bool, error) {
 		return []bool{}, fmt.Errorf("bitmap value is not a single value: %v, length: %d", bitmapVals, len(bitmapVals))
 	}
 
+	if len(bitmapVals[0]) != 8 {
+		return []bool{}, fmt.Errorf("bitmap value has insufficient bytes: %v, length: %d", bitmapVals[0], len(bitmapVals[0]))
+	}
+
+	// The bitmap is user defined and always uint64 size. The input cannot be further validated for correctness.
 	bitmapInt := binary.LittleEndian.Uint64(bitmapVals[0])
 	for i := 0; i < length; i++ {
 		result[i] = bitmapInt&(1<<i) > 0


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/NONEVM-1799
- Ensure the provided value is a uint64 value
- Ensure the bitmap correlates to a maximum of 64 accounts