### PR TITLE
log stuff

### DIFF
--- a/pkg/solana/chainreader/batch.go
+++ b/pkg/solana/chainreader/batch.go
@@ -176,6 +176,7 @@ func doMethodBatchCall(ctx context.Context, lggr logger.Logger, client MultipleA
 
 		// HACK: workaround for OffRampLatestConfigDetails: we need to use an input param to filter an array in the return values, not for seeds
 		if batchCall.ReadName == ccipconsts.MethodNameOffRampLatestConfigDetails {
+			lggr.Debugw("OffRampLatestConfigDetails check", "readName", batchCall.ReadName, "params", batchCall.Params, "paramsType", reflect.TypeOf(batchCall.Params))
 			params, ok := batchCall.Params.(map[string]any)
 			if !ok {
 				results[idx].err = fmt.Errorf("batch call params is unexpected type: %T, expected %T", batchCall.Params, map[string]any{})


### PR DESCRIPTION
### Description

Debugging this issue in loop mode:

```
{"L":"DEBUG","T":"15:27:00.934637000","N":"CCIPCommitPlugin.solana.22222222222222222222222222222222222222222222.12463857294658392847.offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm","C":"reader/observed_ccip.go:365","M":"observed CCIP Reader query","plugin":"Commit","oracleID":2,"donID":2,"configDigest":"000a793b91df95ee493f2dff139b23b202d4013686630198b76f6cdfb1c9f8d8","component":"CCIPReader","duration":"1.316070542s","query":"GetRMNRemoteConfig","error":"get chain config: failed to refresh cache for chain 12463857294658392847: process OffRamp results: get offramp result 0: batch call params is unexpected type: *struct {}, expected map[string]interface {}"}
```

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
