### PR TITLE
A1 PLEX-2601 LP fix latest processed slot tracking

### DIFF
--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -471,6 +471,8 @@ consumedAllBlocks:
 		}
 	}
 
+	lp.metrics.SetLatestProcessedSlot(ctx, to)
+
 	return nil
 }
 


### PR DESCRIPTION
A1: solana_log_poller_last_processed_slot can stall behind the actual processing cursor
pkg/solana/logpoller/log_poller.go

The solana_log_poller_last_processed_slot metric does not always report the latest processed slot. It is only updated from fetched blocks inside processBlocksRange (log_poller.go, line 466), but BackfillForAddresses only returns blocks that had matching address activity and not every processed block/slot in the requested range. As a result, on sparse/no-event ranges the metric will lag or not move at all for at times. 