### PR TITLE
Reduce log level for InstructionError in TXM

### DIFF
--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -1050,7 +1050,7 @@ func (txm *Txm) ProcessError(ctx context.Context, sig solanaGo.Signature, resErr
 			return txmutils.Errored, errType
 		// transaction will encounter execution error/revert
 		case strings.Contains(errStr, "InstructionError"):
-			txm.lggr.Errorw("InstructionError", logValues...)
+			txm.lggr.Debugw("InstructionError", logValues...)
 			if !simulation {
 				txm.fetchTransactionLogs(ctx, sig)
 			}


### PR DESCRIPTION
This log can become noisy for Data Feeds where StaleReport InstructionErrors are expected to commonly occur