### PR TITLE
fix(security): resolve CodeQL workflow alerts

### DIFF
--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -5,6 +5,9 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
       - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
 
+permissions:
+  contents: write
+
 defaults:
   run:
     working-directory: ./contracts

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -3,7 +3,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # check every day at midnight UTC
-  
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   E2E-Solana-Image:
     uses: ./.github/workflows/open-pr.yml

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -13,6 +13,12 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  id-token: write
+  checks: write
+  pull-requests: write
+
 env:
   CL_ECR: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
   CONTRACT_ARTIFACTS_PATH: contracts/target/deploy

--- a/.github/workflows/e2e_testnet_daily.yml
+++ b/.github/workflows/e2e_testnet_daily.yml
@@ -8,7 +8,7 @@ on:
         default: develop
         type: string
       test_secrets_override_key:
-        description: 'Key to run tests with custom test secrets like ws url, rpc url, private key, etc.'
+        description: 'Set to "1" or any value to use custom test secrets from E2E_TEST_SECRETS_OVERRIDE (avoids exposing all secrets)'
         required: false
         type: string
       team:
@@ -17,6 +17,13 @@ on:
         type: string
   schedule:
     - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+  id-token: write
+  checks: write
+  pull-requests: write
+
 # Only run 1 of this workflow at a time per PR
 env:
   CL_ECR: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
@@ -150,7 +157,7 @@ jobs:
           test_command_to_run: cd ./integration-tests && go test -count=1 -run TestSolanaOCRV2Smoke/embedded $(args) ./smoke 2>&1 | tee /tmp/gotest.log
           test_download_vendor_packages_command: cd ./integration-tests && go mod download
           test_config_override_base64: ${{ env.BASE64_CONFIG_OVERRIDE }}
-          test_secrets_override_base64: ${{ secrets[inputs.test_secrets_override_key] }}
+          test_secrets_override_base64: ${{ inputs.test_secrets_override_key != '' && secrets.E2E_TEST_SECRETS_OVERRIDE || '' }}
           download_contract_artifacts_path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
           go_mod_path: ./integration-tests/go.mod
           cl_repo: ${{ env.CL_ECR }}

--- a/.github/workflows/gauntlet.yml
+++ b/.github/workflows/gauntlet.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   tool_versions:
     name: Get the tool versions
@@ -14,7 +18,7 @@ jobs:
       nodejs_version: ${{ steps.tool-versions.outputs.nodejs_version }}
     steps:
       - uses: actions/checkout@v4
-      - uses: smartcontractkit/tool-versions-to-env-action@v1.0.8
+      - uses: smartcontractkit/tool-versions-to-env-action@aabd5efbaf28005284e846c5cf3a02f2cba2f4c2 # v1.0.8
         id: tool-versions
 
   gauntlet_build:

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -7,6 +7,10 @@ on:
       - develop
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 env:
   ECR_TAG: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:develop
   CONTRACT_ARTIFACTS_PATH: contracts/target/deploy

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -1,6 +1,10 @@
 name: Lint GH Workflows
 on:
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   lint_workflows:
     name: Validate Github Action Workflows

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   build-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/nix-packages-test.yml
+++ b/.github/workflows/nix-packages-test.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   nix-packages-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -10,6 +10,11 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   create-commits-and-pr:
     permissions:

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   relay_run_unit_tests:
     name: Relay Run Unit Tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+  actions: read
+
 defaults:
   run:
     working-directory: contracts
@@ -40,7 +44,7 @@ jobs:
     needs: [get_projectserum_version, build_wrapped_anchor_image]
     steps:
       - name: Free Disk Space
-        uses: smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1
+        uses: smartcontractkit/.github/actions/free-disk-space@ca71236c9f9e1358597795ef7d433dd3d3df8dfb # free-disk-space/v1
       - uses: actions/checkout@v4
       - name: Cache cargo target dir
         uses: actions/cache@v4
@@ -87,7 +91,7 @@ jobs:
     needs: [get_projectserum_version, build_wrapped_anchor_image]
     steps:
       - name: Free Disk Space
-        uses: smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1
+        uses: smartcontractkit/.github/actions/free-disk-space@ca71236c9f9e1358597795ef7d433dd3d3df8dfb # free-disk-space/v1
       - uses: actions/checkout@v4
       - name: Cache cargo target dir
         uses: actions/cache@v4
@@ -131,7 +135,7 @@ jobs:
     needs: [get_projectserum_version, build_wrapped_anchor_image]
     steps:
       - name: Free Disk Space
-        uses: smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1
+        uses: smartcontractkit/.github/actions/free-disk-space@ca71236c9f9e1358597795ef7d433dd3d3df8dfb # free-disk-space/v1
       - name: Checkout sources
         uses: actions/checkout@v4
 

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -6,7 +6,7 @@ on:
         description: Your .toml file as base64 (must NOT contain test secrets)
         required: true
       test_secrets_override_key:
-        description: 'Key to run tests with custom test secrets like ws url, rpc url, private key, etc.'
+        description: 'Set to "1" or any value to use custom test secrets from E2E_TEST_SECRETS_OVERRIDE (avoids exposing all secrets)'
         required: false
         type: string
       cl_image_tag:
@@ -24,6 +24,13 @@ on:
         required: true
         type: string
         default: BIX
+
+permissions:
+  contents: read
+  id-token: write
+  checks: write
+  pull-requests: write
+
 env:
   CL_ECR: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
   CONTRACT_ARTIFACTS_PATH: contracts/target/deploy
@@ -97,7 +104,7 @@ jobs:
           test_command_to_run: cd ./integration-tests && go test -count=1 -run TestSolanaOCRV2Soak/embedded $(args) ./soak 2>&1 | tee /tmp/gotest.log
           test_download_vendor_packages_command: cd ./integration-tests && go mod download
           test_config_override_base64: ${{ env.BASE64_CONFIG_OVERRIDE }}
-          test_secrets_override_base64: ${{ secrets[inputs.test_secrets_override_key] }}
+          test_secrets_override_base64: ${{ inputs.test_secrets_override_key != '' && secrets.E2E_TEST_SECRETS_OVERRIDE || '' }}
           download_contract_artifacts_path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
           go_mod_path: ./integration-tests/go.mod
           cl_repo: ${{ env.CL_ECR }}

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -6,6 +6,10 @@ on:
       - develop
   pull_request:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   wait_for_workflows:
     name: Wait for workflows
@@ -35,7 +39,7 @@ jobs:
       - name: Check out Code
         uses: actions/checkout@v4
       - name: Parse tool-versions file
-        uses: smartcontractkit/tool-versions-to-env-action@v1.0.8
+        uses: smartcontractkit/tool-versions-to-env-action@aabd5efbaf28005284e846c5cf3a02f2cba2f4c2 # v1.0.8
         id: tool-versions
     outputs:
       go-version: ${{ steps.tool-versions.outputs.golang_version }}

--- a/.github/workflows/upstream-tracker.yml
+++ b/.github/workflows/upstream-tracker.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 * * 1' # check monday at midnight UTC
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   Solana-Update-Checker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Resolves workflow-only CodeQL security alerts for smartcontractkit/chainlink-solana.

## Changes (workflow files only)

### 1. Missing workflow permissions (~25 alerts)
Added explicit `permissions` blocks to all workflows that lacked them, using minimal scopes (e.g. `contents: read`, `actions: read`) where appropriate.

**Files:** rust.yml, gauntlet.yml, sonar-scan.yml, nix-packages-test.yml, monitoring.yml, soak.yml, e2e_testnet_daily.yml, e2e_custom_cl.yml, upstream-tracker.yml, dependency-updates.yml, contract-release.yml, lint-gh-workflows.yml, integration-tests-publish.yml, relay.yml, open-pr.yml

### 2. Unpinned action tags (5 alerts)
Pinned third-party action references to full commit SHAs:
- `smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1` → `@ca71236c9f9e1358597795ef7d433dd3d3df8dfb`
- `smartcontractkit/tool-versions-to-env-action@v1.0.8` → `@aabd5efbaf28005284e846c5cf3a02f2cba2f4c2`

**Files:** rust.yml, gauntlet.yml, sonar-scan.yml

### 3. Excessive secrets exposure (2 alerts)
Replaced dynamic secret lookup `secrets[inputs.test_secrets_override_key]` with a fixed secret `E2E_TEST_SECRETS_OVERRIDE` to avoid exposing all org/repo secrets to the runner.

**Semantic change:** When custom test secrets are needed, the secret must now be named `E2E_TEST_SECRETS_OVERRIDE`. Set `test_secrets_override_key` to any non-empty value to enable.

**Files:** soak.yml, e2e_testnet_daily.yml

## Out of scope
- **Code-injection** alert in `.github/actions/setup-go/action.yml` — not modified (workflow-only scope per instructions).

## Verification
- `actionlint .github/workflows/` passes
- No behavior changes to workflows except the secrets override semantics noted above

Made with [Cursor](https://cursor.com)