### PR TITLE
Update Data Streams crate to use Solana 2.1.0

### DIFF
--- a/contracts/crates/chainlink-solana-data-streams/Cargo.toml
+++ b/contracts/crates/chainlink-solana-data-streams/Cargo.toml
@@ -16,10 +16,10 @@ default = []
 borsh = "0.10.3"
 
 [target.'cfg(target_os = "solana")'.dependencies]
-solana-program = "1.17"
+solana-program = "2.1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-solana-sdk = "1.17"
+solana-sdk = "2.1.0"
 
 [dev-dependencies]
-solana-sdk = "1.17"
+solana-sdk = "2.1.0"


### PR DESCRIPTION
The solana-2.1 branch upgrades the Solana dependencies for the chainlink-solana crate to 2.1.0, but does not upgrade the chainlink-solana-data-streams crate dependencies. This PR does that.