### PR TITLE
chore(gauntlet): declare minimum Node.js version

### DIFF
--- a/gauntlet/packages/gauntlet-solana-contracts/package.json
+++ b/gauntlet/packages/gauntlet-solana-contracts/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@chainlink/gauntlet-solana-contracts",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=20"
+  },
   "description": "Gauntlet Solana Contracts",
   "keywords": [
     "typescript",

--- a/gauntlet/packages/gauntlet-solana/package.json
+++ b/gauntlet/packages/gauntlet-solana/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@chainlink/gauntlet-solana",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=20"
+  },
   "description": "Gauntlet Solana",
   "keywords": [
     "typescript",


### PR DESCRIPTION
## Summary
- declare Node.js 20 as the minimum supported runtime for `@chainlink/gauntlet-solana`
- declare the same runtime floor for `@chainlink/gauntlet-solana-contracts`
- align package metadata with the repository's `.tool-versions` and CI runtime

## Verification
- `corepack yarn --cwd ./gauntlet install --frozen-lockfile`
- `corepack yarn --cwd ./gauntlet build`
- `corepack yarn --cwd ./gauntlet lint:format`

Closes #239