### PR TITLE
Deprecate eventDetail for BlockData for CPI event extraction

### DIFF
--- a/pkg/solana/logpoller/cpi_event_extractor.go
+++ b/pkg/solana/logpoller/cpi_event_extractor.go
@@ -2,9 +2,8 @@ package logpoller
 
 import (
 	"encoding/base64"
-	"sync"
-
 	bin "encoding/binary"
+	"sync"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
@@ -83,8 +82,7 @@ func (e *CPIEventExtractor) HasCPIFilters() bool {
 func (e *CPIEventExtractor) ExtractCPIEvents(
 	tx *solana.Transaction,
 	meta *rpc.TransactionMeta,
-	detail eventDetail,
-	logIdxOffset uint,
+	blockData types.BlockData,
 ) []types.ProgramEvent {
 	if meta == nil || len(meta.InnerInstructions) == 0 {
 		return nil
@@ -99,7 +97,7 @@ func (e *CPIEventExtractor) ExtractCPIEvents(
 	defer e.mu.RUnlock()
 
 	var events []types.ProgramEvent
-	logIdx := logIdxOffset
+	logIdx := blockData.TransactionLogIndex
 
 	for _, inner := range meta.InnerInstructions {
 		if int(inner.Index) >= len(tx.Message.Instructions) {
@@ -190,14 +188,14 @@ func (e *CPIEventExtractor) ExtractCPIEvents(
 			event := types.ProgramEvent{
 				Program: sourceProgram.ToSolana().String(),
 				BlockData: types.BlockData{
-					SlotNumber:          detail.slotNumber,
-					BlockHeight:         detail.blockHeight,
-					BlockHash:           detail.blockHash,
-					BlockTime:           detail.blockTime,
-					TransactionHash:     detail.trxSig,
-					TransactionIndex:    detail.trxIdx,
+					SlotNumber:          blockData.SlotNumber,
+					BlockHeight:         blockData.BlockHeight,
+					BlockHash:           blockData.BlockHash,
+					BlockTime:           blockData.BlockTime,
+					TransactionHash:     blockData.TransactionHash,
+					TransactionIndex:    blockData.TransactionIndex,
 					TransactionLogIndex: logIdx,
-					Error:               detail.err,
+					Error:               blockData.Error,
 				},
 				Data:  encodedData,
 				IsCPI: true,

--- a/pkg/solana/logpoller/cpi_event_extractor_test.go
+++ b/pkg/solana/logpoller/cpi_event_extractor_test.go
@@ -122,16 +122,16 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 			},
 		}
 
-		detail := eventDetail{
-			slotNumber:  100,
-			blockHeight: 99,
-			blockHash:   solana.Hash{1, 2, 3},
-			blockTime:   solana.UnixTimeSeconds(12345),
-			trxIdx:      0,
-			trxSig:      solana.Signature{4, 5, 6},
+		blockData := types.BlockData{
+			SlotNumber:  100,
+			BlockHeight: 99,
+			BlockHash:   solana.Hash{1, 2, 3},
+			BlockTime:   solana.UnixTimeSeconds(12345),
+			TransactionIndex: 0,
+			TransactionHash:  solana.Signature{4, 5, 6},
 		}
 
-		events := extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		events := extractor.ExtractCPIEvents(tx, meta, blockData)
 
 		require.Len(t, events, 1)
 		event := events[0]
@@ -139,7 +139,7 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 		require.Equal(t, sourceProgram.ToSolana().String(), event.Program)
 		require.Equal(t, uint64(100), event.SlotNumber)
 		require.Equal(t, uint64(99), event.BlockHeight)
-		require.Equal(t, detail.trxSig, event.TransactionHash)
+		require.Equal(t, blockData.TransactionHash, event.TransactionHash)
 
 		decodedData, err := base64.StdEncoding.DecodeString(event.Data)
 		require.NoError(t, err)
@@ -205,8 +205,8 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 			},
 		}
 
-		detail := eventDetail{slotNumber: 100}
-		events := extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		blockData := types.BlockData{SlotNumber: 100}
+		events := extractor.ExtractCPIEvents(tx, meta, blockData)
 		require.Empty(t, events)
 	})
 
@@ -258,8 +258,8 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 			},
 		}
 
-		detail := eventDetail{slotNumber: 100}
-		events := extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		blockData := types.BlockData{SlotNumber: 100}
+		events := extractor.ExtractCPIEvents(tx, meta, blockData)
 		require.Empty(t, events)
 	})
 
@@ -317,8 +317,8 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 			},
 		}
 
-		detail := eventDetail{slotNumber: 100}
-		events := extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		blockData := types.BlockData{SlotNumber: 100}
+		events := extractor.ExtractCPIEvents(tx, meta, blockData)
 		require.Empty(t, events)
 	})
 
@@ -381,8 +381,8 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 			},
 		}
 
-		detail := eventDetail{slotNumber: 100}
-		events := extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		blockData := types.BlockData{SlotNumber: 100}
+		events := extractor.ExtractCPIEvents(tx, meta, blockData)
 
 		require.Len(t, events, 1)
 		event := events[0]
@@ -409,9 +409,9 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 		}
 		extractor.AddFilter(filter)
 
-		detail := eventDetail{slotNumber: 100}
+		blockData := types.BlockData{SlotNumber: 100}
 
-		events := extractor.ExtractCPIEvents(nil, nil, detail, 0)
+		events := extractor.ExtractCPIEvents(nil, nil, blockData)
 		require.Empty(t, events)
 
 		tx := &solana.Transaction{
@@ -419,13 +419,13 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 				AccountKeys: []solana.PublicKey{solana.PublicKey(sourceProgram)},
 			},
 		}
-		events = extractor.ExtractCPIEvents(tx, nil, detail, 0)
+		events = extractor.ExtractCPIEvents(tx, nil, blockData)
 		require.Empty(t, events)
 
 		meta := &rpc.TransactionMeta{
 			InnerInstructions: []rpc.InnerInstruction{},
 		}
-		events = extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		events = extractor.ExtractCPIEvents(tx, meta, blockData)
 		require.Empty(t, events)
 	})
 
@@ -487,8 +487,8 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 			},
 		}
 
-		detail := eventDetail{slotNumber: 100}
-		events := extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		blockData := types.BlockData{SlotNumber: 100}
+		events := extractor.ExtractCPIEvents(tx, meta, blockData)
 
 		require.Len(t, events, 1)
 		require.Equal(t, sourceProgram.ToSolana().String(), events[0].Program)
@@ -545,8 +545,8 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 			},
 		}
 
-		detail := eventDetail{slotNumber: 200}
-		events := extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		blockData := types.BlockData{SlotNumber: 200}
+		events := extractor.ExtractCPIEvents(tx, meta, blockData)
 
 		require.Len(t, events, 1)
 		require.True(t, events[0].IsCPI)
@@ -608,8 +608,8 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 			},
 		}
 
-		detail := eventDetail{slotNumber: 100}
-		events := extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		blockData := types.BlockData{SlotNumber: 100}
+		events := extractor.ExtractCPIEvents(tx, meta, blockData)
 		require.Empty(t, events)
 	})
 
@@ -663,8 +663,8 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 			},
 		}
 
-		detail := eventDetail{slotNumber: 100}
-		events := extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		blockData := types.BlockData{SlotNumber: 100}
+		events := extractor.ExtractCPIEvents(tx, meta, blockData)
 		require.Empty(t, events)
 	})
 
@@ -719,8 +719,8 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 			},
 		}
 
-		detail := eventDetail{slotNumber: 100}
-		events := extractor.ExtractCPIEvents(tx, meta, detail, 0)
+		blockData := types.BlockData{SlotNumber: 100}
+		events := extractor.ExtractCPIEvents(tx, meta, blockData)
 
 		require.Len(t, events, 1)
 		require.True(t, events[0].IsCPI)

--- a/pkg/solana/logpoller/cpi_event_extractor_test.go
+++ b/pkg/solana/logpoller/cpi_event_extractor_test.go
@@ -123,10 +123,10 @@ func TestCPIEventExtractor_ExtractCPIEvents(t *testing.T) {
 		}
 
 		blockData := types.BlockData{
-			SlotNumber:  100,
-			BlockHeight: 99,
-			BlockHash:   solana.Hash{1, 2, 3},
-			BlockTime:   solana.UnixTimeSeconds(12345),
+			SlotNumber:       100,
+			BlockHeight:      99,
+			BlockHash:        solana.Hash{1, 2, 3},
+			BlockTime:        solana.UnixTimeSeconds(12345),
 			TransactionIndex: 0,
 			TransactionHash:  solana.Signature{4, 5, 6},
 		}

--- a/pkg/solana/logpoller/job_get_block.go
+++ b/pkg/solana/logpoller/job_get_block.go
@@ -112,24 +112,24 @@ func (j *getBlockJob) Run(ctx context.Context) error {
 		return err
 	}
 
-	detail := eventDetail{
-		slotNumber: j.slotNumber,
-		blockHash:  block.Blockhash,
+	blockData := types.BlockData{
+		SlotNumber: j.slotNumber,
+		BlockHash:  block.Blockhash,
 	}
 
 	if block.BlockHeight == nil {
 		return fmt.Errorf("block at slot %d returned from rpc is missing block number", j.slotNumber)
 	}
-	detail.blockHeight = *block.BlockHeight
+	blockData.BlockHeight = *block.BlockHeight
 
 	if block.BlockTime == nil {
 		return fmt.Errorf("block at slot %d returned from rpc is missing block time", j.slotNumber)
 	}
-	detail.blockTime = *block.BlockTime
+	blockData.BlockTime = *block.BlockTime
 
 	events := make([]types.ProgramEvent, 0, len(block.Transactions))
 	for idx, txWithMeta := range block.Transactions {
-		detail.trxIdx = idx
+		blockData.TransactionIndex = idx
 		if txWithMeta.Transaction == nil {
 			return fmt.Errorf("failed to parse transaction %d in slot %d: %w", idx, j.slotNumber, errors.New("missing transaction field"))
 		}
@@ -143,20 +143,21 @@ func (j *getBlockJob) Run(ctx context.Context) error {
 		if txWithMeta.Meta == nil {
 			return fmt.Errorf("expected transaction to have meta. signature: %s; slot: %d; idx: %d", tx.Signatures[0], j.slotNumber, idx)
 		}
-		detail.trxSig = tx.Signatures[0] // according to Solana docs first signature is used as ID
-		detail.err = txWithMeta.Meta.Err
+		blockData.TransactionHash = tx.Signatures[0] // according to Solana docs first signature is used as ID
+		blockData.Error = txWithMeta.Meta.Err
 
 		txOutcome := txSucceeded
 		if txWithMeta.Meta.Err != nil {
 			txOutcome = txReverted
 		}
 
-		txEvents := j.messagesToEvents(ctx, txWithMeta.Meta.LogMessages, detail, txOutcome)
+		txEvents := j.messagesToEvents(ctx, txWithMeta.Meta.LogMessages, blockData, txOutcome)
 		events = append(events, txEvents...)
 
 		// Look for events corresponding to CPI filters
 		if j.cpiEventExtractor != nil && j.cpiEventExtractor.HasCPIFilters() {
-			cpiEvents := j.cpiEventExtractor.ExtractCPIEvents(tx, txWithMeta.Meta, detail, uint(len(txEvents)))
+			blockData.TransactionLogIndex = uint(len(txEvents))
+			cpiEvents := j.cpiEventExtractor.ExtractCPIEvents(tx, txWithMeta.Meta, blockData)
 			events = append(events, cpiEvents...)
 		}
 	}
@@ -178,32 +179,32 @@ func (j *getBlockJob) Run(ctx context.Context) error {
 	return nil
 }
 
-func (j *getBlockJob) messagesToEvents(ctx context.Context, messages []string, detail eventDetail, txOutcome txOutcome) []types.ProgramEvent {
+func (j *getBlockJob) messagesToEvents(ctx context.Context, messages []string, blockData types.BlockData, txOutcome txOutcome) []types.ProgramEvent {
 	var logIdx uint
 	events := make([]types.ProgramEvent, 0, len(messages))
 	outputs, err := j.parseProgramLogs(messages)
 	if err != nil {
-		j.lggr.Errorf("failed to parse program logs at slot %d for tx %s. Skipping tx due to error: %v", detail.slotNumber, detail.trxSig, err)
+		j.lggr.Errorf("failed to parse program logs at slot %d for tx %s. Skipping tx due to error: %v", blockData.SlotNumber, blockData.TransactionHash, err)
 		j.metrics.IncrementTxsLogParsingError(ctx, txOutcome)
 		return events
 	}
 	for _, outputs := range outputs {
 		for i, event := range outputs.Events {
-			event.SlotNumber = detail.slotNumber
-			event.BlockHeight = detail.blockHeight
-			event.BlockHash = detail.blockHash
-			event.BlockTime = detail.blockTime
-			event.TransactionHash = detail.trxSig
-			event.TransactionIndex = detail.trxIdx
+			event.SlotNumber = blockData.SlotNumber
+			event.BlockHeight = blockData.BlockHeight
+			event.BlockHash = blockData.BlockHash
+			event.BlockTime = blockData.BlockTime
+			event.TransactionHash = blockData.TransactionHash
+			event.TransactionIndex = blockData.TransactionIndex
 			event.TransactionLogIndex = logIdx
-			event.Error = detail.err
+			event.Error = blockData.Error
 
 			logIdx++
 			outputs.Events[i] = event
 		}
 
 		if outputs.Truncated {
-			j.lggr.Warnw("Encountered truncated logs", "program", outputs.Program, "detail", detail)
+			j.lggr.Warnw("Encountered truncated logs", "program", outputs.Program, "blockData", blockData)
 			j.metrics.IncrementTruncatedTxs(ctx, txOutcome)
 		}
 
@@ -211,14 +212,4 @@ func (j *getBlockJob) messagesToEvents(ctx context.Context, messages []string, d
 	}
 
 	return events
-}
-
-type eventDetail struct {
-	slotNumber  uint64
-	blockHeight uint64
-	blockHash   solana.Hash
-	blockTime   solana.UnixTimeSeconds
-	trxIdx      int
-	trxSig      solana.Signature
-	err         interface{}
 }


### PR DESCRIPTION
- We need to be able to call `ExtractCPIEvents` from o11y
- `eventDetail` was private and was preventing us from calling this
- Upon looking more, it seems like `eventDetail` and `BlockData` are basically the same 