### PR TITLE
fix(security): resolve CodeQL and Dependabot vulnerabilities

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: false

--- a/.github/workflows/api-diff.yml
+++ b/.github/workflows/api-diff.yml
@@ -3,7 +3,8 @@ name: Analyze API Changes
 on:
   pull_request: {}
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   root-module:

--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -1,4 +1,7 @@
 name: release_artifacts
+permissions:
+  contents: read
+
 on:
   push:
     tags:

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,4 +1,7 @@
 name: DependencyUpdater
+permissions:
+  contents: read
+
 on: 
   workflow_dispatch:
   schedule:

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -1,4 +1,7 @@
 name: e2e_tests_custom_cl
+permissions:
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/e2e_testnet_daily.yml
+++ b/.github/workflows/e2e_testnet_daily.yml
@@ -1,4 +1,7 @@
 name: e2e_testnet_daily
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/gauntlet.yml
+++ b/.github/workflows/gauntlet.yml
@@ -1,4 +1,6 @@
 name: gauntlet
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -1,6 +1,9 @@
 name: Integration Tests Publish
 # Publish the compiled integration tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -1,4 +1,7 @@
 name: Lint GH Workflows
+permissions:
+  contents: read
+
 on:
   pull_request:
 jobs:

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -1,4 +1,6 @@
 name: "Compile SOM"
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/nix-packages-test.yml
+++ b/.github/workflows/nix-packages-test.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:

--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -1,4 +1,6 @@
 name: Open PR With Signed Commit
+permissions:
+  contents: read
 
 on:
   workflow_call:

--- a/.github/workflows/publish-df-sdk.yml
+++ b/.github/workflows/publish-df-sdk.yml
@@ -1,4 +1,6 @@
 name: Publish Chainlink Data Feeds SDK Crate
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -1,4 +1,6 @@
 name: relay
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,7 @@
 name: rust
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:
@@ -154,7 +157,7 @@ jobs:
           docker load --input docker-build.tar
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: "./integration-tests/go.mod"
           check-latest: true
@@ -218,7 +221,7 @@ jobs:
         run: |
           docker load --input docker-build.tar
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: "./go.mod"
           check-latest: true

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,4 +1,6 @@
 name: Static analysis
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,9 @@
 # PRs with assignees are exempt from auto stale marking, it's the responsibility of the assignee to get the PR progressed either with review/merge or closure.
 name: Manage stale Issues and PRs
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 0 * * *" # Will be triggered every day at midnight UTC

--- a/.github/workflows/upstream-tracker.yml
+++ b/.github/workflows/upstream-tracker.yml
@@ -1,4 +1,6 @@
 name: UpstreamTracker
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   schedule:

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -7,7 +7,7 @@
     "@types/chai": "^4.2.22",
     "@types/mocha": "^10.0.0",
     "@types/node": "^14.14.37",
-    "bn.js": "^5.2.0",
+    "bn.js": "^5.2.3",
     "borsh": "^0.7.0",
     "chai": "^4.3.4",
     "ethereum-cryptography": "^3.2.0",


### PR DESCRIPTION
## Summary
- Added workflow permissions to 17+ GitHub Actions workflow files
- Pinned unpinned actions (setup-go) to commit SHAs
- Bumped bn.js to ^5.2.3 in contracts/package.json

## CodeQL Alerts Addressed
- Missing workflow permissions (~25 alerts)
- Unpinned action tags (3 alerts)

## Dependabot Alerts Addressed  
- bn.js (CVE-2026-2739): bumped to ^5.2.3

## Remaining (needs lockfile refresh locally)
- minimatch, ajv, axios, diff: need pnpm/yarn lockfile refresh
- Rust crates (borsh, ed25519-dalek, curve25519-dalek): need cargo update

## Unfixable (no patched version)
- bigint-buffer <= 1.1.5
- pion/dtls/v2 <= 2.2.12
- atty <= 0.2.14
- pkg <= 5.8.1

Made with [Cursor](https://cursor.com)