### PR TITLE
A2 Avoid redundant get signatures for address jobs

### DIFF
--- a/pkg/solana/logpoller/job_get_slots_for_addr.go
+++ b/pkg/solana/logpoller/job_get_slots_for_addr.go
@@ -115,6 +115,10 @@ func (f *getSlotsForAddressJob) run(ctx context.Context) (bool, error) {
 		}
 
 		f.storeSlot(sig.Slot)
+
+		if sig.Slot == f.from {
+			return true, nil
+		}
 	}
 
 	oldestSig := sigs[len(sigs)-1]

--- a/pkg/solana/logpoller/job_get_slots_for_addr_test.go
+++ b/pkg/solana/logpoller/job_get_slots_for_addr_test.go
@@ -105,7 +105,7 @@ func TestGetSlotsForAddressJob(t *testing.T) {
 		err := job.Run(t.Context())
 		require.NoError(t, err)
 		requireJobIsDone(t, job.Done(), "expected job to be done")
-		require.Equal(t, []uint64{19, 20, 11, 10, 10}, actualSlots)
+		require.Equal(t, []uint64{19, 20, 11, 10}, actualSlots)
 	})
 	t.Run("If slot range may have more signatures, schedules a new job", func(t *testing.T) {
 		client := mocks.NewRPCClient(t)

--- a/pkg/solana/logpoller/loader_test.go
+++ b/pkg/solana/logpoller/loader_test.go
@@ -54,16 +54,13 @@ func TestEncodedLogCollector_MultipleEventOrdered(t *testing.T) {
 	address, err := solana.PublicKeyFromBase58("J1zQwrBNBngz26jRPNWsUSZMHJwBwpkoDitXRV95LdK4")
 	require.NoError(t, err)
 	slots := []uint64{44, 43, 42, 41}
-	var txSigsResponse []*rpc.TransactionSignature
-	for _, slot := range slots {
-		txSigsResponse = append(txSigsResponse, &rpc.TransactionSignature{Slot: slot})
-	}
 	client.EXPECT().GetSignaturesForAddressWithOpts(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, key solana.PublicKey, opts *rpc.GetSignaturesForAddressOpts) ([]*rpc.TransactionSignature, error) {
 		switch *opts.MinContextSlot {
 		case 44:
-			return txSigsResponse, nil
-		case 41:
-			return nil, nil
+			return []*rpc.TransactionSignature{{Slot: 44}, {Slot: 43}, {Slot: 42, Signature: solana.Signature{1, 2, 3}}}, nil
+		case 42:
+			require.Equal(t, solana.Signature{1, 2, 3}, opts.Before)
+			return []*rpc.TransactionSignature{{Slot: 42}, {Slot: 41}}, nil
 		default:
 			panic("unexpected call")
 		}
@@ -215,7 +212,7 @@ func TestEncodedLogCollector_Backfill_DoesNotBlockOnRPCError(t *testing.T) {
 			default:
 				panic("unexpected call")
 			}
-		}).Twice()
+		}).Once()
 
 	// Make one slot fail.
 	const failingSlot uint64 = 43


### PR DESCRIPTION
Fixes: In job_get_slots_for_addr.go, the job runner function (run()) could unnecessarily spawn a child job when the requested f.from == sig.Slot and there are no more sigs returned by the top-level `client.GetSignaturesForAddressWithOpts`.
