### PR TITLE
bump txm simulations from debug to error

### DIFF
--- a/pkg/solana/txm/txm.go
+++ b/pkg/solana/txm/txm.go
@@ -670,7 +670,7 @@ func (txm *Txm) simulate() {
 			// Certain errors can be considered not to be failures during simulation to allow the process to continue
 			if txState, errType := txm.ProcessError(ctx, msg.signatures[0], res.Err, true, msg.id); errType != NoFailure {
 				if len(res.Logs) > 0 {
-					txm.lggr.Debugw("simulated transaction error logs", "logs", res.Logs)
+					txm.lggr.Errorw("simulated transaction error logs", "logs", res.Logs)
 				}
 				id, err := txm.txs.OnError(msg.signatures[0], txm.cfg.TxRetentionTimeout(), txState, errType)
 				if err != nil {
@@ -987,7 +987,7 @@ func (txm *Txm) EstimateComputeUnitLimit(ctx context.Context, tx *solanaGo.Trans
 		// Certain errors can be considered not to be failures during simulation to allow the process to continue
 		if txState, errType := txm.ProcessError(ctx, sig, res.Err, true, id); errType != NoFailure {
 			if len(res.Logs) > 0 {
-				txm.lggr.Debugw("simulated transaction error logs", "logs", res.Logs)
+				txm.lggr.Errorw("simulated transaction error logs", "logs", res.Logs)
 			}
 			err := txm.txs.OnPrebroadcastError(id, txm.cfg.TxRetentionTimeout(), txState, errType)
 			if err != nil {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/CCIP-6469

Errors from simulated txns should be surfaced directly in error logs