### PR TITLE
L4 & L5 Fix potential inconsistency between slot number and block hash returned for LatestBlock and LatestFinalizedBlock

### DIFF
--- a/pkg/solana/chain.go
+++ b/pkg/solana/chain.go
@@ -391,12 +391,12 @@ func (c *chain) LatestHead(ctx context.Context) (types.Head, error) {
 	commitment := c.cfg.Commitment()
 	slot, err := sc.SlotHeightWithCommitment(ctx, commitment)
 	if err != nil {
-		return types.Head{}, nil
+		return types.Head{}, fmt.Errorf("failed to get slot height: %w", err)
 	}
 
 	block, err := sc.GetBlockWithOpts(ctx, slot, client.HeadMetadataGetBlockOpts(commitment))
 	if err != nil {
-		return types.Head{}, nil
+		return types.Head{}, fmt.Errorf("failed to get block: %w", err)
 	}
 
 	if block.BlockHeight == nil {

--- a/pkg/solana/client/multinode_client.go
+++ b/pkg/solana/client/multinode_client.go
@@ -159,20 +159,11 @@ func (m *MultiNodeClient) LatestBlock(ctx context.Context) (*Head, error) {
 	ctx, cancel, chStopInFlight, rawRPC := m.acquireQueryCtx(ctx, m.contextDuration)
 	defer cancel()
 
-	slot, err := rawRPC.GetSlot(ctx, rpc.CommitmentConfirmed)
+	head, err := m.getLatestHead(ctx, rawRPC, rpc.CommitmentConfirmed)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := rawRPC.GetLatestBlockhash(ctx, rpc.CommitmentConfirmed)
-	if err != nil {
-		return nil, err
-	}
-
-	head := &Head{
-		SlotNumber: &slot,
-		BlockHash:  &result.Value.Blockhash,
-	}
 	if !head.IsValid() {
 		return nil, errors.New("invalid head")
 	}
@@ -181,23 +172,47 @@ func (m *MultiNodeClient) LatestBlock(ctx context.Context) (*Head, error) {
 	return head, nil
 }
 
+func (m *MultiNodeClient) getLatestHead(ctx context.Context, rpc *rpc.Client, commitment rpc.CommitmentType) (*Head, error) {
+	slot, err := rpc.GetSlot(ctx, commitment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest slot: %w", err)
+	}
+
+	// find latest non empty slot
+	const maxLookBack = 10
+	var minSlot uint64
+	if slot > maxLookBack {
+		minSlot = slot - maxLookBack
+	}
+	maxSlot := slot
+	nonEmptySlots, err := rpc.GetBlocks(ctx, minSlot, &maxSlot, commitment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get blocks for latest head: %w", err)
+	}
+
+	if len(nonEmptySlots) == 0 {
+		return nil, fmt.Errorf("failed to find non-empty block in last %d slots. Slot range [%d, %d]", maxLookBack, minSlot, maxSlot)
+	}
+
+	latestNonEmptySlot := nonEmptySlots[len(nonEmptySlots)-1]
+	block, err := rpc.GetBlockWithOpts(ctx, latestNonEmptySlot, HeadMetadataGetBlockOpts(commitment))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get block for latest head: %w", err)
+	}
+
+	return &Head{
+		SlotNumber: &latestNonEmptySlot,
+		BlockHash:  &block.Blockhash,
+	}, nil
+}
+
 func (m *MultiNodeClient) LatestFinalizedBlock(ctx context.Context) (*Head, error) {
 	ctx, cancel, chStopInFlight, rawRPC := m.acquireQueryCtx(ctx, m.contextDuration)
 	defer cancel()
 
-	slot, err := rawRPC.GetSlot(ctx, rpc.CommitmentFinalized)
+	head, err := m.getLatestHead(ctx, rawRPC, rpc.CommitmentFinalized)
 	if err != nil {
 		return nil, err
-	}
-
-	result, err := rawRPC.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
-	if err != nil {
-		return nil, err
-	}
-
-	head := &Head{
-		SlotNumber: &slot,
-		BlockHash:  &result.Value.Blockhash,
 	}
 	if !head.IsValid() {
 		return nil, errors.New("invalid head")

--- a/pkg/solana/client/multinode_client_test.go
+++ b/pkg/solana/client/multinode_client_test.go
@@ -2,10 +2,16 @@ package client
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -13,6 +19,113 @@ import (
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	solanatesting "github.com/smartcontractkit/chainlink-solana/pkg/solana/testing"
 )
+
+// jsonRPCErrorBody is the JSON-RPC 2.0 error object.
+type jsonRPCErrorBody struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// jsonRPCOutcome is either a successful result or a JSON-RPC error response.
+type jsonRPCOutcome struct {
+	Result   json.RawMessage
+	RPCError *jsonRPCErrorBody
+}
+
+func jsonRPCSuccess(result json.RawMessage) jsonRPCOutcome {
+	return jsonRPCOutcome{Result: result}
+}
+
+func jsonRPCErrorOutcome(code int, msg string) jsonRPCOutcome {
+	return jsonRPCOutcome{RPCError: &jsonRPCErrorBody{Code: code, Message: msg}}
+}
+
+// jsonRPCHandler handles a single JSON-RPC request. Echo id in responses so the RPC client accepts them.
+type jsonRPCHandler func(method string, params json.RawMessage, id json.RawMessage) jsonRPCOutcome
+
+type jsonRPCRequest struct {
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+	ID     json.RawMessage `json:"id"`
+}
+
+type jsonRPCResponse struct {
+	Error  *jsonRPCErrorBody `json:"error"`
+	Result json.RawMessage   `json:"result"`
+	ID     json.RawMessage   `json:"id"`
+}
+
+func newMockJSONRPCServer(t *testing.T, handle jsonRPCHandler) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var req jsonRPCRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		outcome := handle(req.Method, req.Params, req.ID)
+		w.Header().Set("Content-Type", "application/json")
+		resp := jsonRPCResponse{Result: outcome.Result, Error: outcome.RPCError, ID: req.ID}
+		out, err := json.Marshal(resp)
+		require.NoError(t, err)
+		_, err = w.Write(out)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// testBlockhashB58 is a valid blockhash string for mock getBlock responses.
+const testBlockhashB58 = "5M77sHdwzH6rckuQwF8HL1w52n7hjrh4GVTFiF6T8QyB"
+
+func requireCommitment(t *testing.T, raw json.RawMessage, expectedCommitment rpc.CommitmentType) {
+	t.Helper()
+	var cfg struct {
+		Commitment string `json:"commitment"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &cfg))
+	require.Equal(t, string(expectedCommitment), cfg.Commitment)
+}
+
+func requireValidGetSlotParams(t *testing.T, params json.RawMessage, expectedCommitment rpc.CommitmentType) {
+	t.Helper()
+	var arr []json.RawMessage
+	require.NoError(t, json.Unmarshal(params, &arr))
+	require.Len(t, arr, 1)
+	requireCommitment(t, arr[0], expectedCommitment)
+}
+
+func requireValidGetBlocksParams(t *testing.T, params json.RawMessage, wantMin, wantMax uint64, expectedCommitment rpc.CommitmentType) {
+	t.Helper()
+	var arr []json.RawMessage
+	require.NoError(t, json.Unmarshal(params, &arr))
+	require.Len(t, arr, 3)
+	var minS, maxS uint64
+	require.NoError(t, json.Unmarshal(arr[0], &minS))
+	require.NoError(t, json.Unmarshal(arr[1], &maxS))
+	require.Equal(t, wantMin, minS)
+	require.Equal(t, wantMax, maxS)
+	requireCommitment(t, arr[2], expectedCommitment)
+}
+
+func requireValidGetBlockParams(t *testing.T, params json.RawMessage, wantSlot uint64, expectedCommitment rpc.CommitmentType) {
+	t.Helper()
+	var arr []json.RawMessage
+	require.NoError(t, json.Unmarshal(params, &arr))
+	require.Len(t, arr, 2)
+	var slot uint64
+	require.NoError(t, json.Unmarshal(arr[0], &slot))
+	require.Equal(t, wantSlot, slot)
+
+	var cfg struct {
+		TransactionDetails string `json:"transactionDetails"`
+		Rewards            bool   `json:"rewards"`
+	}
+	require.NoError(t, json.Unmarshal(arr[1], &cfg))
+	require.Equal(t, string(rpc.TransactionDetailsNone), cfg.TransactionDetails)
+	require.False(t, cfg.Rewards)
+	requireCommitment(t, arr[1], expectedCommitment)
+}
 
 func initializeMultiNodeClient(t *testing.T) *MultiNodeClient {
 	url := solanatesting.SetupLocalSolNode(t)
@@ -32,6 +145,159 @@ func TestMultiNodeClient_ClientVersion(t *testing.T) {
 	c := initializeMultiNodeClient(t)
 	_, err := c.ClientVersion(t.Context())
 	require.NoError(t, err)
+}
+
+func TestMultiNodeClient_LatestBlock_MockRPC(t *testing.T) {
+	runGetBlockTest(t, rpc.CommitmentConfirmed, (*MultiNodeClient).LatestBlock)
+}
+
+func TestMultiNodeClient_FinalizedBlock_MockRPC(t *testing.T) {
+	runGetBlockTest(t, rpc.CommitmentConfirmed, (*MultiNodeClient).LatestFinalizedBlock)
+}
+
+func runGetBlockTest(t *testing.T, expectedCommitment rpc.CommitmentType, getBlock func(m *MultiNodeClient, ctx context.Context) (*Head, error)) {
+	expectedHash := solana.MustHashFromBase58(testBlockhashB58)
+	minimalGetBlockResult := fmt.Sprintf(
+		`{"blockhash":%q,"previousBlockhash":"11111111111111111111111111111111","parentSlot":0}`,
+		testBlockhashB58,
+	)
+
+	tests := []struct {
+		name          string
+		handler       jsonRPCHandler
+		expectedError string
+		expectedHead  Head
+	}{
+		{
+			name: "Failure on getSlot",
+			handler: func(method string, params json.RawMessage, _ json.RawMessage) jsonRPCOutcome {
+				switch method {
+				case "getSlot":
+					requireValidGetSlotParams(t, params, expectedCommitment)
+					return jsonRPCErrorOutcome(-32000, "slot unavailable")
+				default:
+					t.Fatalf("unexpected method %s", method)
+					return jsonRPCOutcome{}
+				}
+			},
+			expectedError: "slot unavailable",
+		},
+		{
+			name: "Failure on GetBlocks",
+			handler: func(method string, params json.RawMessage, _ json.RawMessage) jsonRPCOutcome {
+				switch method {
+				case "getSlot":
+					requireValidGetSlotParams(t, params, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(`100`))
+				case "getBlocks":
+					requireValidGetBlocksParams(t, params, 90, 100, expectedCommitment)
+					return jsonRPCErrorOutcome(-32001, "getBlocks failed")
+				default:
+					t.Fatalf("unexpected method %s", method)
+				}
+				return jsonRPCOutcome{}
+			},
+			expectedError: "failed to get blocks for latest head",
+		},
+		{
+			name: "No non-empty blocks in range",
+			handler: func(method string, params json.RawMessage, _ json.RawMessage) jsonRPCOutcome {
+				switch method {
+				case "getSlot":
+					requireValidGetSlotParams(t, params, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(`100`))
+				case "getBlocks":
+					requireValidGetBlocksParams(t, params, 90, 100, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(`[]`))
+				default:
+					t.Fatalf("unexpected method %s", method)
+				}
+				return jsonRPCOutcome{}
+			},
+			expectedError: "failed to find non-empty block in last 10 slots",
+		},
+		{
+			name: "Happy path: latest slot < maxLookBack",
+			handler: func(method string, params json.RawMessage, _ json.RawMessage) jsonRPCOutcome {
+				switch method {
+				case "getSlot":
+					requireValidGetSlotParams(t, params, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(`5`))
+				case "getBlocks":
+					requireValidGetBlocksParams(t, params, 0, 5, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(`[1,2,3]`))
+				case "getBlock":
+					requireValidGetBlockParams(t, params, 3, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(minimalGetBlockResult))
+				default:
+					t.Fatalf("unexpected method %s", method)
+				}
+				return jsonRPCOutcome{}
+			},
+			expectedHead: Head{SlotNumber: ptr[uint64](3), BlockHash: &expectedHash},
+		},
+		{
+			name: "Happy path",
+			handler: func(method string, params json.RawMessage, _ json.RawMessage) jsonRPCOutcome {
+				switch method {
+				case "getSlot":
+					requireValidGetSlotParams(t, params, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(`100`))
+				case "getBlocks":
+					requireValidGetBlocksParams(t, params, 90, 100, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(`[95,97]`))
+				case "getBlock":
+					requireValidGetBlockParams(t, params, 97, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(minimalGetBlockResult))
+				default:
+					t.Fatalf("unexpected method %s", method)
+				}
+				return jsonRPCOutcome{}
+			},
+			expectedHead: Head{SlotNumber: ptr[uint64](97), BlockHash: &expectedHash},
+		},
+		{
+			name: "Get block fails",
+			handler: func(method string, params json.RawMessage, _ json.RawMessage) jsonRPCOutcome {
+				switch method {
+				case "getSlot":
+					requireValidGetSlotParams(t, params, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(`50`))
+				case "getBlocks":
+					requireValidGetBlocksParams(t, params, 40, 50, expectedCommitment)
+					return jsonRPCSuccess(json.RawMessage(`[48,50]`))
+				case "getBlock":
+					requireValidGetBlockParams(t, params, 50, expectedCommitment)
+					return jsonRPCErrorOutcome(-32002, "block not found")
+				default:
+					t.Fatalf("unexpected method %s", method)
+				}
+				return jsonRPCOutcome{}
+			},
+			expectedError: "failed to get block for latest head",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newMockJSONRPCServer(t, tc.handler)
+			c, err := NewMultiNodeClient(server.URL, config.NewDefault(), 5*time.Second, logger.Test(t))
+			require.NoError(t, err)
+			head, err := getBlock(c, t.Context())
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+				require.Nil(t, head)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, head)
+				require.Equal(t, tc.expectedHead, *head)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }
 
 func TestMultiNodeClient_LatestBlock(t *testing.T) {

--- a/pkg/solana/client/multinode_client_test.go
+++ b/pkg/solana/client/multinode_client_test.go
@@ -164,7 +164,7 @@ func TestMultiNodeClient_LatestBlock_MockRPC(t *testing.T) {
 }
 
 func TestMultiNodeClient_FinalizedBlock_MockRPC(t *testing.T) {
-	runGetBlockTest(t, rpc.CommitmentConfirmed, (*MultiNodeClient).LatestFinalizedBlock)
+	runGetBlockTest(t, rpc.CommitmentFinalized, (*MultiNodeClient).LatestFinalizedBlock)
 }
 
 func runGetBlockTest(t *testing.T, expectedCommitment rpc.CommitmentType, getBlock func(m *MultiNodeClient, ctx context.Context) (*Head, error)) {

--- a/pkg/solana/client/multinode_client_test.go
+++ b/pkg/solana/client/multinode_client_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -58,18 +59,29 @@ type jsonRPCResponse struct {
 func newMockJSONRPCServer(t *testing.T, handle jsonRPCHandler) *httptest.Server {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPost, r.Method)
+		if !assert.Equal(t, http.MethodPost, r.Method) {
+			http.Error(w, "only POST supported", http.StatusMethodNotAllowed)
+			return
+		}
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if !assert.NoError(t, err) {
+			http.Error(w, "failed to read body", http.StatusInternalServerError)
+			return
+		}
 		var req jsonRPCRequest
-		require.NoError(t, json.Unmarshal(body, &req))
+		if !assert.NoError(t, json.Unmarshal(body, &req)) {
+			http.Error(w, "invalid JSON-RPC request", http.StatusBadRequest)
+			return
+		}
 		outcome := handle(req.Method, req.Params, req.ID)
 		w.Header().Set("Content-Type", "application/json")
 		resp := jsonRPCResponse{Result: outcome.Result, Error: outcome.RPCError, ID: req.ID}
 		out, err := json.Marshal(resp)
-		require.NoError(t, err)
-		_, err = w.Write(out)
-		require.NoError(t, err)
+		if !assert.NoError(t, err) {
+			http.Error(w, "failed to marshal response", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(out)
 	}))
 	t.Cleanup(server.Close)
 	return server


### PR DESCRIPTION
The PR fixes following issues:
## L4 Non-atomic RPC invocations can construct self-inconsistent heads. 
In multinode_client.go, both LatestBlock and LatestFinalizedBlock got updated to return the slot number instead of the block height. However, these functions can now construct self-inconsistent heads because they build Head from two separate RPC responses:

## L5 Invalid error suppression can lead to invalid data interpretation
In chain.go::LatestHead, if the calls to SlotHeightWithCommitment and GetBlockWithOpts fail, the error is not propagated to the caller, who gets an empty Head with no error, making it impossible to detect the RPC error. On the other hand, the newly added FinalizedHead ([PR #1484](https://github.com/smartcontractkit/chainlink-solana/pull/1484)) properly handles the errors of the same calls.
