### PR TITLE
Add .gitattributes to mark go.sum as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**go.sum linguist-generated=true


### PR DESCRIPTION
This will collapse go.sum files in PRs.