### PR TITLE
Add LogPoller Test ORM

### DIFF
--- a/pkg/solana/logpoller/testing/test_orm.go
+++ b/pkg/solana/logpoller/testing/test_orm.go
@@ -18,13 +18,13 @@ func NewTestORM(ds sqlutil.DataSource) *TestDSORM {
 }
 
 // HasFilterByEventName checks if a filter exists for the provided event name
-func (o *TestDSORM) HasFilterByEventName(ctx context.Context, chainID, eventName string) (bool, error) {
+func (o *TestDSORM) HasFilterByEventName(ctx context.Context, chainID, eventName string, address []byte) (bool, error) {
 	query := `
 		SELECT COUNT(1) FROM solana.log_poller_filters 
-			WHERE is_deleted = false AND chain_id = $1 AND event_name = $2 LIMIT 1`
+			WHERE is_deleted = false AND chain_id = $1 AND event_name = $2 AND address = $3 LIMIT 1`
 
 	var exists int
-	if err := o.ds.GetContext(ctx, &exists, query, chainID, eventName); err != nil {
+	if err := o.ds.GetContext(ctx, &exists, query, chainID, eventName, address); err != nil {
 		return false, err
 	}
 

--- a/pkg/solana/logpoller/testing/test_orm.go
+++ b/pkg/solana/logpoller/testing/test_orm.go
@@ -1,0 +1,32 @@
+package testing
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+)
+
+type TestDSORM struct {
+	ds      sqlutil.DataSource
+}
+
+// NewTestORM creates a test DSORM which contains method only used by tests
+func NewTestORM(ds sqlutil.DataSource) *TestDSORM {
+	return &TestDSORM{
+		ds:      ds,
+	}
+}
+
+// HasFilterByEventName checks if a filter exists for the provided event name
+func (o *TestDSORM) HasFilterByEventName(ctx context.Context, chainID, eventName string) (bool, error) {
+	query := `
+		SELECT COUNT(1) FROM solana.log_poller_filters 
+			WHERE is_deleted = false AND chain_id = $1 AND event_name = $2 LIMIT 1`
+
+	var exists int
+	if err := o.ds.GetContext(ctx, &exists, query, chainID, eventName); err != nil {
+		return false, err
+	}
+
+	return exists != 0, nil
+}

--- a/pkg/solana/logpoller/testing/test_orm.go
+++ b/pkg/solana/logpoller/testing/test_orm.go
@@ -7,13 +7,13 @@ import (
 )
 
 type TestDSORM struct {
-	ds      sqlutil.DataSource
+	ds sqlutil.DataSource
 }
 
 // NewTestORM creates a test DSORM which contains method only used by tests
 func NewTestORM(ds sqlutil.DataSource) *TestDSORM {
 	return &TestDSORM{
-		ds:      ds,
+		ds: ds,
 	}
 }
 


### PR DESCRIPTION
Created a test ORM for methods only needed by tests. The Solana CCIP E2E test needs to read the LogPoller DB to determine when filters for certain events are registered before proceeding. 

Core PR: https://github.com/smartcontractkit/chainlink/pull/17939