### PR TITLE
Fix relay unit test flakes

### DIFF
--- a/pkg/solana/client/client_test.go
+++ b/pkg/solana/client/client_test.go
@@ -266,10 +266,6 @@ func TestClient_Writer_Integration(t *testing.T) {
 
 func TestClient_GetBlocks(t *testing.T) {
 	url := solanatesting.SetupLocalSolNode(t)
-	privKey, err := solana.NewRandomPrivateKey()
-	require.NoError(t, err)
-	pubKey := privKey.PublicKey()
-	solanatesting.FundTestAccounts(t, []solana.PublicKey{pubKey}, url)
 
 	requestTimeout := 5 * time.Second
 	lggr := logger.Test(t)

--- a/pkg/solana/client/client_test.go
+++ b/pkg/solana/client/client_test.go
@@ -44,7 +44,7 @@ func TestClient_Reader_Integration(t *testing.T) {
 	// check balance
 	bal, err := c.Balance(ctx, pubKey)
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(100_000_000_000), bal) // once funds get sent to the system program it should be unrecoverable (so this number should remain > 0)
+	assert.Equal(t, 100*solana.LAMPORTS_PER_SOL, bal) // once funds get sent to the system program it should be unrecoverable (so this number should remain > 0)
 
 	// check SlotHeight
 	slot0, err := c.SlotHeight(ctx)
@@ -239,12 +239,18 @@ func TestClient_Writer_Integration(t *testing.T) {
 	assert.NoError(t, err)
 
 	// check signature statuses
-	time.Sleep(2 * time.Second) // wait for processing
-	statuses, err := c.SignatureStatuses(ctx, []solana.Signature{sigSuccess, sigFail})
-	assert.NoError(t, err)
-
-	assert.Nil(t, statuses[0].Err)
-	assert.NotNil(t, statuses[1].Err)
+	// try waiting for tx to execute - reduce flakiness
+	require.Eventually(t, func() bool {
+		res, statusErr := c.SignatureStatuses(ctx, []solana.Signature{sigSuccess, sigFail})
+		require.NoError(t, statusErr)
+		require.Equal(t, 2, len(res))
+		if res[0] == nil || res[1] == nil {
+			return false
+		}
+		require.Nil(t, res[0].Err)
+		require.NotNil(t, res[1].Err)
+		return true
+	}, 5*time.Second, 500*time.Millisecond)
 
 	getTxResult, err := c.GetTransaction(ctx, sigSuccess)
 	assert.NoError(t, err)
@@ -389,7 +395,7 @@ func TestClient_SendTxDuplicates_Integration(t *testing.T) {
 		if res[0] == nil {
 			return false
 		}
-		return res[0].ConfirmationStatus == rpc.ConfirmationStatusConfirmed
+		return res[0].ConfirmationStatus == rpc.ConfirmationStatusConfirmed || res[0].ConfirmationStatus == rpc.ConfirmationStatusFinalized
 	}, 5*time.Second, 500*time.Millisecond)
 
 	// expect one sender has only sent one tx

--- a/pkg/solana/testing/test_helpers.go
+++ b/pkg/solana/testing/test_helpers.go
@@ -17,6 +17,12 @@ import (
 	"github.com/smartcontractkit/freeport"
 )
 
+const (
+	fundingTimeout    = 30 * time.Second
+	fundingTimestep   = 500 * time.Millisecond
+	fundingMaxRetries = 5
+)
+
 func SetupLocalSolNode(t *testing.T) string {
 	t.Helper()
 
@@ -29,7 +35,8 @@ func SetupLocalSolNode(t *testing.T) string {
 func SetupLocalSolNodeWithFlags(t *testing.T, flags ...string) (string, string) {
 	t.Helper()
 
-	ports := twoConsecutiveFreeports(t)
+	ports, err := TwoConsecutiveFreeports(t)
+	require.NoError(t, err)
 	portStr := strconv.Itoa(ports[0])
 
 	faucetPort := freeport.GetOne(t)
@@ -83,63 +90,75 @@ func SetupLocalSolNodeWithFlags(t *testing.T, flags ...string) (string, string) 
 	return url, wsURL
 }
 
-func FundTestAccountsWithRetry(t *testing.T, keys []solana.PublicKey, url string, attempts int) error {
+func FundTestAccountsWithRetry(t *testing.T, keys []solana.PublicKey, client *rpc.Client, attempts int) error {
 	t.Helper()
 
-	var errKeys []solana.PublicKey
-	for i, key := range keys {
-		account := keys[i].String()
-		_, err := exec.Command("solana", "airdrop", "100", account, "--url", url).Output()
-		if err != nil {
-			if attempts <= 0 {
-				var exitErr *exec.ExitError
-				if errors.As(err, &exitErr) {
-					return fmt.Errorf("failed to fund solana account: %w; stderr: %s", err, string(exitErr.Stderr))
-				}
-				return err
-			}
-			errKeys = append(errKeys, key)
-		}
-	}
-	// call FundTestAccountsWithRetry recursively with keys that errored, decrement attempts to cap the number of retries
-	if len(errKeys) > 0 {
-		if attempts <= 0 {
-			return fmt.Errorf("failed to fund solana accounts")
-		}
-		time.Sleep(500 * time.Millisecond)
-		return FundTestAccountsWithRetry(t, errKeys, url, attempts-1)
+	if attempts <= 0 {
+		return fmt.Errorf("failed to fund accounts within %d tries", fundingMaxRetries)
 	}
 
-	return nil
+	out, err := client.GetHealth(t.Context())
+	if err != nil || out != rpc.HealthOk {
+		t.Log("client RPC not healthy when trying to fund account")
+		return errors.New("client not healthy when funding account")
+	}
+
+	sigs := []solana.Signature{}
+	for _, v := range keys {
+		sig, err := client.RequestAirdrop(t.Context(), v, 100*solana.LAMPORTS_PER_SOL, rpc.CommitmentFinalized)
+		require.NoError(t, err)
+		sigs = append(sigs, sig)
+	}
+
+	// wait for confirmation so later transactions don't fail
+	remaining := keys
+	initTime := time.Now()
+
+	for elapsed := time.Since(initTime); elapsed < fundingTimeout; elapsed = time.Since(initTime) {
+		time.Sleep(fundingTimestep)
+
+		statusRes, sigErr := client.GetSignatureStatuses(t.Context(), true, sigs...)
+		require.NoError(t, sigErr)
+		require.NotNil(t, statusRes)
+		require.NotNil(t, statusRes.Value)
+
+		accountsWithNonFinalizedFunding := []solana.PublicKey{}
+		for i, res := range statusRes.Value {
+			if res == nil || res.ConfirmationStatus != rpc.ConfirmationStatusFinalized {
+				accountsWithNonFinalizedFunding = append(accountsWithNonFinalizedFunding, keys[i])
+			}
+		}
+		remaining = accountsWithNonFinalizedFunding
+
+		if len(remaining) == 0 {
+			return nil // all done!
+		}
+	}
+
+	return FundTestAccountsWithRetry(t, remaining, client, attempts-1) // recursive call with only remaining & with fewer attempts
 }
 
 func FundTestAccounts(t *testing.T, keys []solana.PublicKey, url string) {
 	t.Helper()
-	err := FundTestAccountsWithRetry(t, keys, url, 5)
+	client := rpc.New(url)
+	err := FundTestAccountsWithRetry(t, keys, client, fundingMaxRetries)
 	require.NoError(t, err)
 }
 
-func twoConsecutiveFreeports(t *testing.T) []int {
+func TwoConsecutiveFreeports(t *testing.T) ([]int, error) {
 	t.Helper()
-	ports := freeport.GetN(t, 2)
-	if ports[0] == ports[1] - 1 {
-		return ports
-	}
 	// track unused ports until consecutive ones are found or max retries is reached
 	// ports are not immediately returned to avoid re-fetching the same ones again
-	unusedPorts := []int{ports[0], ports[1]}
-	attempt := 0
-	maxRetries := 5
-	for attempt < maxRetries{
-		attempt++
+	var unusedPorts []int
+	// try a maximum of 5 times
+	for range 5 {
 		ports := freeport.GetN(t, 2)
-		if ports[0] == ports[1] - 1 {
+		if ports[0]+1 == ports[1] {
 			freeport.Return(unusedPorts)
-			return ports
+			return ports, nil
 		}
 		unusedPorts = append(unusedPorts, ports...)
 	}
 	freeport.Return(unusedPorts)
-	require.Fail(t, "failed to fetch 2 consecutive ports")
-	return nil
+	return nil, errors.New("failed to fetch 2 consecutive ports")
 }

--- a/pkg/solana/testing/test_helpers.go
+++ b/pkg/solana/testing/test_helpers.go
@@ -29,12 +29,12 @@ func SetupLocalSolNode(t *testing.T) string {
 func SetupLocalSolNodeWithFlags(t *testing.T, flags ...string) (string, string) {
 	t.Helper()
 
-	port := freeport.GetN(t, 2)
-	portStr := strconv.Itoa(port[0])
+	ports := twoConsecutiveFreeports(t)
+	portStr := strconv.Itoa(ports[0])
 
 	faucetPort := freeport.GetOne(t)
 	url := "http://127.0.0.1:" + portStr
-	wsURL := "ws://127.0.0.1:" + strconv.Itoa(port[1]) //there is no way to define ws port on Solana validation. It must be +1 from rpc port.
+	wsURL := "ws://127.0.0.1:" + strconv.Itoa(ports[1]) //there is no way to define ws port on Solana validation. It must be +1 from rpc port.
 
 	args := append([]string{
 		"--reset",
@@ -89,10 +89,7 @@ func FundTestAccountsWithRetry(t *testing.T, keys []solana.PublicKey, url string
 	var errKeys []solana.PublicKey
 	for i, key := range keys {
 		account := keys[i].String()
-		_, err := exec.Command("solana", "airdrop", "100",
-			account,
-			"--url", url,
-		).Output()
+		_, err := exec.Command("solana", "airdrop", "100", account, "--url", url).Output()
 		if err != nil {
 			if attempts <= 0 {
 				var exitErr *exec.ExitError
@@ -120,4 +117,29 @@ func FundTestAccounts(t *testing.T, keys []solana.PublicKey, url string) {
 	t.Helper()
 	err := FundTestAccountsWithRetry(t, keys, url, 5)
 	require.NoError(t, err)
+}
+
+func twoConsecutiveFreeports(t *testing.T) []int {
+	t.Helper()
+	ports := freeport.GetN(t, 2)
+	if ports[0] == ports[1] - 1 {
+		return ports
+	}
+	// track unused ports until consecutive ones are found or max retries is reached
+	// ports are not immediately returned to avoid re-fetching the same ones again
+	unusedPorts := []int{ports[0], ports[1]}
+	attempt := 0
+	maxRetries := 5
+	for attempt < maxRetries{
+		attempt++
+		ports := freeport.GetN(t, 2)
+		if ports[0] == ports[1] - 1 {
+			freeport.Return(unusedPorts)
+			return ports
+		}
+		unusedPorts = append(unusedPorts, ports...)
+	}
+	freeport.Return(unusedPorts)
+	require.Fail(t, "failed to fetch 2 consecutive ports")
+	return nil
 }

--- a/pkg/solana/testing/test_helpers_test.go
+++ b/pkg/solana/testing/test_helpers_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 package testing
 
 import (
@@ -44,7 +46,7 @@ func TestSetupLocalSolNode_SimultaneousNetworks(t *testing.T) {
 		// check end balance
 		bal, err = c.Balance(ctx, pubkey)
 		assert.NoError(t, err)
-		assert.Equal(t, uint64(100_000_000_000), bal) // once funds get sent to the system program it should be unrecoverable (so this number should remain > 0)
+		assert.Equal(t, 100*solana.LAMPORTS_PER_SOL, bal) // once funds get sent to the system program it should be unrecoverable (so this number should remain > 0)
 	}
 
 	checkFunded(t, network0)

--- a/pkg/solana/txm/txm_integration_test.go
+++ b/pkg/solana/txm/txm_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-	commonutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
+	"github.com/smartcontractkit/freeport"
 
 	solanaclient "github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
@@ -221,9 +222,10 @@ func TestTxm_Integration_Reorg(t *testing.T) {
 		// Start live validator and setup test environment
 		t.Parallel()
 		ledgerDir := t.TempDir()
-		port := commonutils.MustRandomPort(t)
-		faucetPort := commonutils.MustRandomPort(t)
-		cmd, url := startValidator(t, ledgerDir, port, faucetPort, true)
+		ports, err := solanatesting.TwoConsecutiveFreeports(t)
+		require.NoError(t, err)
+		faucetPort := strconv.Itoa(freeport.GetOne(t))
+		cmd, url := startValidator(t, ledgerDir, strconv.Itoa(ports[0]), faucetPort, true)
 		ctx, cl, txmInstance, senderPubKey, receiverPubKey, obs := setup(t, url, true)
 
 		// Back up the ledger after transferring funds
@@ -245,7 +247,7 @@ func TestTxm_Integration_Reorg(t *testing.T) {
 		_ = cmd.Wait()
 		require.NoError(t, os.RemoveAll(ledgerDir))
 		require.NoError(t, copyDir(cleanLedgerBackupDir, ledgerDir))
-		startValidator(t, ledgerDir, port, faucetPort, false)
+		startValidator(t, ledgerDir, strconv.Itoa(ports[0]), faucetPort, false)
 
 		// Check tx is not finalized yet and reorg is detected
 		status, errGetStatus := txmInstance.GetTransactionStatus(ctx, txID)

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -105,7 +105,7 @@ func empty(t *testing.T, txm *Txm, prom soltxmProm) bool {
 func waitFor(t *testing.T, waitDuration time.Duration, txm *Txm, prom soltxmProm, f func(*testing.T, *Txm, soltxmProm) bool) {
 	require.Eventually(t, func() bool {
 		return f(t, txm, prom)
-	}, waitDuration, time.Second, "unable to confirm inflight txs is empty")
+	}, 2*waitDuration, time.Second, "unable to confirm inflight txs is empty")
 }
 
 func TestTxm(t *testing.T) {

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -103,13 +103,9 @@ func empty(t *testing.T, txm *Txm, prom soltxmProm) bool {
 
 // waits for the provided function to evaluate to true within the provided duration amount of time
 func waitFor(t *testing.T, waitDuration time.Duration, txm *Txm, prom soltxmProm, f func(*testing.T, *Txm, soltxmProm) bool) {
-	for i := 0; i < int(waitDuration.Seconds()*1.5); i++ {
-		if f(t, txm, prom) {
-			return
-		}
-		time.Sleep(time.Second)
-	}
-	assert.NoError(t, errors.New("unable to confirm inflight txs is empty"))
+	require.Eventually(t, func() bool {
+		return f(t, txm, prom)
+	}, waitDuration, time.Second, "unable to confirm inflight txs is empty")
 }
 
 func TestTxm(t *testing.T) {


### PR DESCRIPTION
- Added improved Solana funding retry logic through RPC airdrop
- Added port fetch retry to ensure 2 consecutive ports are secured for Solana local validator
- Disabled race test for local validator simultaneously network setup
- Updated TXM integration test to use new freeport package