### PR TITLE
Narrow fields returned scope of BHE's GetBlock fetch

### DIFF
--- a/pkg/solana/client/client.go
+++ b/pkg/solana/client/client.go
@@ -40,22 +40,6 @@ func HeadMetadataGetBlockOpts(commitment rpc.CommitmentType) *rpc.GetBlockOpts {
 	}
 }
 
-// FeeEstimatorGetBlockOpts returns options for getBlock tuned for the BlockHistoryEstimator.
-// This includes the full transaction list which is needed to inspect compute budget instructions
-// and tx fees, but with rewards excluded and base64 transaction encoding so the response is
-// decoded via the binary path instead of reflective JSON (memory heavy, 1-4MB JSON payload per block).
-func FeeEstimatorGetBlockOpts(commitment rpc.CommitmentType) *rpc.GetBlockOpts {
-	rewards := false
-	v := MaxSupportTransactionVersion
-	return &rpc.GetBlockOpts{
-		Commitment:                     commitment,
-		Encoding:                       solana.EncodingBase64,
-		TransactionDetails:             rpc.TransactionDetailsFull,
-		Rewards:                        &rewards,
-		MaxSupportedTransactionVersion: &v,
-	}
-}
-
 type ReaderWriter interface {
 	Writer
 	Reader
@@ -493,11 +477,11 @@ func (c *Client) GetBlock(ctx context.Context, slot uint64) (result *rpc.GetBloc
 	// it would treat all GetBlock calls as identical and merge them, returning whichever block it fetched first to all callers.
 	key := fmt.Sprintf("GetBlockWithOpts(%d)", slot)
 	v, err, _ := c.requestGroup.Do(key, func() (interface{}, error) {
-		// The only production caller of this method (and the GetLatestBlock wrapper above) seems to be the
-		// BlockHistoryEstimator, which only consumes tx.Meta.Fee and tx.Message.Instructions/AccountKeys.
-		// Use the BHE-tuned opts so we don't pull rewards/balances/log messages or pay heavy reflective
-		// JSON decoding cost on every poll. See FeeEstimatorGetBlockOpts for rationale.
-		return c.rpc.GetBlockWithOpts(ctx, slot, FeeEstimatorGetBlockOpts(c.commitment))
+		version := MaxSupportTransactionVersion
+		return c.rpc.GetBlockWithOpts(ctx, slot, &rpc.GetBlockOpts{
+			Commitment:                     c.commitment,
+			MaxSupportedTransactionVersion: &version,
+		})
 	})
 	res, ok := v.(*rpc.GetBlockResult)
 	if !ok {

--- a/pkg/solana/client/client.go
+++ b/pkg/solana/client/client.go
@@ -40,6 +40,22 @@ func HeadMetadataGetBlockOpts(commitment rpc.CommitmentType) *rpc.GetBlockOpts {
 	}
 }
 
+// FeeEstimatorGetBlockOpts returns options for getBlock tuned for the BlockHistoryEstimator.
+// This includes the full transaction list which is needed to inspect compute budget instructions
+// and tx fees, but with rewards excluded and base64 transaction encoding so the response is
+// decoded via the binary path instead of reflective JSON (memory heavy, 1-4MB JSON payload per block).
+func FeeEstimatorGetBlockOpts(commitment rpc.CommitmentType) *rpc.GetBlockOpts {
+	rewards := false
+	v := MaxSupportTransactionVersion
+	return &rpc.GetBlockOpts{
+		Commitment:                     commitment,
+		Encoding:                       solana.EncodingBase64,
+		TransactionDetails:             rpc.TransactionDetailsFull,
+		Rewards:                        &rewards,
+		MaxSupportedTransactionVersion: &v,
+	}
+}
+
 type ReaderWriter interface {
 	Writer
 	Reader
@@ -477,11 +493,11 @@ func (c *Client) GetBlock(ctx context.Context, slot uint64) (result *rpc.GetBloc
 	// it would treat all GetBlock calls as identical and merge them, returning whichever block it fetched first to all callers.
 	key := fmt.Sprintf("GetBlockWithOpts(%d)", slot)
 	v, err, _ := c.requestGroup.Do(key, func() (interface{}, error) {
-		version := MaxSupportTransactionVersion
-		return c.rpc.GetBlockWithOpts(ctx, slot, &rpc.GetBlockOpts{
-			Commitment:                     c.commitment,
-			MaxSupportedTransactionVersion: &version,
-		})
+		// The only production caller of this method (and the GetLatestBlock wrapper above) seems to be the
+		// BlockHistoryEstimator, which only consumes tx.Meta.Fee and tx.Message.Instructions/AccountKeys.
+		// Use the BHE-tuned opts so we don't pull rewards/balances/log messages or pay heavy reflective
+		// JSON decoding cost on every poll. See FeeEstimatorGetBlockOpts for rationale.
+		return c.rpc.GetBlockWithOpts(ctx, slot, FeeEstimatorGetBlockOpts(c.commitment))
 	})
 	res, ok := v.(*rpc.GetBlockResult)
 	if !ok {

--- a/pkg/solana/fees/block_history.go
+++ b/pkg/solana/fees/block_history.go
@@ -16,6 +16,9 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 )
@@ -30,6 +33,20 @@ var (
 var _ Estimator = &blockHistoryEstimator{}
 
 var errNoComputeUnitPriceCollected = fmt.Errorf("no compute unit prices collected")
+
+// blockHistoryGetBlockOpts returns getBlock options tuned for fee estimation: full transactions with
+// base64 encoding so responses decode via the binary path, rewards omitted.
+func blockHistoryGetBlockOpts(commitment rpc.CommitmentType) *rpc.GetBlockOpts {
+	rewards := false
+	v := client.MaxSupportTransactionVersion
+	return &rpc.GetBlockOpts{
+		Commitment:                     commitment,
+		Encoding:                       solana.EncodingBase64,
+		TransactionDetails:             rpc.TransactionDetailsFull,
+		Rewards:                        &rewards,
+		MaxSupportedTransactionVersion: &v,
+	}
+}
 
 type blockHistoryEstimator struct {
 	starter services.StateMachine
@@ -156,8 +173,12 @@ func (bhe *blockHistoryEstimator) calculatePriceFromLatestBlock(ctx context.Cont
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	// get latest block based on configured confirmation
-	block, err := c.GetLatestBlock(ctx)
+	slot, err := c.SlotHeightWithCommitment(ctx, bhe.cfg.Commitment())
+	if err != nil {
+		return fmt.Errorf("failed to get slot: %w", err)
+	}
+
+	block, err := c.GetBlockWithOpts(ctx, slot, blockHistoryGetBlockOpts(bhe.cfg.Commitment()))
 	if err != nil {
 		return fmt.Errorf("failed to get block: %w", err)
 	}
@@ -281,7 +302,7 @@ func (bhe *blockHistoryEstimator) populateCache(ctx context.Context, loadBatch, 
 			defer func() { <-semaphore }()
 
 			// Fetch the block details
-			block, errGetBlock := c.GetBlock(ctx, s)
+			block, errGetBlock := c.GetBlockWithOpts(ctx, s, blockHistoryGetBlockOpts(bhe.cfg.Commitment()))
 			if errGetBlock != nil {
 				bhe.lgr.Errorw("BlockHistoryEstimator: failed to get block at slot", "slot", s, "error", errGetBlock)
 				return

--- a/pkg/solana/fees/block_history_test.go
+++ b/pkg/solana/fees/block_history_test.go
@@ -51,10 +51,12 @@ func TestBlockHistoryEstimator_LatestBlock(t *testing.T) {
 	lastBlock := testBlocks[len(testBlocks)-1]
 	lastBlockFeeData, _ := ParseBlock(lastBlock)
 	lastBlockMedianPrice, _ := mathutil.Median(lastBlockFeeData.Prices...)
+	lastSlot := lastBlock.ParentSlot + 1
 
 	rw := clientmock.NewReaderWriter(t)
 	rwLoader := func(ctx context.Context) (client.ReaderWriter, error) { return rw, nil }
-	rw.On("GetLatestBlock", mock.Anything).Return(lastBlock, nil)
+	rw.On("SlotHeightWithCommitment", mock.Anything, mock.Anything).Return(lastSlot, nil)
+	rw.On("GetBlockWithOpts", mock.Anything, lastSlot, mock.Anything).Return(lastBlock, nil)
 
 	t.Run("Successful Estimation", func(t *testing.T) {
 		// Setup
@@ -105,13 +107,14 @@ func TestBlockHistoryEstimator_LatestBlock(t *testing.T) {
 		rwLoader := func(ctx context.Context) (client.ReaderWriter, error) { return rw, nil }
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
-		rw.On("GetLatestBlock", mock.Anything).Return(nil, fmt.Errorf("fail rpc call")) // Mock GetLatestBlock returning error
+		rw.On("SlotHeightWithCommitment", mock.Anything, mock.Anything).Return(lastSlot, nil)
+		rw.On("GetBlockWithOpts", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("fail rpc call"))
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t), chainID)
 
 		// Ensure the price remains unchanged
-		require.Error(t, estimator.calculatePrice(ctx), "Expected error when GetLatestBlock fails")
+		require.Error(t, estimator.calculatePrice(ctx), "Expected error when GetBlockWithOpts fails")
 		cfg.On("ComputeUnitPriceMax").Return(maxPrice)
-		assert.Equal(t, uint64(100), estimator.BaseComputeUnitPrice(), "Price should not change when GetLatestBlock fails")
+		assert.Equal(t, uint64(100), estimator.BaseComputeUnitPrice(), "Price should not change when GetBlockWithOpts fails")
 	})
 
 	t.Run("Failed to Parse Block", func(t *testing.T) {
@@ -120,7 +123,8 @@ func TestBlockHistoryEstimator_LatestBlock(t *testing.T) {
 		rwLoader := func(ctx context.Context) (client.ReaderWriter, error) { return rw, nil }
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
-		rw.On("GetLatestBlock", mock.Anything).Return(nil, nil) // Mock GetLatestBlock returning nil
+		rw.On("SlotHeightWithCommitment", mock.Anything, mock.Anything).Return(lastSlot, nil)
+		rw.On("GetBlockWithOpts", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t), chainID)
 
 		// Ensure the price remains unchanged
@@ -135,7 +139,8 @@ func TestBlockHistoryEstimator_LatestBlock(t *testing.T) {
 		rwLoader := func(ctx context.Context) (client.ReaderWriter, error) { return rw, nil }
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
-		rw.On("GetLatestBlock", mock.Anything).Return(&rpc.GetBlockResult{}, nil) // Mock GetLatestBlock returning empty block
+		rw.On("SlotHeightWithCommitment", mock.Anything, mock.Anything).Return(lastSlot, nil)
+		rw.On("GetBlockWithOpts", mock.Anything, mock.Anything, mock.Anything).Return(&rpc.GetBlockResult{}, nil)
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t), chainID)
 
 		// Ensure the price remains unchanged
@@ -203,7 +208,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 	rw.On("GetBlocksWithLimit", mock.Anything, mock.Anything, mock.Anything).
 		Return(&testSlotsResult, nil)
 	for i, slot := range testSlots {
-		rw.On("GetBlock", mock.Anything, slot).
+		rw.On("GetBlockWithOpts", mock.Anything, slot, mock.Anything).
 			Return(testBlocks[i], nil)
 	}
 
@@ -234,7 +239,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 			if i == 0 {
 				continue
 			}
-			partialCacheRW.On("GetBlock", mock.Anything, slot).Return(testBlocks[i], nil).Once()
+			partialCacheRW.On("GetBlockWithOpts", mock.Anything, slot, mock.Anything).Return(testBlocks[i], nil).Once()
 		}
 
 		// Setup
@@ -404,7 +409,7 @@ func TestBlockHistoryEstimator_MultipleBlocks(t *testing.T) {
 		cleanCacheRw.On("GetBlocksWithLimit", mock.Anything, mock.Anything, mock.Anything).
 			Return(&testSlotsResult, nil).Once()
 		for i, slot := range testSlots {
-			cleanCacheRw.On("GetBlock", mock.Anything, slot).Return(testBlocks[i], nil).Once()
+			cleanCacheRw.On("GetBlockWithOpts", mock.Anything, slot, mock.Anything).Return(testBlocks[i], nil).Once()
 		}
 
 		// Setup
@@ -453,6 +458,7 @@ func setupConfigMock(cfg *cfgmock.Config, defaultPrice uint64, minPrice uint64, 
 	cfg.On("BlockHistoryPollPeriod").Return(pollPeriod).Once()
 	cfg.On("BlockHistorySize").Return(depth)
 	cfg.On("BlockHistoryBatchLoadSize").Return(uint64(20)).Maybe()
+	cfg.On("Commitment").Return(rpc.CommitmentConfirmed).Maybe()
 }
 
 // initializeEstimator initializes, starts, and ensures cleanup of the BlockHistoryEstimator.

--- a/pkg/solana/fees/block_history_test.go
+++ b/pkg/solana/fees/block_history_test.go
@@ -3,6 +3,7 @@ package fees
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -108,7 +109,7 @@ func TestBlockHistoryEstimator_LatestBlock(t *testing.T) {
 		cfg := cfgmock.NewConfig(t)
 		setupConfigMock(cfg, defaultPrice, minPrice, pollPeriod, depth)
 		rw.On("SlotHeightWithCommitment", mock.Anything, mock.Anything).Return(lastSlot, nil)
-		rw.On("GetBlockWithOpts", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("fail rpc call"))
+		rw.On("GetBlockWithOpts", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("fail rpc call"))
 		estimator := initializeEstimator(ctx, t, rwLoader, cfg, logger.Test(t), chainID)
 
 		// Ensure the price remains unchanged

--- a/pkg/solana/txm/txm_internal_test.go
+++ b/pkg/solana/txm/txm_internal_test.go
@@ -125,7 +125,8 @@ func TestTxm(t *testing.T) {
 			cfg := config.NewDefault()
 			cfg.Chain.FeeEstimatorMode = &estimator
 			mc := mocks.NewReaderWriter(t)
-			mc.On("GetLatestBlock", mock.Anything).Return(&rpc.GetBlockResult{}, nil).Maybe()
+			mc.On("SlotHeightWithCommitment", mock.Anything, mock.Anything).Return(uint64(1), nil).Maybe()
+			mc.On("GetBlockWithOpts", mock.Anything, mock.Anything, mock.Anything).Return(&rpc.GetBlockResult{}, nil).Maybe()
 			mc.On("SlotHeight", mock.Anything).Return(uint64(0), nil).Maybe()
 
 			// mock solana keystore


### PR DESCRIPTION
Narrow BHE `getBlock` payload to cut allocation churn