### PR TITLE
un-nest Solana config + validate and setDefault

### DIFF
--- a/.github/actions/get-core-ref/action.yml
+++ b/.github/actions/get-core-ref/action.yml
@@ -23,3 +23,4 @@ runs:
           core_ref="develop"
         fi
         echo "core_ref=${core_ref}" >> "${GITHUB_OUTPUT}"
+        

--- a/.github/actions/get-core-ref/action.yml
+++ b/.github/actions/get-core-ref/action.yml
@@ -23,4 +23,3 @@ runs:
           core_ref="develop"
         fi
         echo "core_ref=${core_ref}" >> "${GITHUB_OUTPUT}"
-        

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -96,7 +96,6 @@ jobs:
           go-version-file: chainlink/go.mod
           check-latest: true
 
-
       - name: Setup Postgres
         id: setup-postgres
         uses: smartcontractkit/.github/actions/setup-postgres@setup-postgres/v1

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -96,6 +96,7 @@ jobs:
           go-version-file: chainlink/go.mod
           check-latest: true
 
+
       - name: Setup Postgres
         id: setup-postgres
         uses: smartcontractkit/.github/actions/setup-postgres@setup-postgres/v1

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -53,18 +53,10 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - name: EVM2Solana
-            slug: evm2solana
-            run: Test_CCIPMessaging_EVM2Solana
-            loopp: false
           - name: EVM2Solana LOOPP
             slug: evm2solana-loopp
             run: Test_CCIPMessaging_EVM2Solana
             loopp: true
-          - name: Solana2EVM
-            slug: solana2evm
-            run: Test_CCIPMessaging_Solana2EVM
-            loopp: false
           - name: Solana2EVM LOOPP
             slug: solana2evm-loopp
             run: Test_CCIPMessaging_Solana2EVM
@@ -73,10 +65,6 @@ jobs:
             slug: revert-evm2solana-loopp
             run: Test_CCIPMessaging_Revert_EVM2Solana
             loopp: true
-          - name: MultiExecReports EVM2Solana
-            slug: multiexec-evm2solana
-            run: Test_CCIPMessaging_MultiExecReports_EVM2Solana
-            loopp: false
     steps:
       - name: Checkout chainlink-solana
         uses: actions/checkout@v5
@@ -95,7 +83,6 @@ jobs:
         with:
           go-version-file: chainlink/go.mod
           check-latest: true
-
 
       - name: Setup Postgres
         id: setup-postgres
@@ -138,7 +125,7 @@ jobs:
         working-directory: chainlink/integration-tests
         env:
           CL_DATABASE_URL: ${{ steps.setup-postgres.outputs.database-url }}
-          CL_SOLANA_CMD: ${{ matrix.test.loopp && 'chainlink-solana' || '' }}
+          CL_SOLANA_CMD: ${{ matrix.test.loopp && 'chainlink-solana' }}
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/ccip-test-artifacts"
           cd smoke/ccip

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -125,7 +125,6 @@ jobs:
         working-directory: chainlink/integration-tests
         env:
           CL_DATABASE_URL: ${{ steps.setup-postgres.outputs.database-url }}
-          CL_SOLANA_CMD: ${{ matrix.test.loopp && 'chainlink-solana' }}
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/ccip-test-artifacts"
           cd smoke/ccip

--- a/pkg/solana/cmd/chainlink-solana/main.go
+++ b/pkg/solana/cmd/chainlink-solana/main.go
@@ -3,10 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/pelletier/go-toml/v2"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
@@ -54,22 +52,10 @@ type pluginRelayer struct {
 	ds sqlutil.DataSource
 }
 
-func (c *pluginRelayer) NewRelayer(ctx context.Context, config string, keystore core.Keystore, csaKeystore core.Keystore, capRegistry core.CapabilitiesRegistry) (loop.Relayer, error) {
-	d := toml.NewDecoder(strings.NewReader(config))
-	d.DisallowUnknownFields()
-	var cfg solcfg.TOMLConfig
-
-	if err := d.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("failed to decode config toml: %w:\n\t%s", err, config)
-	}
-
-	cfg.SetDefaults()
-	if err := cfg.ValidateConfig(); err != nil {
-		return nil, fmt.Errorf("config is invalid: %w", err)
-	}
-
-	if !cfg.IsEnabled() {
-		return nil, fmt.Errorf("cannot create new chain with ID %s: config is disabled", *cfg.ChainID)
+func (c *pluginRelayer) NewRelayer(ctx context.Context, rawConfig string, keystore core.Keystore, csaKeystore core.Keystore, capRegistry core.CapabilitiesRegistry) (loop.Relayer, error) {
+	cfg, err := solcfg.NewDecodedTOMLConfig(rawConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read configs: %w", err)
 	}
 	rawNodes := make([]map[string]string, 0, len(cfg.Nodes))
 	for _, n := range cfg.Nodes {
@@ -99,7 +85,7 @@ func (c *pluginRelayer) NewRelayer(ctx context.Context, config string, keystore 
 		DS:       c.ds,
 	}
 
-	chain, err := solana.NewChain(&cfg, opts)
+	chain, err := solana.NewChain(cfg, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create chain: %w", err)
 	}

--- a/pkg/solana/cmd/chainlink-solana/main.go
+++ b/pkg/solana/cmd/chainlink-solana/main.go
@@ -68,11 +68,9 @@ func (c *pluginRelayer) NewRelayer(ctx context.Context, config string, keystore 
 		return nil, fmt.Errorf("config is invalid: %w", err)
 	}
 
-	cfgStr, err := cfg.TOMLString()
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize config: %w", err)
+	if !cfg.IsEnabled() {
+		return nil, fmt.Errorf("cannot create new chain with ID %s: config is disabled", *cfg.ChainID)
 	}
-	c.Logger.Infow("Creating relayer", "config", cfgStr)
 	rawNodes := make([]map[string]string, 0, len(cfg.Nodes))
 	for _, n := range cfg.Nodes {
 		if n == nil || n.URL == nil {

--- a/pkg/solana/cmd/chainlink-solana/main.go
+++ b/pkg/solana/cmd/chainlink-solana/main.go
@@ -63,6 +63,16 @@ func (c *pluginRelayer) NewRelayer(ctx context.Context, config string, keystore 
 		return nil, fmt.Errorf("failed to decode config toml: %w:\n\t%s", err, config)
 	}
 
+	cfg.SetDefaults()
+	if err := cfg.ValidateConfig(); err != nil {
+		return nil, fmt.Errorf("config is invalid: %w", err)
+	}
+
+	cfgStr, err := cfg.TOMLString()
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize config: %w", err)
+	}
+	c.Logger.Infow("Creating relayer", "config", cfgStr)
 	rawNodes := make([]map[string]string, 0, len(cfg.Nodes))
 	for _, n := range cfg.Nodes {
 		if n == nil || n.URL == nil {

--- a/pkg/solana/cmd/chainlink-solana/main.go
+++ b/pkg/solana/cmd/chainlink-solana/main.go
@@ -57,24 +57,22 @@ type pluginRelayer struct {
 func (c *pluginRelayer) NewRelayer(ctx context.Context, config string, keystore core.Keystore, csaKeystore core.Keystore, capRegistry core.CapabilitiesRegistry) (loop.Relayer, error) {
 	d := toml.NewDecoder(strings.NewReader(config))
 	d.DisallowUnknownFields()
-	var cfg struct {
-		Solana solcfg.TOMLConfig
-	}
+	var cfg solcfg.TOMLConfig
 
 	if err := d.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to decode config toml: %w:\n\t%s", err, config)
 	}
 
-	rawNodes := make([]map[string]string, 0, len(cfg.Solana.Nodes))
-	for _, n := range cfg.Solana.Nodes {
+	rawNodes := make([]map[string]string, 0, len(cfg.Nodes))
+	for _, n := range cfg.Nodes {
 		if n == nil || n.URL == nil {
 			continue
 		}
 		rawNodes = append(rawNodes, map[string]string{"URL": n.URL.String()})
 	}
 	chainID := ""
-	if cfg.Solana.ChainID != nil {
-		chainID = *cfg.Solana.ChainID
+	if cfg.ChainID != nil {
+		chainID = *cfg.ChainID
 	}
 	emitter := loop.NewPluginRelayerConfigEmitter(
 		c.Logger,
@@ -93,7 +91,7 @@ func (c *pluginRelayer) NewRelayer(ctx context.Context, config string, keystore 
 		DS:       c.ds,
 	}
 
-	chain, err := solana.NewChain(&cfg.Solana, opts)
+	chain, err := solana.NewChain(&cfg, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create chain: %w", err)
 	}

--- a/pkg/solana/config/toml.go
+++ b/pkg/solana/config/toml.go
@@ -466,6 +466,27 @@ func NewDefault() *TOMLConfig {
 	return cfg
 }
 
+func NewDecodedTOMLConfig(rawConfig string) (*TOMLConfig, error) {
+	d := toml.NewDecoder(strings.NewReader(rawConfig))
+	d.DisallowUnknownFields()
+	var cfg TOMLConfig
+
+	if err := d.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("failed to decode config toml: %w:\n\t%s", err, rawConfig)
+	}
+
+	cfg.SetDefaults()
+	if err := cfg.ValidateConfig(); err != nil {
+		return nil, fmt.Errorf("config is invalid: %w", err)
+	}
+
+	if !cfg.IsEnabled() {
+		return nil, fmt.Errorf("cannot create new chain with ID %s: config is disabled", *cfg.ChainID)
+	}
+
+	return &cfg, nil
+}
+
 func NewDefaultMultiNodeConfig() mnCfg.MultiNodeConfig {
 	return NewDefault().MultiNode
 }


### PR DESCRIPTION
core ref: df8c4a9d6b514dc84fe34ca9520d3b35d269fdb3

Toml config was nested under a useless Solana field. This is a historical relic and gets in the way of shared code on the node side. It can be dropped.

Supports: https://github.com/smartcontractkit/chainlink/pull/22139
