### PR TITLE
Add validations to status swap and less methods

### DIFF
--- a/pkg/solana/txm/utils/utils.go
+++ b/pkg/solana/txm/utils/utils.go
@@ -64,11 +64,22 @@ func (s statuses) Len() int {
 }
 
 func (s statuses) Swap(i, j int) {
+	// no-op if indexes are ever out of bounds
+	if i >= len(s.sigs) || j >= len(s.sigs) {
+		return
+	}
+	if i >= len(s.res) || j >= len(s.res) {
+		return
+	}
 	s.sigs[i], s.sigs[j] = s.sigs[j], s.sigs[i]
 	s.res[i], s.res[j] = s.res[j], s.res[i]
 }
 
 func (s statuses) Less(i, j int) bool {
+	// no-op if indexes are ever out of bounds
+	if i >= len(s.res) || j >= len(s.res) {
+		return true
+	}
 	return ConvertStatus(s.res[i]) > ConvertStatus(s.res[j]) // returns list with highest first
 }
 

--- a/pkg/solana/txm/utils/utils_test.go
+++ b/pkg/solana/txm/utils/utils_test.go
@@ -41,6 +41,50 @@ func TestSortSignaturesAndResults(t *testing.T) {
 	assert.Equal(t, solana.Signature{2}, sig[3])
 }
 
+func TestStatusSortHelpers(t *testing.T) {
+	t.Parallel()
+
+	status := statuses{
+		sigs: make([]solana.Signature, 2),
+		res: []*rpc.SignatureStatusesResult{{ConfirmationStatus: rpc.ConfirmationStatusConfirmed}, {ConfirmationStatus: rpc.ConfirmationStatusFinalized}},
+	}
+	t.Run("successfully swaps statuses in list", func(t *testing.T) {
+		status.Swap(0, 1)
+		require.Equal(t, rpc.ConfirmationStatusFinalized, status.res[0].ConfirmationStatus)
+		require.Equal(t, rpc.ConfirmationStatusConfirmed, status.res[1].ConfirmationStatus)
+	})
+
+	t.Run("no-op if swap indexes are out-of-bounds", func(t *testing.T) {
+		status.Swap(1, 2) // j out of bounds
+		require.Equal(t, rpc.ConfirmationStatusConfirmed, status.res[0].ConfirmationStatus)
+		require.Equal(t, rpc.ConfirmationStatusFinalized, status.res[1].ConfirmationStatus)
+
+		status.Swap(2, 1) // i out of bounds
+		require.Equal(t, rpc.ConfirmationStatusConfirmed, status.res[0].ConfirmationStatus)
+		require.Equal(t, rpc.ConfirmationStatusFinalized, status.res[1].ConfirmationStatus)
+
+		status.Swap(2, 3) // i and j out of bounds
+		require.Equal(t, rpc.ConfirmationStatusConfirmed, status.res[0].ConfirmationStatus)
+		require.Equal(t, rpc.ConfirmationStatusFinalized, status.res[1].ConfirmationStatus)
+	})
+
+	t.Run("successfully compares statuses in list", func(t *testing.T) {
+		less := status.Less(0, 1) 
+		require.False(t, less) // expect highest to lowest statuses and Finalized > Confirmed
+	})
+
+	t.Run("no-op if less indexes are out-of-bounds", func(t *testing.T) {
+		less := status.Less(1, 2) // j out of bounds
+		require.True(t, less)
+
+		less = status.Less(2, 1) // i out of bounds
+		require.True(t, less)
+
+		less = status.Less(2, 3) // i and j out of bounds
+		require.True(t, less)
+	})
+}
+
 func TestSignatureList_AllocateWaitSet(t *testing.T) {
 	sigs := SignatureList{}
 	assert.Equal(t, 0, sigs.Length())

--- a/pkg/solana/txm/utils/utils_test.go
+++ b/pkg/solana/txm/utils/utils_test.go
@@ -44,17 +44,15 @@ func TestSortSignaturesAndResults(t *testing.T) {
 func TestStatusSortHelpers(t *testing.T) {
 	t.Parallel()
 
-	status := statuses{
-		sigs: make([]solana.Signature, 2),
-		res: []*rpc.SignatureStatusesResult{{ConfirmationStatus: rpc.ConfirmationStatusConfirmed}, {ConfirmationStatus: rpc.ConfirmationStatusFinalized}},
-	}
 	t.Run("successfully swaps statuses in list", func(t *testing.T) {
+		status := NewTestStatuses(t)
 		status.Swap(0, 1)
 		require.Equal(t, rpc.ConfirmationStatusFinalized, status.res[0].ConfirmationStatus)
 		require.Equal(t, rpc.ConfirmationStatusConfirmed, status.res[1].ConfirmationStatus)
 	})
 
 	t.Run("no-op if swap indexes are out-of-bounds", func(t *testing.T) {
+		status := NewTestStatuses(t)
 		status.Swap(1, 2) // j out of bounds
 		require.Equal(t, rpc.ConfirmationStatusConfirmed, status.res[0].ConfirmationStatus)
 		require.Equal(t, rpc.ConfirmationStatusFinalized, status.res[1].ConfirmationStatus)
@@ -69,11 +67,13 @@ func TestStatusSortHelpers(t *testing.T) {
 	})
 
 	t.Run("successfully compares statuses in list", func(t *testing.T) {
-		less := status.Less(0, 1) 
+		status := NewTestStatuses(t)
+		less := status.Less(0, 1)
 		require.False(t, less) // expect highest to lowest statuses and Finalized > Confirmed
 	})
 
 	t.Run("no-op if less indexes are out-of-bounds", func(t *testing.T) {
+		status := NewTestStatuses(t)
 		less := status.Less(1, 2) // j out of bounds
 		require.True(t, less)
 
@@ -139,4 +139,12 @@ func TestSetTxConfig(t *testing.T) {
 	assert.Equal(t, uint64(4), cfg.ComputeUnitPriceMin)
 	assert.Equal(t, uint64(5), cfg.ComputeUnitPriceMax)
 	assert.Equal(t, uint32(6), cfg.ComputeUnitLimit)
+}
+
+func NewTestStatuses(t *testing.T) statuses {
+	t.Helper()
+	return statuses{
+		sigs: make([]solana.Signature, 2),
+		res:  []*rpc.SignatureStatusesResult{{ConfirmationStatus: rpc.ConfirmationStatusConfirmed}, {ConfirmationStatus: rpc.ConfirmationStatusFinalized}},
+	}
 }


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/NONEVM-1804

Added sanity checks to status swap and less methods. These methods are currently only used for sorting which handles index checks internally but these methods are public. So sanity checks were added in case they're used directly for anything else in the future.