### PR TITLE
L1 PLEX-2601 LP Fetch Blocks in Batches

### DIFF
--- a/pkg/solana/CONFIG.md
+++ b/pkg/solana/CONFIG.md
@@ -41,7 +41,7 @@ ComputeUnitLimitDefault = 200_000 # Default
 EstimateComputeUnitLimit = false # Default
 LogPollerStartingLookback = '24h' # Default
 LogPollerCPIEventsEnabled = true # Default
-LogPollerSlotsBatchSize = 1000 # Default
+LogPollerSlotsBatchSize = 100 # Default
 ```
 
 
@@ -217,7 +217,7 @@ CPI events require LOOPP mode to function correctly.
 
 ### LogPollerSlotsBatchSize
 ```toml
-LogPollerSlotsBatchSize = 1000 # Default
+LogPollerSlotsBatchSize = 100 # Default
 ```
 LogPollerSlotsBatchSize is the number of slots to process in a batch when polling for logs. Setting this value too high may increase memory usage, while setting it too low may increase the number of RPC calls and decrease performance.
 

--- a/pkg/solana/config/docs.toml
+++ b/pkg/solana/config/docs.toml
@@ -61,7 +61,7 @@ LogPollerStartingLookback = '24h' # Default
 # CPI events require LOOPP mode to function correctly.
 LogPollerCPIEventsEnabled = true # Default
 # LogPollerSlotsBatchSize is the number of slots to process in a batch when polling for logs. Setting this value too high may increase memory usage, while setting it too low may increase the number of RPC calls and decrease performance.
-LogPollerSlotsBatchSize = 1000 # Default
+LogPollerSlotsBatchSize = 100 # Default
 
 [MultiNode]
 # Enabled enables the multinode feature.

--- a/pkg/solana/config/testdata/config-full.toml
+++ b/pkg/solana/config/testdata/config-full.toml
@@ -25,7 +25,7 @@ ComputeUnitLimitDefault = 100000
 EstimateComputeUnitLimit = false
 LogPollerStartingLookback = '24h0m0s'
 LogPollerCPIEventsEnabled = true
-LogPollerSlotsBatchSize = 1000
+LogPollerSlotsBatchSize = 100
 
 [Workflow]
 AcceptanceTimeout = '42s'

--- a/pkg/solana/config/toml_test.go
+++ b/pkg/solana/config/toml_test.go
@@ -55,7 +55,7 @@ var fullConfig = TOMLConfig{
 		EstimateComputeUnitLimit:  ptr(false),
 		LogPollerStartingLookback: config.MustNewDuration(24 * time.Hour),
 		LogPollerCPIEventsEnabled: ptr(true),
-		LogPollerSlotsBatchSize:   ptr[int64](1000),
+		LogPollerSlotsBatchSize:   ptr[int64](100),
 	},
 	Workflow: WorkflowConfig{
 		AcceptanceTimeout: config.MustNewDuration(42 * time.Second),

--- a/pkg/solana/logpoller/loader.go
+++ b/pkg/solana/logpoller/loader.go
@@ -120,16 +120,12 @@ func (c *EncodedLogCollector) scheduleBlocksFetching(ctx context.Context, slots 
 	}
 
 	c.engine.GoCtx(ctx, func(ctx context.Context) {
-		ctx, cancel := context.WithCancel(ctx)
 		startTime := time.Now()
-		defer cancel()
 		for batchStart := 0; batchStart < len(slots); {
 			batchEnd := min(batchStart+c.slotsBatchSize, len(slots))
 			jobs, err := c.scheduleBlocks(ctx, slots[batchStart:batchEnd], blocks)
 			if err != nil {
 				c.lggr.Errorw("Failed to schedule block fetching jobs for batch.", "err", err)
-				// do not close blocks channel here to avoid signalling end of stream to the consumer - instead, just stop all the jobs and return
-				cancel()
 				return
 			}
 
@@ -145,6 +141,7 @@ func (c *EncodedLogCollector) scheduleBlocksFetching(ctx context.Context, slots 
 		}
 
 		c.lggr.Infow("Finished fetching all blocks.", "from", slots[0], "to", slots[len(slots)-1], "duration", time.Since(startTime))
+		// only close the channel after all jobs are done. Do not close on failures to avoid signaling successful completion to the upstream
 		close(blocks)
 	})
 	return blocks, nil

--- a/pkg/solana/logpoller/loader.go
+++ b/pkg/solana/logpoller/loader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
@@ -35,16 +36,19 @@ type EncodedLogCollector struct {
 	client            RPCClient
 	lggr              logger.SugaredLogger
 	cpiEventExtractor *CPIEventExtractor
+	slotsBatchSize    int
 
 	workers *worker.Group
 	metrics *solLpMetrics
 }
 
-func NewEncodedLogCollector(client RPCClient, lggr logger.Logger, chainID string, metrics *solLpMetrics, cpiEventExtractor *CPIEventExtractor) *EncodedLogCollector {
+func NewEncodedLogCollector(client RPCClient, lggr logger.Logger, chainID string, metrics *solLpMetrics, cpiEventExtractor *CPIEventExtractor, slotsBatchSize int64) *EncodedLogCollector {
 	c := &EncodedLogCollector{
 		client:            client,
 		metrics:           metrics,
 		cpiEventExtractor: cpiEventExtractor,
+		// nolint:gosec
+		slotsBatchSize: int(slotsBatchSize), // G115: integer overflow conversion int64 -&gt; int
 	}
 
 	c.Service, c.engine = services.Config{
@@ -110,29 +114,56 @@ func (c *EncodedLogCollector) getSlotsToFetch(ctx context.Context, addresses []t
 
 func (c *EncodedLogCollector) scheduleBlocksFetching(ctx context.Context, slots []uint64) (<-chan types.Block, error) {
 	blocks := make(chan types.Block)
-	getBlockJobs := make([]*getBlockJob, len(slots))
-	for i, slot := range slots {
-		getBlockJobs[i] = newGetBlockJob(ctx.Done(), c.client, blocks, c.lggr, slot, c.metrics, c.cpiEventExtractor)
-		err := c.workers.Do(ctx, getBlockJobs[i])
-		if err != nil {
-			return nil, fmt.Errorf("could not schedule job to fetch blocks for slot: %w", err)
-		}
+	if len(slots) == 0 {
+		close(blocks)
+		return blocks, nil
 	}
 
-	go func() {
-		for _, job := range getBlockJobs {
-			select {
-			case <-ctx.Done():
+	c.engine.GoCtx(ctx, func(ctx context.Context) {
+		ctx, cancel := context.WithCancel(ctx)
+		startTime := time.Now()
+		defer cancel()
+		for batchStart := 0; batchStart < len(slots); {
+			batchEnd := min(batchStart+c.slotsBatchSize, len(slots))
+			jobs, err := c.scheduleBlocks(ctx, slots[batchStart:batchEnd], blocks)
+			if err != nil {
+				c.lggr.Errorw("Failed to schedule block fetching jobs for batch.", "err", err)
+				// do not close blocks channel here to avoid signalling end of stream to the consumer - instead, just stop all the jobs and return
+				cancel()
 				return
-			case <-job.Done():
-				continue
+			}
+
+			batchStart = batchEnd
+			for _, job := range jobs {
+				select {
+				case <-ctx.Done():
+					c.lggr.Infow("Context cancelled while waiting for block fetching jobs to finish.")
+					return
+				case <-job.Done():
+				}
 			}
 		}
 
+		c.lggr.Infow("Finished fetching all blocks.", "from", slots[0], "to", slots[len(slots)-1], "duration", time.Since(startTime))
 		close(blocks)
-	}()
-
+	})
 	return blocks, nil
+}
+
+func (c *EncodedLogCollector) scheduleBlocks(ctx context.Context, slots []uint64, blocks chan types.Block) ([]*getBlockJob, error) {
+	getBlockJobs := make([]*getBlockJob, 0, len(slots))
+	for i, slot := range slots {
+		if ctx.Err() != nil {
+			return getBlockJobs, ctx.Err()
+		}
+		getBlockJobs = append(getBlockJobs, newGetBlockJob(ctx.Done(), c.client, blocks, c.lggr, slot, c.metrics, c.cpiEventExtractor))
+		err := c.workers.Do(ctx, getBlockJobs[i])
+		if err != nil {
+			return getBlockJobs, fmt.Errorf("could not schedule job to fetch blocks for slot: %w", err)
+		}
+	}
+
+	return getBlockJobs, nil
 }
 
 func (c *EncodedLogCollector) BackfillForAddresses(ctx context.Context, addresses []types.PublicKey, fromSlot, toSlot uint64) (orderedBlocks <-chan types.Block, cleanUp func(), err error) {

--- a/pkg/solana/logpoller/loader_internal_test.go
+++ b/pkg/solana/logpoller/loader_internal_test.go
@@ -81,6 +81,7 @@ func TestScheduleBlocksFetching_HappyPath(t *testing.T) {
 		}
 		require.Contains(t, expectedSlots, block.SlotNumber, "received block for unexpected slot")
 		delete(expectedSlots, block.SlotNumber)
+		prev = block.SlotNumber
 	}
 	require.Empty(t, expectedSlots)
 }

--- a/pkg/solana/logpoller/loader_internal_test.go
+++ b/pkg/solana/logpoller/loader_internal_test.go
@@ -77,7 +77,7 @@ func TestScheduleBlocksFetching_HappyPath(t *testing.T) {
 	prev := uint64(0)
 	for block := range ch {
 		if prev != 0 {
-			require.Equal(t, block.SlotNumber-prev, uint64(1), "expected blocks to be received in consecutive order since batch size is 1")
+			require.Equal(t, uint64(1), block.SlotNumber-prev, "expected blocks to be received in consecutive order since batch size is 1")
 		}
 		require.Contains(t, expectedSlots, block.SlotNumber, "received block for unexpected slot")
 		delete(expectedSlots, block.SlotNumber)

--- a/pkg/solana/logpoller/loader_internal_test.go
+++ b/pkg/solana/logpoller/loader_internal_test.go
@@ -1,0 +1,86 @@
+package logpoller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller/mocks"
+)
+
+func TestScheduleBlocksFetching_EmptySlots(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	client := mocks.NewRPCClient(t)
+	metrics, err := NewSolLpMetrics(t.Name())
+	require.NoError(t, err)
+
+	collector := NewEncodedLogCollector(client, logger.Test(t), t.Name(), metrics, nil, 10)
+	require.NoError(t, collector.Start(ctx))
+	t.Cleanup(func() { require.NoError(t, collector.Close()) })
+
+	ch, err := collector.scheduleBlocksFetching(ctx, nil)
+	require.NoError(t, err)
+
+	_, ok := <-ch
+	require.False(t, ok, "blocks channel should be closed when no slots are provided")
+}
+
+func TestScheduleBlocksFetching_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	client := mocks.NewRPCClient(t)
+	metrics, err := NewSolLpMetrics(t.Name())
+	require.NoError(t, err)
+
+	const batchSize = 1
+	slots := []uint64{100, 101, 102, 103, 104, 105, 106, 107, 108, 109}
+
+	collector := NewEncodedLogCollector(client, logger.Test(t), t.Name(), metrics, nil, batchSize)
+	require.NoError(t, collector.Start(ctx))
+	t.Cleanup(func() { require.NoError(t, collector.Close()) })
+
+	blockTime := solana.UnixTimeSeconds(128)
+	client.EXPECT().
+		GetBlockWithOpts(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, slot uint64, _ *rpc.GetBlockOpts) (*rpc.GetBlockResult, error) {
+			tx := solana.Transaction{Signatures: []solana.Signature{{1}}}
+			txB, txErr := tx.MarshalBinary()
+			require.NoError(t, txErr)
+			return &rpc.GetBlockResult{
+				BlockHeight: &slot,
+				BlockTime:   &blockTime,
+				Blockhash:   solana.Hash{1, 2, 3},
+				Transactions: []rpc.TransactionWithMeta{{
+					Transaction: rpc.DataBytesOrJSONFromBytes(txB),
+					Meta:        &rpc.TransactionMeta{LogMessages: []string{}},
+				}},
+			}, nil
+		}).
+		Times(len(slots))
+
+	ch, err := collector.scheduleBlocksFetching(ctx, slots)
+	require.NoError(t, err)
+	expectedSlots := make(map[uint64]struct{})
+	for _, slot := range slots {
+		expectedSlots[slot] = struct{}{}
+	}
+
+	prev := uint64(0)
+	for block := range ch {
+		if prev != 0 {
+			require.Equal(t, block.SlotNumber-prev, uint64(1), "expected blocks to be received in consecutive order since batch size is 1")
+		}
+		require.Contains(t, expectedSlots, block.SlotNumber, "received block for unexpected slot")
+		delete(expectedSlots, block.SlotNumber)
+	}
+	require.Empty(t, expectedSlots)
+}

--- a/pkg/solana/logpoller/loader_test.go
+++ b/pkg/solana/logpoller/loader_test.go
@@ -40,7 +40,7 @@ func TestEncodedLogCollector_MultipleEventOrdered(t *testing.T) {
 	metrics, err := logpoller.NewSolLpMetrics("test-chain-id")
 	require.NoError(t, err)
 
-	collector := logpoller.NewEncodedLogCollector(client, logger.Test(t), "test-chain-id", metrics, nil)
+	collector := logpoller.NewEncodedLogCollector(client, logger.Test(t), "test-chain-id", metrics, nil, 10)
 
 	require.NoError(t, collector.Start(ctx))
 	t.Cleanup(func() {
@@ -184,7 +184,7 @@ func TestEncodedLogCollector_Backfill_DoesNotBlockOnRPCError(t *testing.T) {
 	metrics, err := logpoller.NewSolLpMetrics("test-chain-id")
 	require.NoError(t, err)
 
-	collector := logpoller.NewEncodedLogCollector(client, logger.Test(t), "test-chain-id", metrics, nil).WithMaxGroupRetryCount(2)
+	collector := logpoller.NewEncodedLogCollector(client, logger.Test(t), "test-chain-id", metrics, nil, 10).WithMaxGroupRetryCount(2)
 
 	ctx := t.Context()
 	require.NoError(t, collector.Start(ctx))

--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -116,7 +116,7 @@ func New(lggr logger.SugaredLogger, orm ORM, cl RPCClient, cfg config.Config, ch
 		Start: lp.start,
 		NewSubServices: func(lggr logger.Logger) []services.Service {
 			lp.filters = newFilters(lggr, orm, lp.cpiEventExtractor)
-			loader := NewEncodedLogCollector(cl, lggr, chainID, lp.metrics, lp.cpiEventExtractor)
+			loader := NewEncodedLogCollector(cl, lggr, chainID, lp.metrics, lp.cpiEventExtractor, cfg.LogPollerSlotsBatchSize())
 			lp.loader = loader
 			return []services.Service{loader}
 		},

--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -90,7 +90,6 @@ type Service struct {
 	processBlocks     func(ctx context.Context, blocks []types.Block) error
 	blockTime         time.Duration
 	startingLookback  time.Duration
-	slotsBatchSize    int64
 	metrics           *solLpMetrics
 }
 
@@ -127,7 +126,6 @@ func New(lggr logger.SugaredLogger, orm ORM, cl RPCClient, cfg config.Config, ch
 
 	lp.startingLookback = cfg.LogPollerStartingLookback()
 	lp.blockTime = cfg.BlockTime()
-	lp.slotsBatchSize = cfg.LogPollerSlotsBatchSize()
 
 	return lp, nil
 }
@@ -391,7 +389,7 @@ func (lp *Service) backfillFilters(ctx context.Context, filters []types.Filter, 
 	}
 
 	if minSlot < to {
-		err := lp.processBlocksRangeInBatches(ctx, addresses, minSlot, to)
+		err := lp.processBlocksRange(ctx, addresses, minSlot, to)
 		if err != nil {
 			return err
 		}
@@ -414,19 +412,6 @@ func (lp *Service) backfillFilters(ctx context.Context, filters []types.Filter, 
 	}
 
 	return err
-}
-
-func (lp *Service) processBlocksRangeInBatches(ctx context.Context, addresses []types.PublicKey, from, to int64) error {
-	lp.lggr.Infow("Processing block range in batches", "from", from, "to", to, "batchSize", lp.slotsBatchSize)
-	for batchStart := from; batchStart <= to; batchStart += lp.slotsBatchSize {
-		batchEnd := min(batchStart+lp.slotsBatchSize-1, to)
-		err := lp.processBlocksRange(ctx, addresses, batchStart, batchEnd)
-		if err != nil {
-			return fmt.Errorf("failed processing batch [%d, %d]: %w", batchStart, batchEnd, err)
-		}
-	}
-
-	return nil
 }
 
 func (lp *Service) processBlocksRange(ctx context.Context, addresses []types.PublicKey, from, to int64) error {
@@ -535,7 +520,7 @@ func (lp *Service) run(ctx context.Context) (err error) {
 	}
 
 	lp.lggr.Debugw("Got new slot range to process", "from", lastProcessedSlot+1, "to", highestSlot)
-	err = lp.processBlocksRangeInBatches(ctx, addresses, lastProcessedSlot+1, highestSlot)
+	err = lp.processBlocksRange(ctx, addresses, lastProcessedSlot+1, highestSlot)
 	if err != nil {
 		return fmt.Errorf("failed processing block range [%d, %d]: %w", lastProcessedSlot+1, highestSlot, err)
 	}

--- a/pkg/solana/logpoller/log_poller_test.go
+++ b/pkg/solana/logpoller/log_poller_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"math/rand"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -73,7 +72,7 @@ func TestLogPoller_run(t *testing.T) {
 		lp.Filters.EXPECT().GetFiltersToBackfill().Return([]types.Filter{{StartingBlock: 16}}).Once()
 
 		expectedErr := errors.New("loaderFailed")
-		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, mock.Anything, uint64(16), uint64(115)).Return(nil, nil, expectedErr).Once()
+		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, mock.Anything, uint64(16), uint64(128)).Return(nil, nil, expectedErr).Once()
 		err := lp.LogPoller.run(t.Context())
 		require.ErrorIs(t, err, expectedErr)
 	})
@@ -89,8 +88,7 @@ func TestLogPoller_run(t *testing.T) {
 		done := func() {}
 		blocks := make(chan types.Block)
 		close(blocks)
-		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, []types.PublicKey{{1, 2, 3}, {3, 2, 1}}, uint64(12), uint64(111)).Return(blocks, done, nil).Once()
-		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, []types.PublicKey{{1, 2, 3}, {3, 2, 1}}, uint64(112), uint64(128)).Return(blocks, done, nil).Once()
+		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, []types.PublicKey{{1, 2, 3}, {3, 2, 1}}, uint64(12), uint64(128)).Return(blocks, done, nil).Once()
 		lp.Filters.EXPECT().MarkFilterBackfilled(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, filterID int64) error {
 			switch filterID {
 			case 1:
@@ -155,7 +153,7 @@ func TestLogPoller_run(t *testing.T) {
 		expectedError := errors.New("failed to start backfill")
 		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, mock.Anything, uint64(129), uint64(130)).Return(nil, nil, expectedError).Once()
 		err := lp.LogPoller.run(t.Context())
-		require.ErrorContains(t, err, "failed processing block range [129, 130]: failed processing batch [129, 130]: error backfilling filters: failed to start backfill")
+		require.ErrorContains(t, err, "failed processing block range [129, 130]: error backfilling filters: failed to start backfill")
 	})
 	t.Run("Happy path", func(t *testing.T) {
 		lp := newMockedLP(t)
@@ -163,16 +161,13 @@ func TestLogPoller_run(t *testing.T) {
 		lp.Filters.EXPECT().LoadFilters(mock.Anything).Return(nil).Once()
 		lp.Filters.EXPECT().GetFiltersToBackfill().Return(nil).Once()
 		lp.Filters.EXPECT().GetDistinctAddresses(mock.Anything).Return([]types.PublicKey{{}}, nil).Once()
-		lp.Client.EXPECT().SlotHeightWithCommitment(mock.Anything, rpc.CommitmentFinalized).Return(230, nil).Once()
+		lp.Client.EXPECT().SlotHeightWithCommitment(mock.Anything, rpc.CommitmentFinalized).Return(130, nil).Once()
 		blocks := make(chan types.Block)
 		close(blocks)
-		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, mock.Anything, uint64(129), uint64(228)).Return(blocks, func() {}, nil).Run(func(_ context.Context, _ []types.PublicKey, _, _ uint64) {
-			// ensure that batches are processed in the correct order by configuring second call after the first one is done
-			lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, mock.Anything, uint64(229), uint64(230)).Return(blocks, func() {}, nil).Once()
-		}).Once()
+		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, mock.Anything, uint64(129), uint64(130)).Return(blocks, func() {}, nil).Once()
 		err := lp.LogPoller.run(t.Context())
 		require.NoError(t, err)
-		require.Equal(t, int64(230), lp.LogPoller.lastProcessedSlot)
+		require.Equal(t, int64(130), lp.LogPoller.lastProcessedSlot)
 	})
 	// These two sub-tests demonstrate the difference between single-batch and multi-batch
 	// failure scenarios, showing how the batch-level cursor update prevents redundant RPC calls.
@@ -398,69 +393,6 @@ func Test_GetLastProcessedSlot(t *testing.T) {
 			lp.Filters.AssertExpectations(t)
 		})
 	}
-}
-
-func TestLogPoller_processBlocksRange(t *testing.T) {
-	t.Parallel()
-
-	t.Run("Returns error if failed to start backfill", func(t *testing.T) {
-		lp := newMockedLP(t)
-		expectedErr := errors.New("failed to start backfill")
-		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, expectedErr).Once()
-		err := lp.LogPoller.processBlocksRange(t.Context(), nil, 10, 20)
-		require.ErrorIs(t, err, expectedErr)
-	})
-	funcWithCallExpectation := func(t *testing.T) func() {
-		var called atomic.Bool
-		t.Cleanup(func() {
-			require.True(t, called.Load(), "expected function to be called")
-		})
-		return func() { called.Store(true) }
-	}
-	t.Run("Can abort by cancelling context", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		lp := newMockedLP(t)
-		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(context.Context, []types.PublicKey, uint64, uint64) (<-chan types.Block, func(), error) {
-			cancel()
-			return nil, funcWithCallExpectation(t), nil
-		}).Once()
-		err := lp.LogPoller.processBlocksRange(ctx, nil, 10, 20)
-		require.ErrorIs(t, err, context.Canceled)
-	})
-	t.Run("Happy path", func(t *testing.T) {
-		lp := newMockedLP(t)
-		blocks := make(chan types.Block, 2)
-		blocks <- types.Block{SlotNumber: 11}
-		blocks <- types.Block{SlotNumber: 12}
-		close(blocks)
-		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(blocks, funcWithCallExpectation(t), nil).Once()
-		err := lp.LogPoller.processBlocksRange(t.Context(), nil, 10, 20)
-		require.NoError(t, err)
-		assert.Equal(t, int64(12), lp.LogPoller.lastProcessedSlot)
-	})
-	t.Run("Updates lastProcessedSlot incrementally on partial failure", func(t *testing.T) {
-		lp := newMockedLP(t)
-		blocks := make(chan types.Block, 3)
-		blocks <- types.Block{SlotNumber: 11}
-		blocks <- types.Block{SlotNumber: 12}
-
-		expectedErr := errors.New("simulated processing error")
-		callCount := 0
-		lp.LogPoller.processBlocks = func(_ context.Context, _ []types.Block) error {
-			callCount++
-			if callCount == 1 {
-				blocks <- types.Block{SlotNumber: 13}
-				close(blocks)
-				return nil
-			}
-			return expectedErr
-		}
-
-		lp.Loader.EXPECT().BackfillForAddresses(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(blocks, funcWithCallExpectation(t), nil).Once()
-		err := lp.LogPoller.processBlocksRange(t.Context(), nil, 10, 20)
-		require.ErrorIs(t, err, expectedErr)
-		assert.Equal(t, int64(12), lp.LogPoller.lastProcessedSlot)
-	})
 }
 
 func TestProcess(t *testing.T) {

--- a/pkg/solana/logpoller/log_poller_test.go
+++ b/pkg/solana/logpoller/log_poller_test.go
@@ -284,6 +284,68 @@ func TestLogPoller_run(t *testing.T) {
 	})
 }
 
+// TestLogPoller_run_EncodedLogCollector_uniqueGetSignaturesRequests asserts that when LogPollerSlotsBatchSize is
+// smaller than the number of slots in the backfill range, block fetching runs in multiple batches but
+// GetSignaturesForAddress (getSlotsForAddressJob) is not invoked twice for the same RPC cursor (MinContextSlot + Before).
+func TestLogPoller_run_EncodedLogCollector_uniqueGetSignaturesRequests(t *testing.T) {
+	t.Parallel()
+
+	const slotsBatchSize = 2
+	cfg := config.NewDefault()
+	cfg.Chain.LogPollerSlotsBatchSize = ptr[int64](slotsBatchSize)
+
+	lp := newMockedLPwithConfig(t, cfg, chainID)
+	loader := NewEncodedLogCollector(lp.Client, logger.Test(t), t.Name(), nil, nil, slotsBatchSize)
+	require.NoError(t, loader.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, loader.Close()) })
+	lp.LogPoller.loader = loader
+	lp.LogPoller.lastProcessedSlot = 100
+
+	ctx := t.Context()
+
+	address, err := solana.PublicKeyFromBase58("J1zQwrBNBngz26jRPNWsUSZMHJwBwpkoDitXRV95LdK4")
+	require.NoError(t, err)
+	addr := types.PublicKey(address)
+
+	// Five slots 101..105 — strictly larger than slotsBatchSize so scheduleBlocksFetching uses multiple batches.
+	slots := []uint64{105, 104, 103, 102, 101}
+
+	lp.Filters.EXPECT().LoadFilters(mock.Anything).Return(nil).Once()
+	lp.Filters.EXPECT().GetFiltersToBackfill().Return(nil).Once()
+	lp.Filters.EXPECT().GetDistinctAddresses(mock.Anything).Return([]types.PublicKey{addr}, nil).Once()
+
+	lp.Client.EXPECT().SlotHeightWithCommitment(mock.Anything, rpc.CommitmentFinalized).Return(uint64(105), nil).Once()
+
+	lp.Client.EXPECT().GetSignaturesForAddressWithOpts(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ solana.PublicKey, opts *rpc.GetSignaturesForAddressOpts) ([]*rpc.TransactionSignature, error) {
+			txSigsResponse := make([]*rpc.TransactionSignature, 0, len(slots))
+			for _, slot := range slots {
+				tx := &rpc.TransactionSignature{Slot: slot}
+				txSigsResponse = append(txSigsResponse, tx)
+			}
+			// add an extra signature with lower slot to signal that there the block range is fully processed
+			txSigsResponse = append(txSigsResponse, &rpc.TransactionSignature{Slot: slots[len(slots)-1] - 1})
+			return txSigsResponse, nil
+		}).Once() // GetSignaturesForAddress should be called only once for the whole range, not once per batch.
+
+	blockTime := solana.UnixTimeSeconds(128)
+	lp.Client.EXPECT().
+		GetBlockWithOpts(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, slot uint64, _ *rpc.GetBlockOpts) (*rpc.GetBlockResult, error) {
+			println(slot)
+			require.Contains(t, slots, slot)
+			return &rpc.GetBlockResult{
+				Blockhash:   solana.Hash{1, 2, 3},
+				BlockHeight: &slot,
+				BlockTime:   &blockTime,
+			}, nil
+		}).Times(len(slots))
+
+	err = lp.LogPoller.run(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(105), lp.LogPoller.lastProcessedSlot)
+}
+
 func Test_GetLastProcessedSlot(t *testing.T) {
 	ctx := t.Context()
 


### PR DESCRIPTION
## Summary
PLEX-2601 — Batch block fetching inside the log poller loader so slot discovery via `getSignaturesForAddress` runs once per backfill range, instead of restarting for every slot-range batch.

## Problem
Previously, large backfills were split in the log poller into multiple independent slot ranges. Each range called BackfillForAddresses, which re-ran `getSlotsToFetch` from the newest signatures. Pagination (`beforeSig`) did not carry across adjacent batches, so every batch effectively rediscovered recent history and walked backward again. That added redundant RPC load, slowed deep catch-up on hot addresses, and could worsen throttling or recovery time in worst cases. 

## Solution
* Revert batching at the poller layer (`processBlocksRangeInBatches` / per-batch BackfillForAddresses).
* Move batching to EncodedLogCollector: after a single getSlotsToFetch pass for [fromSlot, toSlot], scheduleBlocksFetching processes the resulting slot list in chunks of LogPollerSlotsBatchSize (limits concurrent getBlock work / memory), while signature discovery pagination stays coherent for the whole range.
* Lower the default LogPollerSlotsBatchSize to further limit memory usage, as `getSlotsToFetch` no longer executed multiple times.  