### PR TITLE
publish df1 sdk

### DIFF
--- a/.github/workflows/publish-df-sdk.yml
+++ b/.github/workflows/publish-df-sdk.yml
@@ -7,6 +7,9 @@ on:
         description: "Version to publish (e.g., 2.0.8)"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -19,7 +22,7 @@ jobs:
           ref: develop
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Verify tag matches version
         run: |
@@ -33,7 +36,7 @@ jobs:
       - name: Publish chainlink-data-streams-sdk
         run: |
           cd sdk/chainlink-solana
-          cargo publish --token ${CARGO_CHAINLINK_SOLANA_SDK}
+          cargo publish --token "${CARGO_CHAINLINK_SOLANA_SDK}"
           if ! cargo owner --list | grep -q "github:smartcontractkit:RustCrates"; then
             cargo owner --add github:smartcontractkit:RustCrates
           fi

--- a/.github/workflows/publish-df-sdk.yml
+++ b/.github/workflows/publish-df-sdk.yml
@@ -22,7 +22,7 @@ jobs:
           ref: develop
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
 
       - name: Verify tag matches version
         run: |

--- a/.github/workflows/publish-df-sdk.yml
+++ b/.github/workflows/publish-df-sdk.yml
@@ -1,0 +1,41 @@
+name: Publish Chainlink Data Feeds SDK Crate
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g., 2.0.8)"
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: publish-cargo
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.90.0
+
+      - name: Verify tag matches version
+        run: |
+          VERSION=$(grep '^version = "' sdk/chainlink-solana/Cargo.toml | cut -d '"' -f2)
+          TAG_VERSION=${{ github.event.inputs.version }}
+          if [ "$VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: Cargo.toml ($VERSION) != expected version ($TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Publish chainlink-data-streams-sdk
+        run: |
+          cd sdk/chainlink-solana
+          cargo publish --token ${CARGO_CHAINLINK_SOLANA_SDK}
+          if ! cargo owner --list | grep -q "github:smartcontractkit:RustCrates"; then
+            cargo owner --add github:smartcontractkit:RustCrates
+          fi
+        env:
+          CARGO_CHAINLINK_SOLANA_SDK: ${{ secrets.CARGO_CHAINLINK_SOLANA }}

--- a/.github/workflows/publish-df-sdk.yml
+++ b/.github/workflows/publish-df-sdk.yml
@@ -7,12 +7,11 @@ on:
         description: "Version to publish (e.g., 2.0.8)"
         required: true
 
-permissions:
-  contents: read
-
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment: publish-cargo
 
     steps:
@@ -22,7 +21,9 @@ jobs:
           ref: develop
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
+        uses: dtolnay/rust-toolchain@2ae36166d3d3fcc53eaa7b030a26ca5ac4739e8c #v1.70.0
+        with:
+          toolchain: 1.90.0
 
       - name: Verify tag matches version
         run: |


### PR DESCRIPTION
### Description

Per security's instructions:

> an environment called publish-cargo which has a secret called CARGO_CHAINLINK_SOLANA . That’s the token that can publish the crate.

The publish-cargo environment is restricted to the develop branch

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
