### PR TITLE
DF-23489 WIP bump multinode, retain behaviour

### DIFF
--- a/pkg/solana/cmd/chainlink-solana/main.go
+++ b/pkg/solana/cmd/chainlink-solana/main.go
@@ -65,6 +65,9 @@ func (c *pluginRelayer) NewRelayer(ctx context.Context, config string, keystore 
 		return nil, fmt.Errorf("failed to decode config toml: %w:\n\t%s", err, config)
 	}
 
+	// force-retain prior behavior in multinode's unreachableLoop
+	cfg.Solana.MultiNode.MultiNode.PollSuccessThreshold = new(uint32)
+
 	rawNodes := make([]map[string]string, 0, len(cfg.Solana.Nodes))
 	for _, n := range cfg.Solana.Nodes {
 		if n == nil || n.URL == nil {


### PR DESCRIPTION
### Description

Bumps chainlink-framework retaining behavior:
- `PollSuccessThreshold == 0` is set explicitly, retaining previous behaviour
- `RandomRPC` node selection is not configured — no effect.

[DF-23489](https://smartcontract-it.atlassian.net/browse/DF-23489)

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies

Waiting for tag of https://github.com/smartcontractkit/chainlink-framework/pull/101
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->


[DF-23489]: https://smartcontract-it.atlassian.net/browse/DF-23489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ