### PR TITLE
CCIP Solana - add e2e test workflow on CCIP related changes

### DIFF
--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -1,0 +1,138 @@
+name: CCIP Solana Messaging Tests
+
+on:
+  pull_request:
+    paths:
+      - 'pkg/solana/**'
+  workflow_dispatch:
+    inputs:
+      cl_branch_ref:
+        description: Chainlink repo branch to test against
+        required: true
+        default: develop
+        type: string
+
+concurrency:
+  group: ccip-solana-messaging-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  get-core-ref:
+    name: Get Core Ref
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      core-ref: ${{ steps.get-core-ref.outputs.core-ref || github.event.inputs.cl_branch_ref || 'develop' }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Get core ref
+        id: get-core-ref
+        uses: ./.github/actions/get-core-ref
+
+  ccip-messaging-tests:
+    name: CCIP Messaging (${{ matrix.test.name }})
+    needs: get-core-ref
+    runs-on: ubuntu-latest-8cores-32GB
+    permissions:
+      contents: read
+      actions: write # upload-artifact
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - name: EVM2Solana
+            slug: evm2solana
+            run: Test_CCIPMessaging_EVM2Solana
+            loopp: false
+          - name: EVM2Solana LOOPP
+            slug: evm2solana-loopp
+            run: Test_CCIPMessaging_EVM2Solana
+            loopp: true
+          - name: Solana2EVM
+            slug: solana2evm
+            run: Test_CCIPMessaging_Solana2EVM
+            loopp: false
+          - name: Solana2EVM LOOPP
+            slug: solana2evm-loopp
+            run: Test_CCIPMessaging_Solana2EVM
+            loopp: true
+          - name: Revert EVM2Solana LOOPP
+            slug: revert-evm2solana-loopp
+            run: Test_CCIPMessaging_Revert_EVM2Solana
+            loopp: true
+          - name: MultiExecReports EVM2Solana
+            slug: multiexec-evm2solana
+            run: Test_CCIPMessaging_MultiExecReports_EVM2Solana
+            loopp: false
+    steps:
+      - name: Checkout chainlink-solana
+        uses: actions/checkout@v4
+        with:
+          path: chainlink-solana
+
+      - name: Checkout chainlink
+        uses: actions/checkout@v4
+        with:
+          repository: smartcontractkit/chainlink
+          ref: ${{ needs.get-core-ref.outputs.core-ref }}
+          path: chainlink
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: chainlink/go.mod
+          check-latest: true
+
+      - name: Override chainlink-solana dependency
+        run: |
+          SOLANA_PATH="${{ github.workspace }}/chainlink-solana"
+          for dir in . deployment integration-tests; do
+            pushd "chainlink/$dir"
+            go mod edit -replace "github.com/smartcontractkit/chainlink-solana=${SOLANA_PATH}"
+            go mod edit -replace "github.com/smartcontractkit/chainlink-solana/contracts=${SOLANA_PATH}/contracts"
+            go mod tidy
+            popd
+          done
+
+      - name: Build LOOPP plugin binary
+        if: matrix.test.loopp
+        working-directory: chainlink-solana
+        run: go build -o "$GOPATH/bin/chainlink-solana" ./pkg/solana/cmd/chainlink-solana
+
+      - name: Run CCIP Messaging Test
+        working-directory: chainlink/integration-tests
+        env:
+          CL_SOLANA_CMD: ${{ matrix.test.loopp && 'chainlink-solana' || '' }}
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/ccip-test-artifacts"
+          cd smoke/ccip
+          set -o pipefail
+          go test -run "${{ matrix.test.run }}" -timeout 18m -test.parallel=4 -count=1 -json 2>&1 | tee "${GITHUB_WORKSPACE}/ccip-test-artifacts/gotest.json"
+
+      - name: Show Docker containers status
+        if: failure()
+        run: docker ps -a
+
+      - name: Upload test output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccip-messaging-${{ matrix.test.slug }}-${{ github.run_id }}
+          path: ccip-test-artifacts/
+          retention-days: 7
+          if-no-files-found: warn
+
+  check-results:
+    name: CCIP Solana Messaging Tests
+    if: always()
+    runs-on: ubuntu-latest
+    needs: ccip-messaging-tests
+    steps:
+      - name: Fail if tests were not successful
+        if: needs.ccip-messaging-tests.result == 'failure'
+        run: exit 1

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -105,7 +105,11 @@ jobs:
       - name: Build LOOPP plugin binary
         if: matrix.test.loopp
         working-directory: chainlink-solana
-        run: go build -o "$GOPATH/bin/chainlink-solana" ./pkg/solana/cmd/chainlink-solana
+        run: |
+          PLUGIN_BIN="$(go env GOPATH)/bin"
+          mkdir -p "$PLUGIN_BIN"
+          go build -o "$PLUGIN_BIN/chainlink-solana" ./pkg/solana/cmd/chainlink-solana
+          echo "$PLUGIN_BIN" >> "$GITHUB_PATH"
 
       - name: Run CCIP Messaging Test
         working-directory: chainlink/integration-tests

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -31,7 +31,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get core ref
         id: get-core-ref
@@ -74,12 +74,12 @@ jobs:
             loopp: false
     steps:
       - name: Checkout chainlink-solana
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: chainlink-solana
 
       - name: Checkout chainlink
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: smartcontractkit/chainlink
           ref: ${{ needs.get-core-ref.outputs.core-ref }}

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -31,7 +31,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Get core ref
         id: get-core-ref
@@ -74,12 +74,12 @@ jobs:
             loopp: false
     steps:
       - name: Checkout chainlink-solana
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           path: chainlink-solana
 
       - name: Checkout chainlink
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           repository: smartcontractkit/chainlink
           ref: ${{ needs.get-core-ref.outputs.core-ref }}

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -86,14 +86,14 @@ jobs:
           path: chainlink
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: chainlink/go.mod
           check-latest: true
 
       - name: Setup Postgres
         id: setup-postgres
-        uses: smartcontractkit/.github/actions/setup-postgres@13b05e8b4e11a8c4402f8034daaf9a4332032dc7 # v1.0.0
+        uses: smartcontractkit/.github/actions/setup-postgres@setup-postgres/v1
         with:
           image-tag: "16-alpine"
           tmpfs: "true"
@@ -145,7 +145,7 @@ jobs:
 
       - name: Upload test output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ccip-messaging-${{ matrix.test.slug }}-${{ github.run_id }}
           path: ccip-test-artifacts/

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -16,12 +16,15 @@ concurrency:
   group: ccip-solana-messaging-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   get-core-ref:
     name: Get Core Ref
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read # gh pr view for core ref: in PR body
     outputs:
       core-ref: ${{ steps.get-core-ref.outputs.core-ref || github.event.inputs.cl_branch_ref || 'develop' }}
     env:
@@ -132,6 +135,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs: ccip-messaging-tests
+    permissions: {} # aggregate job; no API access needed
     steps:
       - name: Fail if tests were not successful
         if: needs.ccip-messaging-tests.result == 'failure'

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -91,6 +91,23 @@ jobs:
           go-version-file: chainlink/go.mod
           check-latest: true
 
+      - name: Setup Postgres
+        id: setup-postgres
+        uses: smartcontractkit/.github/actions/setup-postgres@13b05e8b4e11a8c4402f8034daaf9a4332032dc7 # v1.0.0
+        with:
+          image-tag: "16-alpine"
+          tmpfs: "true"
+
+      - name: Prepare Test Schema
+        working-directory: chainlink
+        env:
+          CL_DATABASE_URL: ${{ steps.setup-postgres.outputs.database-url }}
+        run: |
+          unset GRAFANA_INTERNAL_TENANT_ID
+          unset GRAFANA_INTERNAL_BASIC_AUTH
+          unset GRAFANA_INTERNAL_HOST
+          go run ./core/store/cmd/preparetest
+
       - name: Override chainlink-solana dependency
         run: |
           SOLANA_PATH="${{ github.workspace }}/chainlink-solana"
@@ -114,6 +131,7 @@ jobs:
       - name: Run CCIP Messaging Test
         working-directory: chainlink/integration-tests
         env:
+          CL_DATABASE_URL: ${{ steps.setup-postgres.outputs.database-url }}
           CL_SOLANA_CMD: ${{ matrix.test.loopp && 'chainlink-solana' || '' }}
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/ccip-test-artifacts"

--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -478,6 +478,9 @@ func (lp *Service) run(ctx context.Context) (err error) {
 		return fmt.Errorf("error loading filters: %w", err)
 	}
 
+	// TODO: remove random log line after confirming CI test runs
+	lp.lggr.Debugw("we in the log poller and we running")
+
 	lastProcessedSlot, err := lp.getLastProcessedSlot(ctx)
 	if err != nil {
 		return fmt.Errorf("failed getting last processed slot: %w", err)

--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -478,9 +478,6 @@ func (lp *Service) run(ctx context.Context) (err error) {
 		return fmt.Errorf("error loading filters: %w", err)
 	}
 
-	// TODO: remove random log line after confirming CI test runs
-	lp.lggr.Debugw("we in the log poller and we running")
-
 	lastProcessedSlot, err := lp.getLastProcessedSlot(ctx)
 	if err != nil {
 		return fmt.Errorf("failed getting last processed slot: %w", err)


### PR DESCRIPTION
## What this adds

New workflow: `.github/workflows/ccip-solana-messaging.yml` — runs Chainlink’s in-memory **CCIP Solana messaging** integration tests when **`pkg/solana/**`** changes.

## How it works

- **Triggers:** PRs that touch `pkg/solana/**` 
- **Per matrix job:** Check out `chainlink-solana` (PR head) + `smartcontractkit/chainlink` 

## What it tests

From `chainlink/integration-tests/smoke/ccip/ccip_messaging_test.go`:

- `Test_CCIPMessaging_EVM2Solana` / **LOOPP**
- `Test_CCIPMessaging_Solana2EVM` / **LOOPP**
- `Test_CCIPMessaging_Revert_EVM2Solana` (**LOOPP**)
- `Test_CCIPMessaging_MultiExecReports_EVM2Solana`

Uses Chainlink’s **in-memory** CCIP stack (simulated EVM + Solana container), not the Solana OCR2 devenv.