### PR TITLE
.github/workflows: simplify e2e timeouts

### DIFF
--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -321,7 +321,7 @@ jobs:
       - name: Run Tests
         uses: smartcontractkit/.github/actions/ctf-run-tests@91995e4dd053581696702eec503ce2d2c8b8e753 # 0.6.1
         with:
-          test_command_to_run: cd ./integration-tests && go test -timeout 24h -count=1 -run TestSolanaOCRV2Smoke -json $(args) ./smoke 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci=true -singlepackage=true -hidepassingtests=false -hidepassinglogs=false
+          test_command_to_run: cd ./integration-tests && go test -count=1 -run TestSolanaOCRV2Smoke -json $(args) ./smoke 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci=true -singlepackage=true -hidepassingtests=false -hidepassinglogs=false
           test_download_vendor_packages_command: cd ./integration-tests && go mod download
           test_config_override_base64: ${{ env.BASE64_CONFIG_OVERRIDE }}
           download_contract_artifacts_path: ${{ env.CONTRACT_ARTIFACTS_PATH }} 
@@ -405,7 +405,7 @@ jobs:
       - name: Run Upgrade Test
         uses: smartcontractkit/.github/actions/ctf-run-tests@91995e4dd053581696702eec503ce2d2c8b8e753 # 0.6.1
         with:
-          test_command_to_run: cd ./integration-tests && go test -timeout 24h -count=1 -run TestSolanaOCRV2UpgradeSmoke -json $(args) ./smoke 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci=true -singlepackage=true -hidepassingtests=false -hidepassinglogs=false
+          test_command_to_run: cd ./integration-tests && go test -count=1 -run TestSolanaOCRV2UpgradeSmoke -json $(args) ./smoke 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci=true -singlepackage=true -hidepassingtests=false -hidepassinglogs=false
           test_download_vendor_packages_command: cd ./integration-tests && go mod download
           test_config_override_base64: ${{ env.BASE64_CONFIG_OVERRIDE }}
           download_contract_artifacts_path: ${{ env.CONTRACT_ARTIFACTS_PATH }} 

--- a/.github/workflows/e2e_testnet_daily.yml
+++ b/.github/workflows/e2e_testnet_daily.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Run Tests
         uses: smartcontractkit/.github/actions/ctf-run-tests@91995e4dd053581696702eec503ce2d2c8b8e753 # 0.6.1
         with:
-          test_command_to_run: cd ./integration-tests && go test -timeout 24h -count=1 -run TestSolanaOCRV2Smoke/embedded -json $(args) ./smoke 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci -singlepackage
+          test_command_to_run: cd ./integration-tests && go test -count=1 -run TestSolanaOCRV2Smoke/embedded -json $(args) ./smoke 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci -singlepackage
           test_download_vendor_packages_command: cd ./integration-tests && go mod download
           test_config_override_base64: ${{ env.BASE64_CONFIG_OVERRIDE }}
           test_secrets_override_base64: ${{ secrets[inputs.test_secrets_override_key] }}

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Run Tests
         uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@fdaf56b1df7248d18e30ad09982d03ec67d6b71c # v2.3.29
         with:
-          test_command_to_run: cd ./integration-tests && go test -timeout 24h -count=1 -run TestSolanaOCRV2Soak/embedded -json $(args) ./soak 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci -singlepackage
+          test_command_to_run: cd ./integration-tests && go test -count=1 -run TestSolanaOCRV2Soak/embedded -json $(args) ./soak 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci -singlepackage
           test_download_vendor_packages_command: cd ./integration-tests && go mod download
           test_config_override_base64: ${{ env.BASE64_CONFIG_OVERRIDE }}
           test_secrets_override_base64: ${{ secrets[inputs.test_secrets_override_key] }}

--- a/docs/RunningE2eTests.md
+++ b/docs/RunningE2eTests.md
@@ -32,7 +32,7 @@ By default all values are pulled either from `default.toml` or if we create an `
 
 ## Run tests
 
-`cd integration-tests/smoke && go test -timeout 24h -count=1 -run TestSolanaOCRV2Smoke -test.timeout 30m;`
+`cd integration-tests/smoke && go test -timeout 30m -count=1 -run TestSolanaOCRV2Smoke;`
 
 ### On demand soak test
 
@@ -54,4 +54,4 @@ If you want to kick off the test from local:
 - `export ENV_JOB_IMAGE: <internal_repo>/chainlink-solana-tests:<tag>`
 - Base64 the .toml config
 - Run `export BASE64_CONFIG_OVERRIDE="<config>"`
-- cd integration-tests/soak && go test -timeout 24h -count=1 -run TestSolanaOCRV2Soak -test.timeout 30m;
+- cd integration-tests/soak && go test -timeout 30m -count=1 -run TestSolanaOCRV2Soak;

--- a/integration-tests/scripts/run_soak_test.sh
+++ b/integration-tests/scripts/run_soak_test.sh
@@ -20,7 +20,7 @@ while IFS= read -r line; do
         terminated_by_script=true
         break
     fi
-done < <(sudo go test -timeout 24h -count=1 -run TestSolanaOCRV2Smoke/embedded -test.timeout 30m 2>&1)
+done < <(sudo go test -timeout 30m -count=1 -run TestSolanaOCRV2Smoke/embedded 2>&1)
 
 # Capture the PID of the background process
 READER_PID=$!


### PR DESCRIPTION
Specifying `timeout` and `test.timeout` is redundant, and in our case the longer `-timeout 24h` is trampling our parameterized `30m` timeouts. Here is a 6h run: https://github.com/smartcontractkit/chainlink-solana/actions/runs/15025545948/job/42225620676?pr=1222