### PR TITLE
chore(ci): bump GHA deps

### DIFF
--- a/.github/actions/build-gauntlet/action.yml
+++ b/.github/actions/build-gauntlet/action.yml
@@ -9,7 +9,7 @@ runs:
       id: tool-versions
 
     - name: Setup Node ${{ steps.tool-versions.outputs.nodejs_version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ steps.tool-versions.outputs.nodejs_version }}
 

--- a/.github/actions/build-test-image/action.yml
+++ b/.github/actions/build-test-image/action.yml
@@ -30,40 +30,62 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+      with:
+        aws-region: ${{ inputs.QA_AWS_REGION }}
+        role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: 3600
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+      with:
+        mask-password: "true"
+
     - name: Check if image exists
       id: check-image
-      uses: smartcontractkit/chainlink-github-actions/docker/image-exists@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
+      uses: smartcontractkit/.github/actions/ecr-image-exists@ecr-image-exists/0.2.0
       with:
         repository: chainlink-solana-tests
         tag: ${{ inputs.tag }}
-        AWS_REGION: ${{ inputs.QA_AWS_REGION }}
-        AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        aws-region: ${{ inputs.QA_AWS_REGION }}
+        aws-role-arn: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+
     - name: Download Artifacts
-      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      uses: actions/download-artifact@v8
       with:
         name: artifacts
         path: ${{ inputs.artifacts_path }}
+
     - name: Get CTF Version
       id: version
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/mod-version@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
+      uses: smartcontractkit/.github/actions/ctf-check-mod-version@ctf-check-mod-version/0.1.0
       with:
         go-project-path: ./integration-tests
         module-name: github.com/smartcontractkit/chainlink-testing-framework/lib
         enforce-semantic-tag: false
-    - name: Build and Publish Test Runner
+
+    - name: Set up Docker Buildx
       if: steps.check-image.outputs.exists == 'false'
-      uses: smartcontractkit/chainlink-github-actions/docker/build-push@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+    - name: Build and Push
+      if: steps.check-image.outputs.exists == 'false'
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      id: build-image
       with:
-        tags: |
-          ${{ inputs.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ inputs.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ inputs.tag }}
-          ${{ inputs.other_tags }}
+        context: .
         file: ./integration-tests/test.Dockerfile
         build-args: |
           BASE_IMAGE=${{ inputs.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ inputs.QA_AWS_REGION }}.amazonaws.com/test-base-image
           IMAGE_VERSION=${{ steps.version.outputs.version }}
           SUITES="${{ inputs.suites }}"
-        AWS_REGION: ${{ inputs.QA_AWS_REGION }}
-        AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        tags: |
+          ${{ inputs.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ inputs.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ inputs.tag }}
+          ${{ inputs.other_tags }}
+        push: true
+
     - name: Print Image Built
       shell: sh
       run: |

--- a/.github/actions/build-test-image/action.yml
+++ b/.github/actions/build-test-image/action.yml
@@ -31,7 +31,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+      uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
       with:
         aws-region: ${{ inputs.QA_AWS_REGION }}
         role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
@@ -39,7 +39,7 @@ runs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+      uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
       with:
         mask-password: "true"
 

--- a/.github/actions/build-wrapped-anchor-image/action.yml
+++ b/.github/actions/build-wrapped-anchor-image/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Get ProjectSerum Version
       uses: ./.github/actions/projectserum_version
@@ -16,7 +16,7 @@ runs:
 
     - name: cache docker build image
       id: cache-image
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: contracts/docker-build.tar
         key: ${{ inputs.runner-os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}

--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Checkout solana
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: smartcontractkit/chainlink-solana
         ref: ${{ inputs.ref }}
@@ -32,7 +32,7 @@ runs:
 
     - name: cache docker build image
       id: cache-image
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: contracts/docker-build.tar
         key: ${{ inputs.runner-os }}-docker-pnpm-build-${{ steps.get-version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
@@ -74,7 +74,7 @@ runs:
 
     #save the contracts artifacts
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: artifacts
         path: contracts/target/deploy

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: false
@@ -26,7 +26,7 @@ runs:
     - name: Get branch name
       if: ${{ inputs.only-modules == 'false' }}
       id: branch-name
-      uses: smartcontractkit/.github/actions/branch-names@branch-names/1.0.0
+      uses: smartcontractkit/.github/actions/branch-names@branch-names/v1
 
     - name: Set go cache keys
       shell: bash
@@ -40,7 +40,7 @@ runs:
       shell: bash
       run: echo "path=./${{ inputs.go-module-file }}" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       name: Cache Go Modules
       with:
         path: |
@@ -51,7 +51,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       if: ${{ inputs.only-modules == 'false' }}
       name: Cache Go Build Outputs
       with:

--- a/.github/actions/setup-testdb/action.yml
+++ b/.github/actions/setup-testdb/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Setup Postgres
       id: setup-postgres
-      uses: smartcontractkit/.github/actions/setup-postgres@13b05e8b4e11a8c4402f8034daaf9a4332032dc7 # v1.0.0
+      uses: smartcontractkit/.github/actions/setup-postgres@setup-postgres/v1
       with:
         tmpfs: 'true'
     # This is considered untrusted code from the POV of chainlink-solana, but this is safe as long as we:
@@ -23,7 +23,7 @@ runs:
     # - Unset all secrets passed to this action by workflows calling it, before running "go run ./core/store/cmd/preparetest"
     # codeql[actions/untrusted-checkout]: disable
     - name: Checkout chainlink
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: smartcontractkit/chainlink
         ref: ${{ inputs.core-ref || 'develop' }}

--- a/.github/actions/setup-testdb/action.yml
+++ b/.github/actions/setup-testdb/action.yml
@@ -33,8 +33,10 @@ runs:
         unset GRAFANA_INTERNAL_TENANT_ID
         unset GRAFANA_INTERNAL_BASIC_AUTH
         unset GRAFANA_INTERNAL_HOST
+
         cd chainlink
         go run ./core/store/cmd/preparetest
       shell: bash
       env:
         CL_DATABASE_URL: ${{ steps.setup-postgres.outputs.database-url }}
+        GOTOOLCHAIN: "" # allow auto selection for running preparetest in chainlink repo

--- a/.github/workflows/api-diff.yml
+++ b/.github/workflows/api-diff.yml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ matrix.module }}/go.mod
           cache: false

--- a/.github/workflows/ccip-solana-messaging.yml
+++ b/.github/workflows/ccip-solana-messaging.yml
@@ -36,7 +36,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get core ref
         id: get-core-ref
@@ -67,12 +67,12 @@ jobs:
             loopp: true
     steps:
       - name: Checkout chainlink-solana
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: chainlink-solana
 
       - name: Checkout chainlink
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: smartcontractkit/chainlink
           ref: ${{ needs.get-core-ref.outputs.core-ref }}
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload test output
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ccip-messaging-${{ matrix.test.slug }}-${{ github.run_id }}
           path: ccip-test-artifacts/

--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -16,7 +16,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get ProjectSerum Version
         id: psversion
         uses: ./.github/actions/projectserum_version
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get_projectserum_version]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build Artifacts
         env:
           psversion: ${{ needs.get_projectserum_version.outputs.projectserum_version }}
@@ -38,7 +38,7 @@ jobs:
         run: |
           tar cfvz artifacts.tar.gz target/deploy/*.so target/idl/*
       - name: Create Release
-        uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: |
             contracts/artifacts.tar.gz

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -278,7 +278,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -286,7 +286,7 @@ jobs:
           mask-aws-account-id: true
 
       - name: Authenticate to ECR
-        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
         with:
           registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
         env:
@@ -415,7 +415,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -423,7 +423,7 @@ jobs:
           mask-aws-account-id: true
 
       - name: Authenticate to ECR
-        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
         with:
           registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
         env:

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           check-latest: true
@@ -45,7 +45,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get ProjectSerum Version
         id: psversion
@@ -57,7 +57,7 @@ jobs:
     outputs:
       changed: ${{ steps.changes.outputs.contracts }}
     steps:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           base: develop
@@ -79,7 +79,7 @@ jobs:
     needs: [ get_projectserum_version ]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
@@ -102,7 +102,7 @@ jobs:
     if: needs.contract-changes.outputs.changed == 'true'
     steps:
       - name: Checkout previous release
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: v1.0.2 # set to v1.1.0 after v1.1.0 is deployed to mainnet
       - name: build contracts
@@ -124,7 +124,7 @@ jobs:
           # clean up the container
           docker stop build-container
           docker rm build-container
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts-previous
           path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
@@ -145,7 +145,7 @@ jobs:
     outputs:
       changed: ${{ steps.check.outputs.continue }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: artifacts
           path: ./temp/artifacts
@@ -155,7 +155,7 @@ jobs:
           cd ./temp/artifacts # need to be in directory for hashes to  compare without path differences
           # shellcheck disable=SC2035
           echo "hash=$(sha1sum * | sha1sum)" >> "$GITHUB_OUTPUT"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: artifacts-previous
           path: ./temp/artifacts/previous
@@ -174,7 +174,7 @@ jobs:
           if [ "${{ steps.previous.outputs.hash }}" != "${{ steps.current.outputs.hash }}" ]; then
             echo "continue=true" >> "$GITHUB_OUTPUT"
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check.outputs.continue
         with:
           name: artifacts
@@ -193,7 +193,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get core ref
         id: get-core-ref
@@ -213,7 +213,7 @@ jobs:
     steps:
       - name: Check if image exists in ECR
         id: check-image-exists
-        uses: smartcontractkit/.github/actions/ecr-image-exists@ecr-image-exists/0.0.1
+        uses: smartcontractkit/.github/actions/ecr-image-exists@ecr-image-exists/0.2.0
         with:
           repository: "chainlink"
           tag: solana.${{ github.sha }}
@@ -221,7 +221,7 @@ jobs:
 
       - name: Checkout Chainlink repo
         if: ${{ steps.check-image-exists.outputs.exists != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: smartcontractkit/chainlink
           ref: ${{ needs.get-core-ref.outputs.core-ref }}
@@ -275,10 +275,10 @@ jobs:
         secrets.QA_AWS_ACCOUNT_NUMBER, secrets.QA_AWS_REGION, github.sha) }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -286,7 +286,7 @@ jobs:
           mask-aws-account-id: true
 
       - name: Authenticate to ECR
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
         env:
@@ -299,7 +299,7 @@ jobs:
         uses: ./.github/actions/build-gauntlet
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: integration-tests/go.mod
           cache: true
@@ -310,7 +310,7 @@ jobs:
         run: go mod download
 
       - name: Download contract artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: artifacts
           path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
@@ -356,7 +356,7 @@ jobs:
 
       - name: Upload Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-test-logs-${{ matrix.variant }}
           path: |
@@ -412,10 +412,10 @@ jobs:
         secrets.QA_AWS_ACCOUNT_NUMBER, secrets.QA_AWS_REGION, github.sha) }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -423,7 +423,7 @@ jobs:
           mask-aws-account-id: true
 
       - name: Authenticate to ECR
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
         env:
@@ -436,7 +436,7 @@ jobs:
         uses: ./.github/actions/build-gauntlet
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: integration-tests/go.mod
           cache: true
@@ -447,13 +447,13 @@ jobs:
         run: go mod download
 
       - name: Download previous contract artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: artifacts-previous
           path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
 
       - name: Download current contract artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: artifacts
           path: contracts/target/deploy-upgrade
@@ -489,7 +489,7 @@ jobs:
 
       - name: Upload Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: upgrade-test-logs-${{ matrix.variant }}
           path: |

--- a/.github/workflows/e2e_custom_cl_reusable.yml
+++ b/.github/workflows/e2e_custom_cl_reusable.yml
@@ -45,12 +45,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: smartcontractkit/chainlink-solana
           ref: ${{ inputs.tests_ref || inputs.solana_ref }}
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           check-latest: true
@@ -68,7 +68,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: smartcontractkit/chainlink-solana
           ref: ${{ inputs.solana_ref }}
@@ -89,7 +89,7 @@ jobs:
     needs: [ get_projectserum_version ]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: smartcontractkit/chainlink-solana
           ref: ${{ inputs.solana_ref }}
@@ -125,7 +125,7 @@ jobs:
         inputs.image_tag) }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: smartcontractkit/chainlink-solana
           ref: ${{ inputs.tests_ref || inputs.solana_ref }}
@@ -134,7 +134,7 @@ jobs:
         run: ./scripts/install-solana-ci.sh
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.aws_region }}
           role-to-assume: ${{ secrets.aws_role_to_assume }}
@@ -142,7 +142,7 @@ jobs:
           mask-aws-account-id: true
 
       - name: Authenticate to ECR
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ secrets.aws_account_id }}
         env:
@@ -152,7 +152,7 @@ jobs:
         uses: ./.github/actions/build-gauntlet
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: integration-tests/go.mod
           cache: true
@@ -163,7 +163,7 @@ jobs:
         run: go mod download
 
       - name: Download contract artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: artifacts
           path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
@@ -199,7 +199,7 @@ jobs:
 
       - name: Upload Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-test-logs-${{ matrix.variant }}
           path: |

--- a/.github/workflows/e2e_custom_cl_reusable.yml
+++ b/.github/workflows/e2e_custom_cl_reusable.yml
@@ -134,7 +134,7 @@ jobs:
         run: ./scripts/install-solana-ci.sh
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: ${{ secrets.aws_region }}
           role-to-assume: ${{ secrets.aws_role_to_assume }}
@@ -142,7 +142,7 @@ jobs:
           mask-aws-account-id: true
 
       - name: Authenticate to ECR
-        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
         with:
           registries: ${{ secrets.aws_account_id }}
         env:

--- a/.github/workflows/e2e_testnet_daily.yml
+++ b/.github/workflows/e2e_testnet_daily.yml
@@ -154,7 +154,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -162,7 +162,7 @@ jobs:
           mask-aws-account-id: true
 
       - name: Authenticate to ECR
-        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
         with:
           registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
         env:

--- a/.github/workflows/e2e_testnet_daily.yml
+++ b/.github/workflows/e2e_testnet_daily.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           check-latest: true
@@ -46,7 +46,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get ProjectSerum Version
         id: psversion
         uses: ./.github/actions/projectserum_version
@@ -64,7 +64,7 @@ jobs:
     needs: [ get_projectserum_version ]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
         with:
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Check if image exists in ECR
         id: check-image-exists
-        uses: smartcontractkit/.github/actions/ecr-image-exists@ecr-image-exists/0.0.1
+        uses: smartcontractkit/.github/actions/ecr-image-exists@ecr-image-exists/0.2.0
         with:
           repository: "chainlink"
           tag: solana.${{ github.sha }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Checkout Chainlink repo
         if: ${{ steps.check-image-exists.outputs.exists != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: smartcontractkit/chainlink
           ref: ${{ github.event.inputs.cl_branch_ref }}
@@ -151,10 +151,10 @@ jobs:
       SOLANA_PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -162,7 +162,7 @@ jobs:
           mask-aws-account-id: true
 
       - name: Authenticate to ECR
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
         env:
@@ -175,7 +175,7 @@ jobs:
         uses: ./.github/actions/build-gauntlet
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: integration-tests/go.mod
           cache: true
@@ -186,7 +186,7 @@ jobs:
         run: go mod download
 
       - name: Download contract artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: artifacts
           path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-test-logs-${{ matrix.variant }}
           path: |

--- a/.github/workflows/gauntlet.yml
+++ b/.github/workflows/gauntlet.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       nodejs_version: ${{ steps.tool-versions.outputs.nodejs_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: smartcontractkit/tool-versions-to-env-action@v1.0.8
         id: tool-versions
 
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tool_versions]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Node ${{ needs.tool_versions.outputs.nodejs_version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ needs.tool_versions.outputs.nodejs_version }}
       - name: Install
@@ -39,9 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tool_versions]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Node ${{ needs.tool_versions.outputs.nodejs_version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ needs.tool_versions.outputs.nodejs_version }}
       - name: Install
@@ -55,14 +55,14 @@ jobs:
       CI: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Nix
-        uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # nix:v2.24.6
+        uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: "sandbox = false"
       - name: Cache Nix
-        uses: cachix/cachix-action@18cf96c7c98e048e10a83abd92116114cd8504be # v14
+        uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
         with:
           name: chainlink-cosmos
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -70,7 +70,7 @@ jobs:
       - run: nix develop -c yarn --cwd ./gauntlet eslint
       - name: Upload eslint report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gauntlet-eslint-report
           path: ./gauntlet/eslint-report.json
@@ -80,9 +80,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tool_versions]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Nix
-        uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # nix:v2.24.6
+        uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: "sandbox = false"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,7 +12,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -23,7 +23,7 @@ jobs:
           echo "version=${version}" | tee -a "$GITHUB_OUTPUT"
       - name: Run golangci-lint (integration-tests)
         if: ${{ always() && !contains(join(github.event.pull_request.labels.*.name, ' '), 'allow-lint-issues') }}
-        uses: smartcontractkit/.github/actions/ci-lint-go@cdcf67030997adc322ddb2ad48949f394f5b04a3 #ci-lint-go/3.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v4
         env:
           checkout-repo: false
           golangci-lint-version: v${{ steps.get-version.outputs.version }}
@@ -38,7 +38,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run golangci-lint (relay)
         if: ${{ always() && !contains(join(github.event.pull_request.labels.*.name, ' '), 'allow-lint-issues') }}
-        uses: smartcontractkit/.github/actions/ci-lint-go@cdcf67030997adc322ddb2ad48949f394f5b04a3 #ci-lint-go/3.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v4
         with:
           checkout-repo: false
           golangci-lint-version: v${{ steps.get-version.outputs.version }}
@@ -59,7 +59,7 @@ jobs:
             --output.checkstyle.path=${{ github.workspace }}/pkg/golangci-lint-report.xml --output.text.path=stdout
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: golangci-lint-relay-report
           path: ${{ github.workspace }}/pkg/golangci-lint-report.xml

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -24,7 +24,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get ProjectSerum Version
         id: psversion
         uses: ./.github/actions/projectserum_version
@@ -42,7 +42,7 @@ jobs:
     needs: [ get-projectserum-version ]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
         with:
@@ -63,7 +63,7 @@ jobs:
     needs: [ e2e-custom-build-artifacts ]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Build Image

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run actionlint
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Docker Buildx Build
         run: docker buildx build --file ops/monitoring/Dockerfile ./

--- a/.github/workflows/nix-packages-test.yml
+++ b/.github/workflows/nix-packages-test.yml
@@ -8,10 +8,10 @@ jobs:
   nix-packages-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # nix:v2.24.6
+        uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: "sandbox = false"

--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -79,7 +79,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Create pull request
         if: '!steps.check.outputs.skip'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: ${{ steps.run.outputs.prTitle }}
           base: ${{ steps.branch.outputs.original }}

--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -17,13 +17,13 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           check-latest: true
           cache: true
-      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # nix:v2.24.6
+      - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run changes
@@ -55,7 +55,7 @@ jobs:
           echo "original=$SHA" >> "$GITHUB_OUTPUT"
           git branch "${{ steps.run.outputs.name }}"
           git push origin "${{ steps.run.outputs.name }}"
-      - uses: planetscale/ghcommit-action@21a8cda29f55e5cc2cdae0cdbdd08e38dd148c25 # v0.1.37
+      - uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
         if: '!steps.check.outputs.skip'
         with:
           commit_message: ${{ steps.run.outputs.commitString }}
@@ -72,14 +72,14 @@ jobs:
       - name: Setup GitHub Token
         if: '!steps.check.outputs.skip'
         id: token
-        uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_SOLANA_CICD_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.AWS_RELENG_TEAM_GATI_LAMBDA_URL }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Create pull request
         if: '!steps.check.outputs.skip'
-        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           title: ${{ steps.run.outputs.prTitle }}
           base: ${{ steps.branch.outputs.original }}

--- a/.github/workflows/publish-df-sdk.yml
+++ b/.github/workflows/publish-df-sdk.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: develop
 

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest-8cores-32GB
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           check-latest: true
@@ -58,7 +58,7 @@ jobs:
         run: GORACE="log_path=$PWD/race" go test ./pkg/... -race -count=5 -timeout=15m -covermode=atomic -coverpkg=./... -coverprofile=race_coverage.txt
       - name: Upload Go test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: go-relay-test-results
           path: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get ProjectSerum Version
         id: psversion
         uses: ./.github/actions/projectserum_version
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: build image
         uses: ./.github/actions/build-wrapped-anchor-image
         with:
@@ -41,20 +41,20 @@ jobs:
     steps:
       - name: Free Disk Space
         uses: smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target dir
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: contracts/target
           key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('contracts/**/Cargo.lock') }}
       - name: Cache hello-world target dir
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: contracts/examples/hello-world/target
           key: ${{ runner.os }}-v2-cargo-build-target-hello-world-${{ hashFiles('contracts/**/Cargo.lock') }}
       - name: cache docker build image
         id: cache-image
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: contracts/docker-build.tar
           key: ${{ runner.os }}-docker-pnpm-build-${{ needs.get_projectserum_version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
@@ -88,15 +88,15 @@ jobs:
     steps:
       - name: Free Disk Space
         uses: smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target dir
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: contracts/target
           key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('contracts/**/Cargo.lock') }}
       - name: cache docker build image
         id: cache-image
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: contracts/docker-build.tar
           key: ${{ runner.os }}-docker-pnpm-build-${{ needs.get_projectserum_version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
@@ -133,17 +133,17 @@ jobs:
       - name: Free Disk Space
         uses: smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache cargo target dir
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: contracts/target
           key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('contracts/**/Cargo.lock') }}
 
       - name: cache docker build image
         id: cache-image
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           fail-on-cache-miss: true
           path: contracts/docker-build.tar
@@ -154,7 +154,7 @@ jobs:
           docker load --input docker-build.tar
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "./integration-tests/go.mod"
           check-latest: true
@@ -164,7 +164,7 @@ jobs:
         run: ../scripts/install-solana-ci.sh
 
       - name: Setup Postgres
-        uses: smartcontractkit/.github/actions/setup-postgres@13b05e8b4e11a8c4402f8034daaf9a4332032dc7 # v1.0.0
+        uses: smartcontractkit/.github/actions/setup-postgres@setup-postgres/v1
         with:
           tmpfs: "true"
 
@@ -202,15 +202,15 @@ jobs:
     runs-on: ubuntu-latest-8cores-32GB
     needs: [get_projectserum_version, build_wrapped_anchor_image]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target dir
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: contracts/target
           key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('contracts/**/Cargo.lock') }}
       - name: cache docker build image
         id: cache-image
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: contracts/docker-build.tar
           key: ${{ runner.os }}-docker-pnpm-build-${{ needs.get_projectserum_version.outputs.projectserum_version }}-${{ hashFiles('contracts/**/Cargo.lock') }}
@@ -218,7 +218,7 @@ jobs:
         run: |
           docker load --input docker-build.tar
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "./go.mod"
           check-latest: true

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -18,10 +18,10 @@ permissions:
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@351f82a4dc29e4159746a068ed925da17341219f
@@ -30,7 +30,7 @@ jobs:
         components: rustfmt, clippy
 
     - name: Cache Cargo dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -30,7 +30,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get ProjectSerum Version
         id: psversion
         uses: ./.github/actions/projectserum_version
@@ -48,7 +48,7 @@ jobs:
     needs: [ get_projectserum_version ]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build contracts
         uses: ./.github/actions/build_contract_artifacts
         with:
@@ -78,10 +78,10 @@ jobs:
     needs: [ e2e_custom_build_artifacts ]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -89,7 +89,7 @@ jobs:
           mask-aws-account-id: true
 
       - name: Authenticate to ECR
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
         env:
@@ -102,7 +102,7 @@ jobs:
         uses: ./.github/actions/build-gauntlet
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: integration-tests/go.mod
           cache: true
@@ -113,7 +113,7 @@ jobs:
         run: go mod download
 
       - name: Download contract artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: artifacts
           path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: soak-test-logs-${{ matrix.variant }}
           path: |

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -89,7 +89,7 @@ jobs:
           mask-aws-account-id: true
 
       - name: Authenticate to ECR
-        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
         with:
           registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
         env:

--- a/.github/workflows/solana-verified-build.yml
+++ b/.github/workflows/solana-verified-build.yml
@@ -21,11 +21,11 @@ jobs:
       solana_changes: ${{ steps.changes.outputs.solana_changes }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Detect changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           list-files: "shell"
@@ -41,7 +41,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Get Long and Short SHAs
@@ -54,17 +54,17 @@ jobs:
           echo "short_sha=${FULL_SHA:0:12}"
           echo "full_sha=${FULL_SHA}"
         } >> "$GITHUB_OUTPUT"
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ steps.get_sha.outputs.full_sha }}
         fetch-depth: 0
-    - uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1
+    - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
     - name: Install Solana Verify
       run: |
         cargo install solana-verify@0.4.6
     - name: Cache cargo target dir
       id: cache-target
-      uses: actions/cache@v4 # v4
+      uses: actions/cache@v5
       with:
         path: /contracts/target/deploy/*.so
         key: ${{ runner.os }}-solana-contract-verified-${{ hashFiles('contracts/**/*.rs', 'contracts/**/Cargo.lock') }}
@@ -78,7 +78,7 @@ jobs:
         cd contracts
         tar cfvz artifacts.tar.gz target/deploy/*.so 
     - name: Publish Release
-      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: solana-artifacts-localtest-${{ steps.get_sha.outputs.short_sha }}

--- a/.github/workflows/solana-verified-build.yml
+++ b/.github/workflows/solana-verified-build.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         ref: ${{ steps.get_sha.outputs.full_sha }}
         fetch-depth: 0
-    - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
+    - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
     - name: Install Solana Verify
       run: |
         cargo install solana-verify@0.4.6

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -13,13 +13,13 @@ jobs:
     if: always()
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
 
       - name: Wait for Workflows
         id: wait
-        uses: smartcontractkit/chainlink-github-actions/utils/wait-for-workflows@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
+        uses: smartcontractkit/chainlink-github-actions/utils/wait-for-workflows@v2.3.32
         with:
           max-timeout: "1200"
           polling-interval: "30"
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Parse tool-versions file
         uses: smartcontractkit/tool-versions-to-env-action@v1.0.8
         id: tool-versions
@@ -48,12 +48,12 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Fetch blame information
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # fetches all history for all tags and branches to provide more metadata for sonar reports
 
       - name: Download Golangci integration tests reports
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
         with:
           workflow: golangci-lint.yml
           workflow_conclusion: ""
@@ -62,7 +62,7 @@ jobs:
           if_no_artifact_found: warn
 
       - name: Download Golangci relay reports
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
         with:
           workflow: golangci-lint.yml
           workflow_conclusion: ""
@@ -71,7 +71,7 @@ jobs:
           if_no_artifact_found: warn
 
       - name: Download Relayer unit tests report
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
         with:
           workflow: relay.yml
           workflow_conclusion: ""
@@ -80,7 +80,7 @@ jobs:
           if_no_artifact_found: warn
 
       - name: Download gauntlet eslint reports
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
         with:
           workflow: gauntlet.yml
           workflow_conclusion: ""
@@ -105,7 +105,7 @@ jobs:
 
 
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@53c3e3207fe4b8d52e2f1ac9d6eb1d2506f626c0 # v2.0.2
+        uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         with:
           args: >
             -Dsonar.go.tests.reportPaths=${{ steps.sonarqube_report_paths.outputs.sonarqube_tests_report_paths }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v9.0.0
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         exempt-all-pr-assignees: true

--- a/.github/workflows/upstream-tracker.yml
+++ b/.github/workflows/upstream-tracker.yml
@@ -43,7 +43,7 @@ jobs:
           echo "$WIKI" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
           echo "wikirange=$WIKIRANGE" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.updates.outputs.open || steps.updates.outputs.closed || steps.updates.outputs.wiki
       - name: Open Issue
         if: steps.updates.outputs.open || steps.updates.outputs.closed || steps.updates.outputs.wiki


### PR DESCRIPTION
Bumps many GHA dependencies to their newest versions, for `node24` support.

### Changes

* Apart from the bumps as detailed below I've migrated some references from `chainlink-github-actions` repo to the equivalent action in the `.github` repository.
    * See: `.github/actions/build-test-image/action.yml`

### Updates

```
Updated (24):
  actions-rust-lang/setup-rust-toolchain                  9399c7bb15d4 → 46268bd06076  # v1.16.1
  actions/cache                                           v4 → v5
  actions/checkout                                        v4 → v6
  actions/download-artifact                               65a9edc58814 → v8
  actions/setup-go                                        v5 → v6
  actions/setup-node                                      v4 → v6
  actions/stale                                           v9.0.0 → v10
  actions/upload-artifact                                 v4 → v7
  aws-actions/amazon-ecr-login                            062b18b96a7a → fa648b43de3d  # v2.1.5
  aws-actions/configure-aws-credentials                   010d0da01d0b → d979d5b3a711  # v6.1.1
  cachix/cachix-action                                    18cf96c7c98e → 5f2d7c529421  # v17
  cachix/install-nix-action                               3715ab1a11ca → 8aa03977d8d7  # v31.10.6
  dawidd6/action-download-artifact                        bf251b5aa9c2 → b6e2e70617bc  # v21
  docker/setup-buildx-action                              d70bba72b1f3 → 4d04d5d9486b  # v4.0.0
  dorny/paths-filter                                      de90cc6fb38f → fbd0ab8f3e69  # v4.0.1
  peter-evans/create-pull-request                         6d6857d36972 → 5f6978faf089  # v8.1.1
  planetscale/ghcommit-action                             21a8cda29f55 → 25309d8005ac  # v0.2.20
  smartcontractkit/.github/actions/branch-names           branch-names/1.0.0 → branch-names/v1
  smartcontractkit/.github/actions/ci-lint-go             cdcf67030997 → ci-lint-go/v4
  smartcontractkit/.github/actions/ecr-image-exists       ecr-image-exists/0.0.1 → ecr-image-exists/0.2.0
  smartcontractkit/.github/actions/setup-github-token     ef78fa97bf3c → setup-github-token/v1
  smartcontractkit/.github/actions/setup-postgres         13b05e8b4e11 → setup-postgres/v1
  softprops/action-gh-release                             c95fe1489396 → b4309332981a  # v3.0.0
  sonarsource/sonarqube-scan-action                       53c3e3207fe4 → 59db25f34e16  # v8.0.0

Skipped - already up to date (9):
  actions/checkout
  actions/setup-go
  reviewdog/action-actionlint
  smartcontractkit/.github/actions/apidiff-go
  smartcontractkit/.github/actions/changed-modules-go
  smartcontractkit/.github/actions/ctf-build-image
  smartcontractkit/.github/actions/free-disk-space
  smartcontractkit/.github/actions/setup-postgres
  smartcontractkit/tool-versions-to-env-action

Unknown - not in config (1):
  slackapi/slack-github-action

Files scanned: 28  modified: 28
```

### Testing 

This PR.
