### PR TITLE
Add KMS Signing Ability for DF Solana Contracts

### DIFF
--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/abstract/upgrade.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/abstract/upgrade.ts
@@ -1,6 +1,6 @@
 import { Result } from '@chainlink/gauntlet-core'
 import { logger, prompt } from '@chainlink/gauntlet-core/dist/utils'
-import { SolanaCommand, TransactionResponse, utils } from '@chainlink/gauntlet-solana'
+import { SolanaCommand, TransactionResponse } from '@chainlink/gauntlet-solana'
 import {
   AccountMeta,
   PublicKey,
@@ -70,10 +70,10 @@ export const makeUpgradeProgramCommand = (contractId: CONTRACT_LIST): SolanaCons
     }
 
     execute = async () => {
-      const rawTx = await this.makeRawTransaction(this.wallet.payer.publicKey)
+      const rawTx = await this.makeRawTransaction(this.wallet.publicKey)
       await prompt(`Continue upgrading the ${contractId} program?`)
       logger.loading('Upgrading program...')
-      const txhash = await this.provider.sendAndConfirm(utils.makeTx(rawTx), [this.wallet.payer])
+      const txhash = await this.signAndSendRawTx(rawTx)
       logger.success(`Program upgraded on tx ${txhash}`)
       return {
         responses: [

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/accessController/addAccess.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/accessController/addAccess.ts
@@ -27,21 +27,23 @@ export default class AddAccess extends SolanaCommand {
     const accessAddress = new PublicKey(this.flags.address)
 
     console.log(`Giving access to ${accessAddress}...`)
-    const tx = await program.rpc.addAccess({
-      accounts: {
+    const ix = await program.methods
+      .addAccess()
+      .accounts({
         state: state,
-        owner: this.wallet.payer.publicKey,
+        owner: this.wallet.publicKey,
         address: accessAddress,
-      },
-      signers: [this.wallet.payer],
-    })
+      })
+      .instruction()
 
-    logger.success(`Access given on tx ${tx}`)
+    const txhash = await this.sendTxWithIDL(this.signAndSendRawTx, accessController.idl)([ix])
+
+    logger.success(`Access given on tx ${txhash}`)
 
     return {
       responses: [
         {
-          tx: this.wrapResponse(tx, address, { state: state.toString() }),
+          tx: this.wrapResponse(txhash, address, { state: state.toString() }),
           contract: state.toString(),
         },
       ],

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/accessController/initialize.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/accessController/initialize.ts
@@ -1,6 +1,7 @@
 import { Result } from '@chainlink/gauntlet-core'
+import { logger } from '@chainlink/gauntlet-core/dist/utils'
 import { SolanaCommand, TransactionResponse } from '@chainlink/gauntlet-solana'
-import { Keypair, SystemProgram, SYSVAR_RENT_PUBKEY } from '@solana/web3.js'
+import { Keypair } from '@solana/web3.js'
 import { CONTRACT_LIST, getContract } from '../../../lib/contracts'
 
 export default class Initialize extends SolanaCommand {
@@ -19,24 +20,29 @@ export default class Initialize extends SolanaCommand {
     const program = this.loadProgram(accessController.idl, address)
 
     const state = Keypair.generate()
-    const owner = this.wallet.payer
 
-    console.log(`Initializing access controller contract with State at ${state.publicKey}...`)
-    const txHash = await program.rpc.initialize({
-      accounts: {
+    logger.loading(`Initializing access controller contract with State at ${state.publicKey}...`)
+
+    const createStateIx = await program.account.accessController.createInstruction(state)
+    const initIx = await program.methods
+      .initialize()
+      .accounts({
         state: state.publicKey,
-        owner: owner.publicKey,
-      },
-      signers: [owner, state],
-      instructions: [await program.account.accessController.createInstruction(state)],
-    })
+        owner: this.wallet.publicKey,
+      })
+      .instruction()
 
-    console.log('TX', txHash)
+    const txHash = await this.sendTxWithIDL(this.signAndSendRawTx, accessController.idl)(
+      [createStateIx, initIx],
+      [state],
+    )
 
-    console.log(`
+    logger.success(`TX ${txHash}`)
+
+    logger.info(`
     STATE ACCOUNTS:
       - State: ${state.publicKey}
-      - Owner: ${owner.publicKey}
+      - Owner: ${this.wallet.publicKey}
     `)
 
     return {

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/initialize.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/initialize.ts
@@ -1,7 +1,7 @@
 import { Result } from '@chainlink/gauntlet-core'
 import { SolanaCommand, TransactionResponse } from '@chainlink/gauntlet-solana'
 import { Keypair, PublicKey, TransactionInstruction, SystemProgram } from '@solana/web3.js'
-import { getOrCreateAssociatedTokenAccount } from '@solana/spl-token'
+import { getAssociatedTokenAddress, createAssociatedTokenAccountIdempotentInstruction } from '@solana/spl-token'
 import { CONTRACT_LIST, getContract } from '../../../lib/contracts'
 import { utils } from '@coral-xyz/anchor'
 import { logger, BN, prompt } from '@chainlink/gauntlet-core/dist/utils'
@@ -64,15 +64,14 @@ export default class Initialize extends SolanaCommand {
     const maxAnswer = new BN(input.maxAnswer)
     const transmissions = new PublicKey(input.transmissions)
 
-    const tokenVault = (
-      await getOrCreateAssociatedTokenAccount(
-        this.provider.connection,
-        this.wallet.payer,
-        linkPublicKey,
-        vaultAuthority,
-        true,
-      )
-    ).address
+    const tokenVault = await getAssociatedTokenAddress(linkPublicKey, vaultAuthority, true)
+
+    const createAtaIx = createAssociatedTokenAccountIdempotentInstruction(
+      signer,
+      tokenVault,
+      vaultAuthority,
+      linkPublicKey,
+    )
 
     const tx = await program.methods
       .initialize(minAnswer, maxAnswer)
@@ -105,7 +104,7 @@ export default class Initialize extends SolanaCommand {
       programId: program.programId,
     })
 
-    return [feedCreationInstruction, tx]
+    return [createAtaIx, feedCreationInstruction, tx]
   }
 
   execute = async () => {

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/setBillingAccessController.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/setBillingAccessController.ts
@@ -38,20 +38,22 @@ export default class SetBillingAccessController extends SolanaCommand {
     this.require(oldAC.toString() !== ac.toString(), 'New access controller is the same as existing access controller')
     await prompt(`Continue setting billing access controller?`)
 
-    const tx = await program.rpc.setBillingAccessController({
-      accounts: {
+    const ix = await program.methods
+      .setBillingAccessController()
+      .accounts({
         state: state,
-        authority: this.wallet.payer.publicKey,
+        authority: this.wallet.publicKey,
         accessController: ac,
-      },
-      signers: [this.wallet.payer],
-    })
+      })
+      .instruction()
 
-    logger.success(`Billing access controller set on tx ${tx}`)
+    const txhash = await this.sendTxWithIDL(this.signAndSendRawTx, ocr2.idl)([ix])
+
+    logger.success(`Billing access controller set on tx ${txhash}`)
     return {
       responses: [
         {
-          tx: this.wrapResponse(tx, state.toString()),
+          tx: this.wrapResponse(txhash, state.toString()),
           contract: state.toString(),
         },
       ],

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/setRequesterAccessController.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/ocr2/setRequesterAccessController.ts
@@ -38,20 +38,22 @@ export default class SetRequesterAccessController extends SolanaCommand {
     this.require(oldAC.toString() !== ac.toString(), 'New access controller is the same as existing access controller')
     await prompt(`Continue setting requester access controller?`)
 
-    const tx = await program.rpc.setRequesterAccessController({
-      accounts: {
+    const ix = await program.methods
+      .setRequesterAccessController()
+      .accounts({
         state: state,
-        authority: this.wallet.payer.publicKey,
+        authority: this.wallet.publicKey,
         accessController: ac,
-      },
-      signers: [this.wallet.payer],
-    })
+      })
+      .instruction()
 
-    logger.success(`Requester access controller set on tx ${tx}`)
+    const txhash = await this.sendTxWithIDL(this.signAndSendRawTx, ocr2.idl)([ix])
+
+    logger.success(`Requester access controller set on tx ${txhash}`)
     return {
       responses: [
         {
-          tx: this.wrapResponse(tx, state.toString()),
+          tx: this.wrapResponse(txhash, state.toString()),
           contract: state.toString(),
         },
       ],

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/store/initialize.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/store/initialize.ts
@@ -1,4 +1,5 @@
 import { Result } from '@chainlink/gauntlet-core'
+import { logger } from '@chainlink/gauntlet-core/dist/utils'
 import { SolanaCommand, TransactionResponse } from '@chainlink/gauntlet-solana'
 import { Keypair, PublicKey } from '@solana/web3.js'
 import BN from 'bn.js'
@@ -27,23 +28,25 @@ export default class Initialize extends SolanaCommand {
     const accessController = new PublicKey(this.flags.accessController)
     const owner = this.wallet.publicKey
 
-    console.log(`Initializing store contract with State at ${state.publicKey}...`)
-    const txHash = await program.rpc.initialize({
-      accounts: {
+    logger.loading(`Initializing store contract with State at ${state.publicKey}...`)
+
+    const createStateIx = await program.account.store.createInstruction(state)
+    const initIx = await program.methods
+      .initialize()
+      .accounts({
         store: state.publicKey,
         owner: owner,
         loweringAccessController: accessController,
-      },
-      signers: [state],
-      instructions: [await program.account.store.createInstruction(state)],
-    })
+      })
+      .instruction()
 
-    console.log('TX', txHash)
+    const txHash = await this.sendTxWithIDL(this.signAndSendRawTx, store.idl)([createStateIx, initIx], [state])
 
-    console.log(`
+    logger.success(`TX ${txHash}`)
+
+    logger.info(`
     STATE ACCOUNTS:
       - State: ${state.publicKey}
-      - Payer: ${this.provider.wallet.publicKey}
       - Owner: ${owner}
     `)
 

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/store/migrate.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/store/migrate.ts
@@ -1,6 +1,6 @@
 import { Result } from '@chainlink/gauntlet-core'
 import { logger, prompt } from '@chainlink/gauntlet-core/dist/utils'
-import { SolanaCommand, TransactionResponse, utils } from '@chainlink/gauntlet-solana'
+import { SolanaCommand, TransactionResponse } from '@chainlink/gauntlet-solana'
 import { AccountMeta, PublicKey, TransactionInstruction } from '@solana/web3.js'
 import { CONTRACT_LIST, getContract } from '../../../lib/contracts'
 import { makeRawUpgradeTransaction } from '../../abstract/upgrade'
@@ -53,9 +53,7 @@ export default class Migrate extends SolanaCommand {
 
   execute = async () => {
     const contract = getContract(CONTRACT_LIST.STORE, '')
-    const rawTx = await this.makeRawTransaction(this.wallet.payer.publicKey)
-    const tx = utils.makeTx(rawTx)
-    logger.debug(tx)
+    const rawTx = await this.makeRawTransaction(this.wallet.publicKey)
     logger.info(
       `Migrating Store program (${contract.programId.toString()})
     - store account: ${this.flags.state}
@@ -67,7 +65,7 @@ export default class Migrate extends SolanaCommand {
     await prompt(`Continue migrating?`)
 
     logger.loading('Sending tx...')
-    const txhash = await this.sendTx(tx, [this.wallet.payer], contract.idl)
+    const txhash = await this.sendTxWithIDL(this.signAndSendRawTx, contract.idl)(rawTx)
     logger.success(`Migrated on tx hash: ${txhash}`)
 
     return {

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/store/setLoweringAccessController.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/store/setLoweringAccessController.ts
@@ -38,20 +38,22 @@ export default class SetLoweringAccessController extends SolanaCommand {
     this.require(oldAC.toString() !== ac.toString(), 'New access controller is the same as existing access controller')
     await prompt(`Continue setting lowering access controller?`)
 
-    const tx = await program.rpc.setLoweringAccessController({
-      accounts: {
+    const ix = await program.methods
+      .setLoweringAccessController()
+      .accounts({
         store: state,
-        authority: this.wallet.payer.publicKey,
+        authority: this.wallet.publicKey,
         accessController: ac,
-      },
-      signers: [this.wallet.payer],
-    })
+      })
+      .instruction()
 
-    logger.success(`Access controller set on tx ${tx}`)
+    const txhash = await this.sendTxWithIDL(this.signAndSendRawTx, store.idl)([ix])
+
+    logger.success(`Access controller set on tx ${txhash}`)
     return {
       responses: [
         {
-          tx: this.wrapResponse(tx, state.toString()),
+          tx: this.wrapResponse(txhash, state.toString()),
           contract: state.toString(),
         },
       ],

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/store/setValidatorConfig.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/store/setValidatorConfig.ts
@@ -1,6 +1,6 @@
 import { Result } from '@chainlink/gauntlet-core'
 import { logger, BN } from '@chainlink/gauntlet-core/dist/utils'
-import { SolanaCommand, TransactionResponse, utils } from '@chainlink/gauntlet-solana'
+import { SolanaCommand, TransactionResponse } from '@chainlink/gauntlet-solana'
 import { PublicKey } from '@solana/web3.js'
 import { CONTRACT_LIST, getContract } from '../../../lib/contracts'
 
@@ -58,12 +58,10 @@ export default class SetValidatorConfig extends SolanaCommand {
 
   execute = async () => {
     const contract = getContract(CONTRACT_LIST.STORE, '')
-    const rawTx = await this.makeRawTransaction(this.wallet.payer.publicKey)
-    const tx = utils.makeTx(rawTx)
-    logger.debug(tx)
+    const rawTx = await this.makeRawTransaction(this.wallet.publicKey)
     logger.info(`Setting validator config on ${this.flags.feed.toString()}...`)
     logger.loading('Sending tx...')
-    const txhash = await this.sendTx(tx, [this.wallet.payer], contract.idl)
+    const txhash = await this.sendTxWithIDL(this.signAndSendRawTx, contract.idl)(rawTx)
     logger.success(`Validator config on tx ${txhash}`)
 
     return {

--- a/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/token/deploy.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/src/commands/contracts/token/deploy.ts
@@ -1,7 +1,15 @@
 import { Result } from '@chainlink/gauntlet-core'
 import { logger, prompt, BN } from '@chainlink/gauntlet-core/dist/utils'
 import { SolanaCommand, TransactionResponse } from '@chainlink/gauntlet-solana'
-import { createAssociatedTokenAccount, createMint, mintTo } from '@solana/spl-token'
+import {
+  createInitializeMintInstruction,
+  createAssociatedTokenAccountInstruction,
+  createMintToInstruction,
+  getAssociatedTokenAddress,
+  MINT_SIZE,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import { Keypair, SystemProgram } from '@solana/web3.js'
 import { TOKEN_DECIMALS } from '../../../lib/constants'
 import { CONTRACT_LIST } from '../../../lib/contracts'
 
@@ -15,44 +23,53 @@ export default class DeployToken extends SolanaCommand {
   }
 
   execute = async () => {
-    const mintAuthority = this.wallet.payer
+    const mintAuthority = this.wallet.publicKey
 
     logger.loading('Creating token...')
 
     const decimals = this.flags.decimals || TOKEN_DECIMALS
-    const token = await createMint(
-      this.provider.connection,
-      this.wallet.payer,
-      mintAuthority.publicKey,
-      this.wallet.payer.publicKey, // Freeze authority
-      decimals,
+    const mint = Keypair.generate()
+    const lamports = await this.provider.connection.getMinimumBalanceForRentExemption(MINT_SIZE)
+
+    const createMintIxs = [
+      SystemProgram.createAccount({
+        fromPubkey: this.wallet.publicKey,
+        newAccountPubkey: mint.publicKey,
+        space: MINT_SIZE,
+        lamports,
+        programId: TOKEN_PROGRAM_ID,
+      }),
+      createInitializeMintInstruction(mint.publicKey, decimals, mintAuthority, mintAuthority),
+    ]
+
+    const tokenVault = await getAssociatedTokenAddress(mint.publicKey, this.wallet.publicKey)
+    const createAtaIx = createAssociatedTokenAccountInstruction(
+      this.wallet.publicKey,
+      tokenVault,
+      this.wallet.publicKey,
+      mint.publicKey,
     )
 
+    await this.signAndSendRawTx([...createMintIxs, createAtaIx], [mint])
+
     const billion = BigInt(Math.pow(10, 9))
-    const tokenVault = await createAssociatedTokenAccount(
-      this.provider.connection,
-      this.wallet.payer,
-      token,
-      this.wallet.payer.publicKey,
-    )
     const mintAmount = billion * BigInt(Math.pow(10, decimals))
 
     await prompt(
       `Minting ${billion.toString()} token units, with ${decimals} decimals. Total ${mintAmount.toString()}. Continue?`,
     )
 
-    await mintTo(this.provider.connection, this.wallet.payer, token, tokenVault, mintAuthority, mintAmount)
-
-    // To disable minting https://github.com/solana-labs/solana-program-library/blob/36e886392b8c6619b275f6681aed6d8aae6e70f9/token/js/client/token.js#L985
+    const mintToIx = createMintToInstruction(mint.publicKey, tokenVault, mintAuthority, mintAmount)
+    await this.signAndSendRawTx([mintToIx])
 
     logger.info(`
       TOKEN:
-        - Address: ${token}
+        - Address: ${mint.publicKey}
       VAULT:
         - address: ${tokenVault.toString()}
       STATE ACCOUNTS:
-        - Mint Authority: ${mintAuthority.publicKey}
-        - Freeze Authority: ${this.wallet.payer.publicKey}
+        - Mint Authority: ${mintAuthority}
+        - Freeze Authority: ${mintAuthority}
     `)
 
     return {
@@ -61,8 +78,8 @@ export default class DeployToken extends SolanaCommand {
       },
       responses: [
         {
-          tx: { ...this.wrapResponse('', token.toString()), wait: async () => ({ success: true }) },
-          contract: token.toString(),
+          tx: { ...this.wrapResponse('', mint.publicKey.toString()), wait: async () => ({ success: true }) },
+          contract: mint.publicKey.toString(),
         },
       ],
     } as Result<TransactionResponse>

--- a/gauntlet/packages/gauntlet-solana-contracts/test/commands/contracts/contractCommands.test.ts
+++ b/gauntlet/packages/gauntlet-solana-contracts/test/commands/contracts/contractCommands.test.ts
@@ -1,0 +1,304 @@
+import { PublicKey, Keypair } from '@solana/web3.js'
+
+// Helper to create a mock program with chainable methods builder
+const createMockProgram = (instructionResult = {}) => {
+  const mockInstruction = jest.fn().mockResolvedValue(instructionResult)
+  const mockAccounts = jest.fn().mockReturnValue({ instruction: mockInstruction })
+  const createMethodChain = () => ({
+    accounts: mockAccounts,
+  })
+  return {
+    methods: {
+      addAccess: jest.fn().mockReturnValue(createMethodChain()),
+      initialize: jest.fn().mockReturnValue(createMethodChain()),
+      setBillingAccessController: jest.fn().mockReturnValue(createMethodChain()),
+      setRequesterAccessController: jest.fn().mockReturnValue(createMethodChain()),
+      setLoweringAccessController: jest.fn().mockReturnValue(createMethodChain()),
+    },
+    account: {
+      accessController: {
+        createInstruction: jest.fn().mockResolvedValue(instructionResult),
+      },
+      state: {
+        fetch: jest.fn().mockResolvedValue({
+          config: {
+            billingAccessController: new PublicKey(new Uint8Array(32).fill(2)),
+            requesterAccessController: new PublicKey(new Uint8Array(32).fill(3)),
+          },
+        }),
+        size: 1000,
+      },
+      store: {
+        fetch: jest.fn().mockResolvedValue({
+          loweringAccessController: new PublicKey(new Uint8Array(32).fill(4)),
+        }),
+      },
+    },
+    programId: new PublicKey(new Uint8Array(32).fill(5)),
+    idl: { errors: [] },
+    _mockInstruction: mockInstruction,
+    _mockAccounts: mockAccounts,
+  }
+}
+
+// Mock gauntlet-core
+jest.mock('@chainlink/gauntlet-core/dist/utils', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    loading: jest.fn(),
+    success: jest.fn(),
+    debug: jest.fn(),
+    log: jest.fn(),
+    line: jest.fn(),
+  },
+  assertions: {
+    assert: jest.fn((condition: boolean, message: string) => {
+      if (!condition) throw new Error(message)
+    }),
+    expect: jest.fn(),
+  },
+  prompt: jest.fn().mockResolvedValue(undefined),
+  BN: jest.requireActual('bn.js'),
+}))
+
+jest.mock('@chainlink/gauntlet-core/dist/lib/args', () => ({
+  boolean: jest.fn((val: string | undefined) => val === 'true'),
+}))
+
+// Mock contracts
+const mockProgramId = new PublicKey(new Uint8Array(32).fill(10))
+jest.mock('../../../src/lib/contracts', () => ({
+  CONTRACT_LIST: {
+    ACCESS_CONTROLLER: 'access_controller',
+    OCR_2: 'ocr_2',
+    STORE: 'store',
+    TOKEN: 'token',
+  },
+  getContract: jest.fn().mockReturnValue({
+    programId: new PublicKey(new Uint8Array(32).fill(10)),
+    idl: { errors: [] },
+  }),
+}))
+
+// Mock gauntlet-solana SolanaCommand
+const mockSignAndSendRawTx = jest.fn().mockResolvedValue('mock-tx-hash')
+const mockSendTxWithIDL = jest.fn().mockReturnValue(jest.fn().mockResolvedValue('mock-tx-hash'))
+const mockWrapResponse = jest.fn().mockImplementation((hash, address, states) => ({
+  hash,
+  address,
+  states,
+  wait: jest.fn().mockResolvedValue({ success: true }),
+}))
+const mockLoadProgram = jest.fn()
+
+jest.mock('@chainlink/gauntlet-solana', () => {
+  class MockSolanaCommand {
+    flags: any
+    args: any
+    wallet: any
+    provider: any
+    middlewares: any[]
+    signAndSendRawTx: any
+    sendTxWithIDL: any
+    wrapResponse: any
+    loadProgram: any
+
+    constructor(flags: any, args: any) {
+      this.flags = flags || {}
+      this.args = args || []
+      this.middlewares = []
+      this.wallet = {
+        publicKey: new PublicKey(new Uint8Array(32).fill(1)),
+      }
+      this.provider = {
+        connection: {
+          getMinimumBalanceForRentExemption: jest.fn().mockResolvedValue(1000000),
+        },
+      }
+      this.signAndSendRawTx = mockSignAndSendRawTx
+      this.sendTxWithIDL = mockSendTxWithIDL
+      this.wrapResponse = mockWrapResponse
+      this.loadProgram = mockLoadProgram
+    }
+
+    use() {}
+
+    require(condition: boolean, message: string) {
+      if (!condition) throw new Error(message)
+    }
+
+    requireFlag(flag: string, message: string) {
+      if (!this.flags.help && !this.flags[flag]) throw new Error(message)
+    }
+  }
+
+  return {
+    SolanaCommand: MockSolanaCommand,
+    TransactionResponse: {},
+  }
+})
+
+describe('AddAccess command', () => {
+  let AddAccess: any
+  let mockProgram: ReturnType<typeof createMockProgram>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockProgram = createMockProgram({ programId: mockProgramId, keys: [], data: Buffer.from([]) })
+    mockLoadProgram.mockReturnValue(mockProgram)
+    jest.isolateModules(() => {
+      AddAccess = require('../../../src/commands/contracts/accessController/addAccess').default
+    })
+  })
+
+  it('has correct static properties', () => {
+    expect(AddAccess.id).toBe('access_controller:add_access')
+    expect(AddAccess.category).toBe('access_controller')
+  })
+
+  it('constructor requires state and address flags', () => {
+    expect(() => new AddAccess({}, [])).toThrow()
+    expect(() => new AddAccess({ state: 'abc' }, [])).toThrow()
+  })
+
+  it('execute calls program.methods.addAccess with correct accounts', async () => {
+    const stateKey = 'EPRYwrb1Dwi8VT5SutS4vYNdF8HqvE7QwvqeCCwHdVLC'
+    const accessAddress = '9ohrpVDVNKKW1LipksFrmq6wa1oLLYL9QSoYUn4pAQ2v'
+    const cmd = new AddAccess({ state: stateKey, address: accessAddress }, [])
+    const result = await cmd.execute()
+
+    expect(mockLoadProgram).toHaveBeenCalled()
+    expect(mockProgram.methods.addAccess).toHaveBeenCalled()
+    expect(mockProgram._mockAccounts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: new PublicKey(stateKey),
+        owner: cmd.wallet.publicKey,
+        address: new PublicKey(accessAddress),
+      }),
+    )
+    expect(mockSendTxWithIDL).toHaveBeenCalled()
+    expect(result.responses).toHaveLength(1)
+  })
+})
+
+describe('SetBillingAccessController command', () => {
+  let SetBillingAC: any
+  let mockProgram: ReturnType<typeof createMockProgram>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockProgram = createMockProgram()
+    mockLoadProgram.mockReturnValue(mockProgram)
+    jest.isolateModules(() => {
+      SetBillingAC = require('../../../src/commands/contracts/ocr2/setBillingAccessController').default
+    })
+  })
+
+  it('has correct static properties', () => {
+    expect(SetBillingAC.id).toBe('ocr2:set_billing_access_controller')
+    expect(SetBillingAC.category).toBe('ocr_2')
+  })
+
+  it('execute calls program.methods.setBillingAccessController', async () => {
+    const stateAddr = Keypair.generate().publicKey.toString()
+    const acAddr = Keypair.generate().publicKey.toString()
+    const cmd = new SetBillingAC({ accessController: acAddr }, [stateAddr])
+    const result = await cmd.execute()
+
+    expect(mockProgram.methods.setBillingAccessController).toHaveBeenCalled()
+    expect(mockProgram._mockAccounts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: new PublicKey(stateAddr),
+        authority: cmd.wallet.publicKey,
+        accessController: new PublicKey(acAddr),
+      }),
+    )
+    expect(mockSendTxWithIDL).toHaveBeenCalled()
+    expect(result.responses).toHaveLength(1)
+  })
+
+  it('throws when new AC equals old AC', async () => {
+    const stateAddr = Keypair.generate().publicKey.toString()
+    const oldAC = new PublicKey(new Uint8Array(32).fill(2))
+    const cmd = new SetBillingAC({ accessController: oldAC.toString() }, [stateAddr])
+    await expect(cmd.execute()).rejects.toThrow('same as existing')
+  })
+})
+
+describe('SetRequesterAccessController command', () => {
+  let SetRequesterAC: any
+  let mockProgram: ReturnType<typeof createMockProgram>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockProgram = createMockProgram()
+    mockLoadProgram.mockReturnValue(mockProgram)
+    jest.isolateModules(() => {
+      SetRequesterAC = require('../../../src/commands/contracts/ocr2/setRequesterAccessController').default
+    })
+  })
+
+  it('execute calls program.methods.setRequesterAccessController', async () => {
+    const stateAddr = Keypair.generate().publicKey.toString()
+    const acAddr = Keypair.generate().publicKey.toString()
+    const cmd = new SetRequesterAC({ accessController: acAddr }, [stateAddr])
+    const result = await cmd.execute()
+
+    expect(mockProgram.methods.setRequesterAccessController).toHaveBeenCalled()
+    expect(mockProgram._mockAccounts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: new PublicKey(stateAddr),
+        authority: cmd.wallet.publicKey,
+        accessController: new PublicKey(acAddr),
+      }),
+    )
+    expect(result.responses).toHaveLength(1)
+  })
+
+  it('throws when new AC equals old AC', async () => {
+    const stateAddr = Keypair.generate().publicKey.toString()
+    const oldAC = new PublicKey(new Uint8Array(32).fill(3))
+    const cmd = new SetRequesterAC({ accessController: oldAC.toString() }, [stateAddr])
+    await expect(cmd.execute()).rejects.toThrow('same as existing')
+  })
+})
+
+describe('SetLoweringAccessController command', () => {
+  let SetLoweringAC: any
+  let mockProgram: ReturnType<typeof createMockProgram>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockProgram = createMockProgram()
+    mockLoadProgram.mockReturnValue(mockProgram)
+    jest.isolateModules(() => {
+      SetLoweringAC = require('../../../src/commands/contracts/store/setLoweringAccessController').default
+    })
+  })
+
+  it('execute calls program.methods.setLoweringAccessController', async () => {
+    const stateAddr = Keypair.generate().publicKey.toString()
+    const acAddr = Keypair.generate().publicKey.toString()
+    const cmd = new SetLoweringAC({ accessController: acAddr }, [stateAddr])
+    const result = await cmd.execute()
+
+    expect(mockProgram.methods.setLoweringAccessController).toHaveBeenCalled()
+    expect(mockProgram._mockAccounts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        store: new PublicKey(stateAddr),
+        authority: cmd.wallet.publicKey,
+        accessController: new PublicKey(acAddr),
+      }),
+    )
+    expect(result.responses).toHaveLength(1)
+  })
+
+  it('throws when new AC equals old AC', async () => {
+    const stateAddr = Keypair.generate().publicKey.toString()
+    const oldAC = new PublicKey(new Uint8Array(32).fill(4))
+    const cmd = new SetLoweringAC({ accessController: oldAC.toString() }, [stateAddr])
+    await expect(cmd.execute()).rejects.toThrow('same as existing')
+  })
+})

--- a/gauntlet/packages/gauntlet-solana/package.json
+++ b/gauntlet/packages/gauntlet-solana/package.json
@@ -25,6 +25,7 @@
     "bundle": "yarn build && pkg ."
   },
   "dependencies": {
+    "@aws-sdk/client-kms": "^3.540.0",
     "@chainlink/gauntlet-core": "0.1.2",
     "@ledgerhq/hw-app-solana": "^6.20.0",
     "@ledgerhq/hw-transport-node-hid": "^6.20.0",

--- a/gauntlet/packages/gauntlet-solana/src/commands/kmsWallet.test.ts
+++ b/gauntlet/packages/gauntlet-solana/src/commands/kmsWallet.test.ts
@@ -1,0 +1,140 @@
+import { PublicKey, Transaction, VersionedTransaction, VersionedMessage, Keypair } from '@solana/web3.js'
+import { KMSClient, GetPublicKeyCommand, SignCommand } from '@aws-sdk/client-kms'
+import { KMSWallet } from './kmsWallet'
+import { WalletTypes } from './wallet'
+
+// Mock AWS SDK
+jest.mock('@aws-sdk/client-kms', () => {
+  const mockSend = jest.fn()
+  return {
+    KMSClient: jest.fn().mockImplementation(() => ({ send: mockSend })),
+    GetPublicKeyCommand: jest.fn(),
+    SignCommand: jest.fn(),
+    SigningAlgorithmSpec: { ED25519_SHA_512: 'ED25519_SHA_512' },
+    __mockSend: mockSend,
+  }
+})
+
+// Mock logger
+jest.mock('@chainlink/gauntlet-core/dist/utils', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+const { __mockSend: mockSend } = jest.requireMock('@aws-sdk/client-kms')
+
+// DER-encoded Ed25519 SubjectPublicKeyInfo: 12-byte header + 32-byte raw key
+const makeValidDerKey = (rawKey: Uint8Array): Uint8Array => {
+  const derHeader = new Uint8Array([0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00])
+  const full = new Uint8Array(44)
+  full.set(derHeader, 0)
+  full.set(rawKey, 12)
+  return full
+}
+
+describe('KMSWallet', () => {
+  const testKeyId = 'arn:aws:kms:us-east-1:123456789:key/test-key'
+  const testRegion = 'us-east-1'
+  const rawPubKey = Keypair.generate().publicKey.toBytes()
+  const validDerKey = makeValidDerKey(rawPubKey)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('create', () => {
+    it('creates wallet with valid Ed25519 KMS key', async () => {
+      mockSend.mockResolvedValueOnce({ PublicKey: validDerKey })
+
+      const wallet = await KMSWallet.create(testKeyId, testRegion)
+
+      expect(wallet.publicKey).toEqual(new PublicKey(rawPubKey))
+      expect(wallet.type()).toBe(WalletTypes.KMS)
+      expect(KMSClient).toHaveBeenCalledWith({ region: testRegion })
+    })
+
+    it('throws when GetPublicKey returns no key', async () => {
+      mockSend.mockResolvedValueOnce({ PublicKey: undefined })
+
+      await expect(KMSWallet.create(testKeyId, testRegion)).rejects.toThrow('Failed to retrieve public key from KMS')
+    })
+
+    it('throws when key is wrong size', async () => {
+      // Only 20 bytes total — too short for 12 header + 32 key
+      mockSend.mockResolvedValueOnce({ PublicKey: new Uint8Array(20) })
+
+      await expect(KMSWallet.create(testKeyId, testRegion)).rejects.toThrow('Expected 32-byte Ed25519 public key')
+    })
+  })
+
+  describe('signTransaction', () => {
+    let wallet: KMSWallet
+
+    beforeEach(async () => {
+      mockSend.mockResolvedValueOnce({ PublicKey: validDerKey })
+      wallet = await KMSWallet.create(testKeyId, testRegion)
+    })
+
+    it('signs a legacy transaction', async () => {
+      const tx = new Transaction()
+      tx.recentBlockhash = 'GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi'
+      tx.feePayer = wallet.publicKey
+
+      const fakeSignature = new Uint8Array(64).fill(1)
+      mockSend.mockResolvedValueOnce({ Signature: fakeSignature })
+
+      const signed = await wallet.signTransaction(tx)
+      expect(signed.signatures).toHaveLength(1)
+      expect(SignCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          KeyId: testKeyId,
+          MessageType: 'RAW',
+          SigningAlgorithm: 'ED25519_SHA_512',
+        }),
+      )
+    })
+
+    it('throws when KMS returns no signature', async () => {
+      const tx = new Transaction()
+      tx.recentBlockhash = 'GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi'
+      tx.feePayer = wallet.publicKey
+
+      mockSend.mockResolvedValueOnce({ Signature: undefined })
+
+      await expect(wallet.signTransaction(tx)).rejects.toThrow('KMS signing failed: no signature returned')
+    })
+  })
+
+  describe('signAllTransactions', () => {
+    it('signs multiple transactions sequentially', async () => {
+      mockSend.mockResolvedValueOnce({ PublicKey: validDerKey })
+      const wallet = await KMSWallet.create(testKeyId, testRegion)
+
+      const fakeSignature = new Uint8Array(64).fill(1)
+      mockSend.mockResolvedValue({ Signature: fakeSignature })
+
+      const tx1 = new Transaction()
+      tx1.recentBlockhash = 'GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi'
+      tx1.feePayer = wallet.publicKey
+
+      const tx2 = new Transaction()
+      tx2.recentBlockhash = 'GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi'
+      tx2.feePayer = wallet.publicKey
+
+      const signed = await wallet.signAllTransactions([tx1, tx2])
+      expect(signed).toHaveLength(2)
+    })
+  })
+
+  describe('payer', () => {
+    it('throws when accessing payer', async () => {
+      mockSend.mockResolvedValueOnce({ PublicKey: validDerKey })
+      const wallet = await KMSWallet.create(testKeyId, testRegion)
+
+      expect(() => wallet.payer).toThrow('Payer method not available on KMS wallet')
+    })
+  })
+})

--- a/gauntlet/packages/gauntlet-solana/src/commands/kmsWallet.ts
+++ b/gauntlet/packages/gauntlet-solana/src/commands/kmsWallet.ts
@@ -1,0 +1,92 @@
+import { PublicKey, Transaction, VersionedTransaction, Keypair } from '@solana/web3.js'
+import { KMSClient, GetPublicKeyCommand, SignCommand, SigningAlgorithmSpec } from '@aws-sdk/client-kms'
+import { logger } from '@chainlink/gauntlet-core/dist/utils'
+import { SolanaWallet, WalletTypes } from './wallet'
+
+const isVersionedTransaction = (tx: Transaction | VersionedTransaction): tx is VersionedTransaction => {
+  return 'version' in tx
+}
+
+// Ed25519 DER-encoded SubjectPublicKeyInfo (RFC 8410) has a fixed 12-byte header
+// followed by the raw 32-byte public key.
+const DER_ED25519_PREFIX_LENGTH = 12
+const ED25519_PUBKEY_LENGTH = 32
+
+export class KMSWallet extends SolanaWallet {
+  publicKey: PublicKey
+  private readonly client: KMSClient
+  private readonly keyId: string
+
+  private constructor(client: KMSClient, keyId: string, publicKey: PublicKey) {
+    super()
+    this.client = client
+    this.keyId = keyId
+    this.publicKey = publicKey
+  }
+
+  static readonly create = async (keyId: string, keyRegion: string): Promise<KMSWallet> => {
+    const client = new KMSClient({ region: keyRegion })
+
+    const response = await client.send(new GetPublicKeyCommand({ KeyId: keyId }))
+    if (!response.PublicKey) {
+      throw new Error('Failed to retrieve public key from KMS')
+    }
+
+    const rawKey = new Uint8Array(response.PublicKey).slice(
+      DER_ED25519_PREFIX_LENGTH,
+      DER_ED25519_PREFIX_LENGTH + ED25519_PUBKEY_LENGTH,
+    )
+    if (rawKey.length !== ED25519_PUBKEY_LENGTH) {
+      throw new Error(
+        `Expected ${ED25519_PUBKEY_LENGTH}-byte Ed25519 public key, got ${rawKey.length} bytes. ` +
+          'Ensure the KMS key uses the ECC_EDWARDS_ED25519 key spec.',
+      )
+    }
+
+    const publicKey = new PublicKey(rawKey)
+    logger.info(`KMS: Using ${publicKey.toString()}, keyId: ${keyId}`)
+    return new KMSWallet(client, keyId, publicKey)
+  }
+
+  signTransaction = async <T extends Transaction | VersionedTransaction>(tx: T): Promise<T> => {
+    logger.info('KMS: Request to sign transaction')
+
+    let msg: Buffer
+    if (isVersionedTransaction(tx)) {
+      msg = Buffer.from(tx.message.serialize())
+    } else {
+      msg = tx.serializeMessage()
+    }
+
+    const response = await this.client.send(
+      new SignCommand({
+        KeyId: this.keyId,
+        Message: msg,
+        MessageType: 'RAW',
+        SigningAlgorithm: SigningAlgorithmSpec.ED25519_SHA_512,
+      }),
+    )
+
+    if (!response.Signature) {
+      throw new Error('KMS signing failed: no signature returned')
+    }
+
+    tx.addSignature(this.publicKey, Buffer.from(response.Signature))
+    return tx
+  }
+
+  signAllTransactions = async <T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]> => {
+    logger.warn('Signing multiple transactions with KMS')
+    const signed: T[] = []
+    for (const tx of txs) {
+      signed.push(await this.signTransaction(tx))
+    }
+    return signed
+  }
+
+  get payer(): Keypair {
+    throw new Error('Payer method not available on KMS wallet')
+  }
+
+  type = () => WalletTypes.KMS
+}

--- a/gauntlet/packages/gauntlet-solana/src/commands/middlewares.test.ts
+++ b/gauntlet/packages/gauntlet-solana/src/commands/middlewares.test.ts
@@ -1,0 +1,144 @@
+import { Keypair, PublicKey } from '@solana/web3.js'
+import { WalletTypes } from './wallet'
+
+// Mock KMS wallet
+const mockKmsPublicKey = new PublicKey(new Uint8Array(32).fill(3))
+jest.mock('./kmsWallet', () => ({
+  KMSWallet: {
+    create: jest.fn().mockResolvedValue({
+      publicKey: new PublicKey(new Uint8Array(32).fill(3)),
+      type: () => 'kms',
+      signTransaction: jest.fn(),
+    }),
+  },
+}))
+
+// Mock Ledger dependencies
+jest.mock('@ledgerhq/hw-transport-node-hid', () => ({
+  default: { create: jest.fn() },
+}))
+jest.mock('@ledgerhq/hw-app-solana', () => {
+  return jest.fn()
+})
+
+// Mock wallet module — use inline values to avoid hoisting issues
+jest.mock('./wallet', () => ({
+  ...jest.requireActual('./wallet'),
+  LocalWallet: {
+    create: jest.fn().mockResolvedValue({
+      publicKey: new PublicKey(new Uint8Array(32).fill(1)),
+      type: () => 'local',
+      signTransaction: jest.fn(),
+    }),
+  },
+  LedgerWallet: {
+    create: jest.fn().mockResolvedValue({
+      publicKey: new PublicKey(new Uint8Array(32).fill(2)),
+      type: () => 'ledger',
+      signTransaction: jest.fn(),
+    }),
+  },
+}))
+
+// Mock logger/assertions
+jest.mock('@chainlink/gauntlet-core/dist/utils', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  assertions: {
+    assert: jest.fn((condition: boolean, message: string) => {
+      if (!condition) throw new Error(message)
+    }),
+  },
+}))
+
+jest.mock('@chainlink/gauntlet-core/dist/lib/args', () => ({
+  boolean: jest.fn((val: string | undefined) => val === 'true'),
+}))
+
+// Mock AnchorProvider
+jest.mock('@coral-xyz/anchor', () => ({
+  AnchorProvider: jest.fn().mockImplementation(() => ({})),
+}))
+
+import { withWallet } from './middlewares'
+import { KMSWallet } from './kmsWallet'
+import { LocalWallet, LedgerWallet } from './wallet'
+
+describe('withWallet middleware', () => {
+  const originalEnv = process.env
+  let mockCommand: any
+  let mockNext: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    mockNext = jest.fn()
+    mockCommand = {
+      flags: {},
+      wallet: null,
+    }
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('loads KMS wallet when --withKms flag is set', async () => {
+    mockCommand.flags = { withKms: true }
+    process.env.KMS_KEY_ID = 'test-key-id'
+    process.env.KMS_KEY_REGION = 'us-east-1'
+
+    await withWallet(mockCommand, mockNext)
+
+    expect(KMSWallet.create).toHaveBeenCalledWith('test-key-id', 'us-east-1')
+    expect(mockCommand.wallet).toBeDefined()
+    expect(mockNext).toHaveBeenCalled()
+  })
+
+  it('loads KMS wallet when WITH_KMS env var is set', async () => {
+    process.env.WITH_KMS = 'true'
+    process.env.KMS_KEY_ID = 'test-key-id'
+    process.env.KMS_KEY_REGION = 'us-east-1'
+
+    await withWallet(mockCommand, mockNext)
+
+    expect(KMSWallet.create).toHaveBeenCalledWith('test-key-id', 'us-east-1')
+    expect(mockNext).toHaveBeenCalled()
+  })
+
+  it('throws when KMS_KEY_ID is missing', async () => {
+    mockCommand.flags = { withKms: true }
+    process.env.KMS_KEY_REGION = 'us-east-1'
+    delete process.env.KMS_KEY_ID
+
+    await expect(withWallet(mockCommand, mockNext)).rejects.toThrow('Missing KMS_KEY_ID')
+  })
+
+  it('throws when KMS_KEY_REGION is missing', async () => {
+    mockCommand.flags = { withKms: true }
+    process.env.KMS_KEY_ID = 'test-key-id'
+    delete process.env.KMS_KEY_REGION
+
+    await expect(withWallet(mockCommand, mockNext)).rejects.toThrow('Missing KMS_KEY_REGION')
+  })
+
+  it('loads Local wallet when no flags are set', async () => {
+    const keypair = Keypair.generate()
+    process.env.PRIVATE_KEY = JSON.stringify(Array.from(keypair.secretKey))
+
+    await withWallet(mockCommand, mockNext)
+
+    expect(LocalWallet.create).toHaveBeenCalled()
+    expect(mockNext).toHaveBeenCalled()
+  })
+
+  it('prioritizes Ledger over KMS', async () => {
+    mockCommand.flags = { withLedger: true, withKms: true }
+    process.env.KMS_KEY_ID = 'test-key-id'
+    process.env.KMS_KEY_REGION = 'us-east-1'
+
+    await withWallet(mockCommand, mockNext)
+
+    expect(LedgerWallet.create).toHaveBeenCalled()
+    expect(KMSWallet.create).not.toHaveBeenCalled()
+  })
+})

--- a/gauntlet/packages/gauntlet-solana/src/commands/middlewares.ts
+++ b/gauntlet/packages/gauntlet-solana/src/commands/middlewares.ts
@@ -6,6 +6,7 @@ import { Connection, Keypair } from '@solana/web3.js'
 import { DEFAULT_DERIVATION_PATH } from '../lib/constants'
 import SolanaCommand from './internal/solana'
 import { LedgerWallet, LocalWallet } from './wallet'
+import { KMSWallet } from './kmsWallet'
 
 const isValidURL = (url: string) => {
   const pattern = new RegExp('^(https?|wss?):/')
@@ -33,6 +34,17 @@ export const withWallet: Middleware = async (c: SolanaCommand, next: Next) => {
     logger.info('Loading Ledger wallet')
     const path = c.flags.ledgerPath || DEFAULT_DERIVATION_PATH
     c.wallet = await LedgerWallet.create(path)
+    console.info(`Operator address is ${c.wallet.publicKey}`)
+    return next()
+  }
+
+  if (c.flags.withKms || boolean(process.env.WITH_KMS)) {
+    logger.info('Loading KMS wallet')
+    const keyId = process.env.KMS_KEY_ID
+    const keyRegion = process.env.KMS_KEY_REGION
+    assertions.assert(!!keyId, 'Missing KMS_KEY_ID environment variable')
+    assertions.assert(!!keyRegion, 'Missing KMS_KEY_REGION environment variable')
+    c.wallet = await KMSWallet.create(keyId, keyRegion)
     console.info(`Operator address is ${c.wallet.publicKey}`)
     return next()
   }

--- a/gauntlet/packages/gauntlet-solana/src/commands/wallet.ts
+++ b/gauntlet/packages/gauntlet-solana/src/commands/wallet.ts
@@ -7,6 +7,7 @@ import { logger } from '@chainlink/gauntlet-core/dist/utils'
 export enum WalletTypes {
   LOCAL = 'local',
   LEDGER = 'ledger',
+  KMS = 'kms',
 }
 
 export abstract class SolanaWallet {

--- a/gauntlet/packages/gauntlet-solana/src/index.ts
+++ b/gauntlet/packages/gauntlet-solana/src/index.ts
@@ -7,5 +7,17 @@ import * as contracts from './lib/contracts'
 import * as utils from './lib/utils'
 import * as feeUtils from './lib/feeUtils'
 import * as provider from './lib/provider'
+import { KMSWallet } from './commands/kmsWallet'
 
-export { SolanaCommand, SendRawTx, waitExecute, TransactionResponse, constants, contracts, utils, provider, feeUtils }
+export {
+  SolanaCommand,
+  SendRawTx,
+  waitExecute,
+  TransactionResponse,
+  constants,
+  contracts,
+  utils,
+  provider,
+  feeUtils,
+  KMSWallet,
+}

--- a/gauntlet/yarn.lock
+++ b/gauntlet/yarn.lock
@@ -2,6 +2,400 @@
 # yarn lockfile v1
 
 
+"@aws-crypto/sha256-browser@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz#153895ef1dba6f9fce38af550e0ef58988eb649e"
+  integrity sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==
+  dependencies:
+    "@aws-crypto/sha256-js" "^5.2.0"
+    "@aws-crypto/supports-web-crypto" "^5.2.0"
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz#c4fdb773fdbed9a664fc1a95724e206cf3860042"
+  integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/supports-web-crypto@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz#a1e399af29269be08e695109aa15da0a07b5b5fb"
+  integrity sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-crypto/util@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-5.2.0.tgz#71284c9cffe7927ddadac793c14f14886d3876da"
+  integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
+  dependencies:
+    "@aws-sdk/types" "^3.222.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/client-kms@^3.540.0":
+  version "3.1020.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-kms/-/client-kms-3.1020.0.tgz#1ae7742bcd89266c8f3fc16ea1c76d1f9f44afe4"
+  integrity sha512-9Or4/EOiApYu3qka/VSc+P0EZji7wPyBo5s/3FZbVoIVVwikN7rzDZbMfSY/utnFqZExt9gS107ZzFoRhnQzsQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/credential-provider-node" "^3.972.28"
+    "@aws-sdk/middleware-host-header" "^3.972.8"
+    "@aws-sdk/middleware-logger" "^3.972.8"
+    "@aws-sdk/middleware-recursion-detection" "^3.972.9"
+    "@aws-sdk/middleware-user-agent" "^3.972.27"
+    "@aws-sdk/region-config-resolver" "^3.972.10"
+    "@aws-sdk/types" "^3.973.6"
+    "@aws-sdk/util-endpoints" "^3.996.5"
+    "@aws-sdk/util-user-agent-browser" "^3.972.8"
+    "@aws-sdk/util-user-agent-node" "^3.973.13"
+    "@smithy/config-resolver" "^4.4.13"
+    "@smithy/core" "^3.23.13"
+    "@smithy/fetch-http-handler" "^5.3.15"
+    "@smithy/hash-node" "^4.2.12"
+    "@smithy/invalid-dependency" "^4.2.12"
+    "@smithy/middleware-content-length" "^4.2.12"
+    "@smithy/middleware-endpoint" "^4.4.28"
+    "@smithy/middleware-retry" "^4.4.45"
+    "@smithy/middleware-serde" "^4.2.16"
+    "@smithy/middleware-stack" "^4.2.12"
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/node-http-handler" "^4.5.1"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/smithy-client" "^4.12.8"
+    "@smithy/types" "^4.13.1"
+    "@smithy/url-parser" "^4.2.12"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-body-length-browser" "^4.2.2"
+    "@smithy/util-body-length-node" "^4.2.3"
+    "@smithy/util-defaults-mode-browser" "^4.3.44"
+    "@smithy/util-defaults-mode-node" "^4.2.48"
+    "@smithy/util-endpoints" "^3.3.3"
+    "@smithy/util-middleware" "^4.2.12"
+    "@smithy/util-retry" "^4.2.12"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/core@^3.973.26":
+  version "3.973.26"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.973.26.tgz#5989c5300f9da7ed57f34b88091c77b4fa5d7256"
+  integrity sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.6"
+    "@aws-sdk/xml-builder" "^3.972.16"
+    "@smithy/core" "^3.23.13"
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/signature-v4" "^5.3.12"
+    "@smithy/smithy-client" "^4.12.8"
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-middleware" "^4.2.12"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@^3.972.24":
+  version "3.972.24"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz#bc33a34f15704d02552aa8b3994d17008b991f86"
+  integrity sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==
+  dependencies:
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.26":
+  version "3.972.26"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz#6524c3681dbb62d3c4de82262631ab94b800f00e"
+  integrity sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==
+  dependencies:
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/fetch-http-handler" "^5.3.15"
+    "@smithy/node-http-handler" "^4.5.1"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/smithy-client" "^4.12.8"
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-stream" "^4.5.21"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@^3.972.27":
+  version "3.972.27"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.27.tgz#f0ca03f66ea9eeedc4905c23c7e27b4bb2984e0c"
+  integrity sha512-Um26EsNSUfVUX0wUXnUA1W3wzKhVy6nviEElsh5lLZUYj9bk6DXOPnpte0gt+WHubcVfVsRk40bbm4KaroTEag==
+  dependencies:
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/credential-provider-env" "^3.972.24"
+    "@aws-sdk/credential-provider-http" "^3.972.26"
+    "@aws-sdk/credential-provider-login" "^3.972.27"
+    "@aws-sdk/credential-provider-process" "^3.972.24"
+    "@aws-sdk/credential-provider-sso" "^3.972.27"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.27"
+    "@aws-sdk/nested-clients" "^3.996.17"
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/credential-provider-imds" "^4.2.12"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/shared-ini-file-loader" "^4.4.7"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-login@^3.972.27":
+  version "3.972.27"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.27.tgz#a910688c418a32bf6b84abed839a9bb09fe4da7e"
+  integrity sha512-t3ehEtHomGZwg5Gixw4fYbYtG9JBnjfAjSDabxhPEu/KLLUp0BB37/APX7MSKXQhX6ZH7pseuACFJ19NrAkNdg==
+  dependencies:
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/nested-clients" "^3.996.17"
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/shared-ini-file-loader" "^4.4.7"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-node@^3.972.28":
+  version "3.972.28"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.28.tgz#bf42b55edc650b31a9b7a440f79ff77202aaad20"
+  integrity sha512-rren+P6k5rShG5PX61iVi40kKdueyuMLBRTctQbyR5LooO9Ygr5L6R7ilG7RF1957NSH3KC3TU206fZuKwjSpQ==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.24"
+    "@aws-sdk/credential-provider-http" "^3.972.26"
+    "@aws-sdk/credential-provider-ini" "^3.972.27"
+    "@aws-sdk/credential-provider-process" "^3.972.24"
+    "@aws-sdk/credential-provider-sso" "^3.972.27"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.27"
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/credential-provider-imds" "^4.2.12"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/shared-ini-file-loader" "^4.4.7"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@^3.972.24":
+  version "3.972.24"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz#940c76a2db0aece23879dcf75ac5b6ee8f8fa135"
+  integrity sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==
+  dependencies:
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/shared-ini-file-loader" "^4.4.7"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-sso@^3.972.27":
+  version "3.972.27"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.27.tgz#2d7682048a2027dff4dabe2dec8377c658a109fe"
+  integrity sha512-CWXeGjlbBuHcm9appZUgXKP2zHDyTti0/+gXpSFJ2J3CnSwf1KWjicjN0qG2ozkMH6blrrzMrimeIOEYNl238Q==
+  dependencies:
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/nested-clients" "^3.996.17"
+    "@aws-sdk/token-providers" "3.1020.0"
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/shared-ini-file-loader" "^4.4.7"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.27":
+  version "3.972.27"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.27.tgz#6eeed854b3fc3e17bd96ce0feb6f1a90280b6e6d"
+  integrity sha512-CUY4hQIFswdQNEsRGEzGBUKGMK5KpqmNDdu2ROMgI+45PLFS8H0y3Tm7kvM16uvvw3n1pVxk85tnRVUTgtaa1w==
+  dependencies:
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/nested-clients" "^3.996.17"
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/shared-ini-file-loader" "^4.4.7"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-host-header@^3.972.8":
+  version "3.972.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz#72186e96500b49b38fb5482d6b7bf95e5b985281"
+  integrity sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-logger@^3.972.8":
+  version "3.972.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz#7fee4223afcb6f7828dbdf4ea745ce15027cf384"
+  integrity sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==
+  dependencies:
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-recursion-detection@^3.972.9":
+  version "3.972.9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz#53a2cc0cf827863163b2351209212f642015c2e2"
+  integrity sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.6"
+    "@aws/lambda-invoke-store" "^0.2.2"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-user-agent@^3.972.27":
+  version "3.972.27"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.27.tgz#356669047041861c12b131711db9d562c022294d"
+  integrity sha512-TIRLO5UR2+FVUGmhYoAwVkKhcVzywEDX/5LzR9tjy1h8FQAXOtFg2IqgmwvxU7y933rkTn9rl6AdgcAUgQ1/Kg==
+  dependencies:
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/types" "^3.973.6"
+    "@aws-sdk/util-endpoints" "^3.996.5"
+    "@smithy/core" "^3.23.13"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-retry" "^4.2.12"
+    tslib "^2.6.2"
+
+"@aws-sdk/nested-clients@^3.996.17":
+  version "3.996.17"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.996.17.tgz#f250ab33dc2723fa69e56daa9ef09fbeaafd88fe"
+  integrity sha512-7B0HIX0tEFmOSJuWzdHZj1WhMXSryM+h66h96ZkqSncoY7J6wq61KOu4Kr57b/YnJP3J/EeQYVFulgR281h+7A==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/middleware-host-header" "^3.972.8"
+    "@aws-sdk/middleware-logger" "^3.972.8"
+    "@aws-sdk/middleware-recursion-detection" "^3.972.9"
+    "@aws-sdk/middleware-user-agent" "^3.972.27"
+    "@aws-sdk/region-config-resolver" "^3.972.10"
+    "@aws-sdk/types" "^3.973.6"
+    "@aws-sdk/util-endpoints" "^3.996.5"
+    "@aws-sdk/util-user-agent-browser" "^3.972.8"
+    "@aws-sdk/util-user-agent-node" "^3.973.13"
+    "@smithy/config-resolver" "^4.4.13"
+    "@smithy/core" "^3.23.13"
+    "@smithy/fetch-http-handler" "^5.3.15"
+    "@smithy/hash-node" "^4.2.12"
+    "@smithy/invalid-dependency" "^4.2.12"
+    "@smithy/middleware-content-length" "^4.2.12"
+    "@smithy/middleware-endpoint" "^4.4.28"
+    "@smithy/middleware-retry" "^4.4.45"
+    "@smithy/middleware-serde" "^4.2.16"
+    "@smithy/middleware-stack" "^4.2.12"
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/node-http-handler" "^4.5.1"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/smithy-client" "^4.12.8"
+    "@smithy/types" "^4.13.1"
+    "@smithy/url-parser" "^4.2.12"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-body-length-browser" "^4.2.2"
+    "@smithy/util-body-length-node" "^4.2.3"
+    "@smithy/util-defaults-mode-browser" "^4.3.44"
+    "@smithy/util-defaults-mode-node" "^4.2.48"
+    "@smithy/util-endpoints" "^3.3.3"
+    "@smithy/util-middleware" "^4.2.12"
+    "@smithy/util-retry" "^4.2.12"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/region-config-resolver@^3.972.10":
+  version "3.972.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz#cbabd969a2d4fedb652273403e64d98b79d0144c"
+  integrity sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/config-resolver" "^4.4.13"
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.1020.0":
+  version "3.1020.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1020.0.tgz#4df14632e6d8cabf9c061866d04507202acb2af4"
+  integrity sha512-T61KA/VKl0zVUubdxigr1ut7SEpwE1/4CIKb14JDLyTAOne2yWKtQE1dDCSHl0UqrZNwW/bTt+EBHfQbslZJdw==
+  dependencies:
+    "@aws-sdk/core" "^3.973.26"
+    "@aws-sdk/nested-clients" "^3.996.17"
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/shared-ini-file-loader" "^4.4.7"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.222.0", "@aws-sdk/types@^3.973.6":
+  version "3.973.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.973.6.tgz#1964a7c01b5cb18befa445998ad1d02f86c5432d"
+  integrity sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-endpoints@^3.996.5":
+  version "3.996.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz#6b12e80869ae6e84075bc24c2a4e6273ea87dfc2"
+  integrity sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==
+  dependencies:
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/types" "^4.13.1"
+    "@smithy/url-parser" "^4.2.12"
+    "@smithy/util-endpoints" "^3.3.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.965.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz#e30e6ff2aff6436209ed42c765dec2d2a48df7c0"
+  integrity sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-browser@^3.972.8":
+  version "3.972.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz#1044845c97c898cd68fc3f9c773494a6a98cdf80"
+  integrity sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==
+  dependencies:
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/types" "^4.13.1"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-node@^3.973.13":
+  version "3.973.13"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.13.tgz#0f825e75900569606c25cfc2dc4cceb585462664"
+  integrity sha512-s1dCJ0J9WU9UPkT3FFqhKTSquYTkqWXGRaapHFyWwwJH86ZussewhNST5R5TwXVL1VSHq4aJVl9fWK+svaRVCQ==
+  dependencies:
+    "@aws-sdk/middleware-user-agent" "^3.972.27"
+    "@aws-sdk/types" "^3.973.6"
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-config-provider" "^4.2.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@^3.972.16":
+  version "3.972.16"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz#ea22fe022cf12d12b07f6faf75c4fa214dea00bc"
+  integrity sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    fast-xml-parser "5.5.8"
+    tslib "^2.6.2"
+
+"@aws/lambda-invoke-store@^0.2.2":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz#802f6a50f6b6589063ef63ba8acdee86fcb9f395"
+  integrity sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
@@ -1146,6 +1540,401 @@
   dependencies:
     "@sinonjs/commons" "^3.0.1"
 
+"@smithy/config-resolver@^4.4.13":
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-4.4.13.tgz#8bffd41de647ec349b4a74bf02bdd1b32452bacd"
+  integrity sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==
+  dependencies:
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-config-provider" "^4.2.2"
+    "@smithy/util-endpoints" "^3.3.3"
+    "@smithy/util-middleware" "^4.2.12"
+    tslib "^2.6.2"
+
+"@smithy/core@^3.23.13":
+  version "3.23.13"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.23.13.tgz#343e0d78b907f463b560d9e50d8ae16456281830"
+  integrity sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==
+  dependencies:
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/types" "^4.13.1"
+    "@smithy/url-parser" "^4.2.12"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-body-length-browser" "^4.2.2"
+    "@smithy/util-middleware" "^4.2.12"
+    "@smithy/util-stream" "^4.5.21"
+    "@smithy/util-utf8" "^4.2.2"
+    "@smithy/uuid" "^1.1.2"
+    tslib "^2.6.2"
+
+"@smithy/credential-provider-imds@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz#fa2e52116cac7eaf5625e0bfd399a4927b598f66"
+  integrity sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==
+  dependencies:
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/types" "^4.13.1"
+    "@smithy/url-parser" "^4.2.12"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.3.15":
+  version "5.3.15"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz#acf69a8b3bab0396d2782fc901bad0b957c8c6a2"
+  integrity sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==
+  dependencies:
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/querystring-builder" "^4.2.12"
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-base64" "^4.3.2"
+    tslib "^2.6.2"
+
+"@smithy/hash-node@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-4.2.12.tgz#0ee7f6a1d2958c313ee24b07159dcb9547792441"
+  integrity sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-buffer-from" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/invalid-dependency@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz#1a28c13fb33684b91848d4d6ec5104a1c1413e7f"
+  integrity sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/is-array-buffer@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz#f84f0d9f9a36601a9ca9381688bd1b726fd39111"
+  integrity sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/is-array-buffer@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz#c401ce54b12a16529eb1c938a0b6c2247cb763b8"
+  integrity sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/middleware-content-length@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz#dec97ea1444b12e734156b764e9953b2b37c70fd"
+  integrity sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==
+  dependencies:
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/middleware-endpoint@^4.4.28":
+  version "4.4.28"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz#201b568f3669bd816f60a6043d914c134d80f46c"
+  integrity sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==
+  dependencies:
+    "@smithy/core" "^3.23.13"
+    "@smithy/middleware-serde" "^4.2.16"
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/shared-ini-file-loader" "^4.4.7"
+    "@smithy/types" "^4.13.1"
+    "@smithy/url-parser" "^4.2.12"
+    "@smithy/util-middleware" "^4.2.12"
+    tslib "^2.6.2"
+
+"@smithy/middleware-retry@^4.4.45":
+  version "4.4.46"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.4.46.tgz#dbbf0af08c1bd03fe2afa09a6cfb7a9056387ce6"
+  integrity sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==
+  dependencies:
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/service-error-classification" "^4.2.12"
+    "@smithy/smithy-client" "^4.12.8"
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-middleware" "^4.2.12"
+    "@smithy/util-retry" "^4.2.13"
+    "@smithy/uuid" "^1.1.2"
+    tslib "^2.6.2"
+
+"@smithy/middleware-serde@^4.2.16":
+  version "4.2.16"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz#7f259e1e4e43332ad29b53cf3b4d9f14fde690ce"
+  integrity sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==
+  dependencies:
+    "@smithy/core" "^3.23.13"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/middleware-stack@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz#96b43b2fab0d4a6723f813f76b72418b0fdb6ba0"
+  integrity sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/node-config-provider@^4.3.12":
+  version "4.3.12"
+  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz#bb722da6e2a130ae585754fa7bc8d909f9f5d702"
+  integrity sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==
+  dependencies:
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/shared-ini-file-loader" "^4.4.7"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz#9f05b4478ccfc6db82af37579a36fa48ee8f6067"
+  integrity sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==
+  dependencies:
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/querystring-builder" "^4.2.12"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/property-provider@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/property-provider/-/property-provider-4.2.12.tgz#e9f8e5ce125413973b16e39c87cf4acd41324e21"
+  integrity sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/protocol-http@^5.3.12":
+  version "5.3.12"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-5.3.12.tgz#c913053e7dfbac6cdd7f374f0b4f5aa7c518d0e1"
+  integrity sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/querystring-builder@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz#20a0266b151a4b58409f901e1463257a72835c16"
+  integrity sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-uri-escape" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/querystring-parser@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz#918cb609b2d606ab81f2727bfde0265d2ebb2758"
+  integrity sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/service-error-classification@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz#795e9484207acf63817a9e9cf67e90b42e720840"
+  integrity sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+
+"@smithy/shared-ini-file-loader@^4.4.7":
+  version "4.4.7"
+  resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz#18cc5a21f871509fafbe535a7bf44bde5a500727"
+  integrity sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/signature-v4@^5.3.12":
+  version "5.3.12"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.3.12.tgz#b61ce40a94bdd91dfdd8f5f2136631c8eb67f253"
+  integrity sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==
+  dependencies:
+    "@smithy/is-array-buffer" "^4.2.2"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-hex-encoding" "^4.2.2"
+    "@smithy/util-middleware" "^4.2.12"
+    "@smithy/util-uri-escape" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/smithy-client@^4.12.8":
+  version "4.12.8"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.12.8.tgz#b2982fe8b72e44621c139045d991555c07df0e1a"
+  integrity sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==
+  dependencies:
+    "@smithy/core" "^3.23.13"
+    "@smithy/middleware-endpoint" "^4.4.28"
+    "@smithy/middleware-stack" "^4.2.12"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-stream" "^4.5.21"
+    tslib "^2.6.2"
+
+"@smithy/types@^4.13.1":
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.13.1.tgz#8aaf15bb0f42b4e7c93c87018a3678a06d74691d"
+  integrity sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/url-parser@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-4.2.12.tgz#e940557bf0b8e9a25538a421970f64bd827f456f"
+  integrity sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==
+  dependencies:
+    "@smithy/querystring-parser" "^4.2.12"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/util-base64@^4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-4.3.2.tgz#be02bcb29a87be744356467ea25ffa413e695cea"
+  integrity sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==
+  dependencies:
+    "@smithy/util-buffer-from" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-browser@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz#c4404277d22039872abdb80e7800f9a63f263862"
+  integrity sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-node@^4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz#f923ca530defb86a9ac3ca2d3066bcca7b304fbc"
+  integrity sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-buffer-from@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz#6fc88585165ec73f8681d426d96de5d402021e4b"
+  integrity sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==
+  dependencies:
+    "@smithy/is-array-buffer" "^2.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-buffer-from@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz#2c6b7857757dfd88f6cd2d36016179a40ccc913b"
+  integrity sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==
+  dependencies:
+    "@smithy/is-array-buffer" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/util-config-provider@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz#52ebf9d8942838d18bc5fb1520de1e8699d7aad6"
+  integrity sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-browser@^4.3.44":
+  version "4.3.44"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.44.tgz#56c0c69415c7a28aaa65c1407b1c090401a38182"
+  integrity sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==
+  dependencies:
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/smithy-client" "^4.12.8"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-node@^4.2.48":
+  version "4.2.48"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.48.tgz#8ee63e2ea706bd111104e8f3796d858cc186625f"
+  integrity sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==
+  dependencies:
+    "@smithy/config-resolver" "^4.4.13"
+    "@smithy/credential-provider-imds" "^4.2.12"
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/property-provider" "^4.2.12"
+    "@smithy/smithy-client" "^4.12.8"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/util-endpoints@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz#0119f15bcac30b3b9af1d3cc0a8477e7199d0185"
+  integrity sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==
+  dependencies:
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/util-hex-encoding@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz#4abf3335dd1eb884041d8589ca7628d81a6fd1d3"
+  integrity sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-middleware@^4.2.12":
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-4.2.12.tgz#d6cb837c2390375e2b6957e7f917350ca4bd8757"
+  integrity sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==
+  dependencies:
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/util-retry@^4.2.12", "@smithy/util-retry@^4.2.13":
+  version "4.2.13"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-4.2.13.tgz#ad816d6ddf197095d188e9ef56664fbd392a39c9"
+  integrity sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==
+  dependencies:
+    "@smithy/service-error-classification" "^4.2.12"
+    "@smithy/types" "^4.13.1"
+    tslib "^2.6.2"
+
+"@smithy/util-stream@^4.5.21":
+  version "4.5.21"
+  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-4.5.21.tgz#a9ea13d0299d030c72ab4b4e394db111cd581629"
+  integrity sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==
+  dependencies:
+    "@smithy/fetch-http-handler" "^5.3.15"
+    "@smithy/node-http-handler" "^4.5.1"
+    "@smithy/types" "^4.13.1"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-buffer-from" "^4.2.2"
+    "@smithy/util-hex-encoding" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/util-uri-escape@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz#48e40206e7fe9daefc8d44bb43a1ab17e76abf4a"
+  integrity sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^2.0.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.3.0.tgz#dd96d7640363259924a214313c3cf16e7dd329c5"
+  integrity sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-4.2.2.tgz#21db686982e6f3393ac262e49143b42370130f13"
+  integrity sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==
+  dependencies:
+    "@smithy/util-buffer-from" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/uuid@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@smithy/uuid/-/uuid-1.1.2.tgz#b6e97c7158615e4a3c775e809c00d8c269b5a12e"
+  integrity sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==
+  dependencies:
+    tslib "^2.6.2"
+
 "@solana/buffer-layout-utils@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz#b45a6cab3293a2eb7597cceb474f229889d875ca"
@@ -1914,6 +2703,11 @@ borsh@^0.7.0:
     bs58 "^4.0.0"
     text-encoding-utf-8 "^1.0.2"
 
+bowser@^2.11.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
+  integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
+
 brace-expansion@^1.1.7:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
@@ -2502,6 +3296,22 @@ fast-stable-stringify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz#5c5543462b22aeeefd36d05b34e51c78cb86d313"
   integrity sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==
+
+fast-xml-builder@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz#0c407a1d9d5996336c0cd76f7ff785cac6413017"
+  integrity sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==
+  dependencies:
+    path-expression-matcher "^1.1.3"
+
+fast-xml-parser@5.5.8:
+  version "5.5.8"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz#929571ed8c5eb96e6d9bd572ba14fc4b84875716"
+  integrity sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==
+  dependencies:
+    fast-xml-builder "^1.1.4"
+    path-expression-matcher "^1.2.0"
+    strnum "^2.2.0"
 
 fastq@^1.6.0:
   version "1.20.1"
@@ -3836,6 +4646,11 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-expression-matcher@^1.1.3, path-expression-matcher@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz#9bdae3787f43b0857b0269e9caaa586c12c8abee"
+  integrity sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -4306,7 +5121,16 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4338,7 +5162,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4376,6 +5207,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+
+strnum@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.2.tgz#f11fd94ab62b536ba2ecc615858f3747c2881b3f"
+  integrity sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==
 
 superstruct@^0.15.4:
   version "0.15.5"
@@ -4524,7 +5360,7 @@ ts-node@^10.0.0:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -4712,7 +5548,16 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Enable using KMS for signing solana transactions, append --withKms to do so, in addition to adding the below to your gauntlet env:

KMS_KEY_ID=
KMS_KEY_REGION=
AWS_PROFILE=