### PR TITLE
Dont block on bad event

### DIFF
--- a/pkg/solana/logpoller/log_poller.go
+++ b/pkg/solana/logpoller/log_poller.go
@@ -165,6 +165,12 @@ func makeLogIndex(txIndex int, txLogIndex uint) (int64, error) {
 	return 0, fmt.Errorf("txIndex or txLogIndex out of range: txIndex=%d, txLogIndex=%d", txIndex, txLogIndex)
 }
 
+// errMalformedEvent marks an event whose data is malformed (bad base64, out-of-range
+// log index/slot, or undecodable subkey). Such events are skipped rather than retried,
+// so a single bad event cannot stall ingestion for the whole chain. Infra errors
+// (filter loading, DB inserts) are returned separately and still propagate.
+var errMalformedEvent = errors.New("malformed event data")
+
 // Process - process stream of events coming from log ingester
 func (lp *Service) Process(ctx context.Context, programEvent types.ProgramEvent) (err error) {
 	// This should never happen, since the log collector isn't started until after the filters
@@ -173,39 +179,45 @@ func (lp *Service) Process(ctx context.Context, programEvent types.ProgramEvent)
 		return err
 	}
 
-	blockData := programEvent.BlockData
-
 	matchingFilters := lp.filters.MatchingFiltersForEncodedEvent(programEvent)
 	if matchingFilters == nil {
 		return nil
 	}
 
+	blockData := programEvent.BlockData
+
+	var revertErr *string
+	if blockData.Error != nil {
+		revertErr = new(string)
+		if j, err2 := json.Marshal(blockData.Error); err2 != nil {
+			*revertErr = fmt.Sprintf("%v", blockData.Error)
+			lp.lggr.Errorw("failed to marshal revert error", "revertErr", blockData.Error, "err", err2)
+		} else {
+			*revertErr = string(j)
+		}
+	}
+
+	logIndex, err := makeLogIndex(blockData.TransactionIndex, blockData.TransactionLogIndex)
+	if err != nil {
+		lp.lggr.Errorw("failed to make log index", "err", err, "tx", programEvent.TransactionHash)
+		return fmt.Errorf("%w: %w", errMalformedEvent, err)
+	}
+	if blockData.SlotNumber > math.MaxInt64 {
+		err = fmt.Errorf("slot number %d out of range", blockData.SlotNumber)
+		lp.lggr.Errorw("slot number out of range", "err", err, "tx", programEvent.TransactionHash)
+		return fmt.Errorf("%w: %w", errMalformedEvent, err)
+	}
+
+	programEventData, err := base64.StdEncoding.DecodeString(programEvent.Data)
+	if err != nil {
+		lp.lggr.Errorw("failed to base64-decode event data", "err", err, "tx", programEvent.TransactionHash)
+		return fmt.Errorf("%w: %w", errMalformedEvent, err)
+	}
+
 	var logs []types.Log
 	for filter := range matchingFilters {
-		var revertErr *string
-		if blockData.Error != nil {
-			if !filter.IncludeReverted {
-				continue
-			}
-			revertErr = new(string)
-			if j, err2 := json.Marshal(blockData.Error); err2 != nil {
-				*revertErr = fmt.Sprintf("%v", blockData.Error)
-				lp.lggr.Errorw("failed to marshal revert error", "revertErr", blockData.Error, "err", err2)
-			} else {
-				*revertErr = string(j)
-			}
-		}
-
-		var logIndex int64
-		logIndex, err = makeLogIndex(blockData.TransactionIndex, blockData.TransactionLogIndex)
-		if err != nil {
-			lp.lggr.Criticalw("failed to make log index", "err", err, "tx", programEvent.TransactionHash)
-			return err
-		}
-		if blockData.SlotNumber > math.MaxInt64 {
-			err = fmt.Errorf("slot number %d out of range", blockData.SlotNumber)
-			lp.lggr.Critical(err.Error())
-			return err
+		if blockData.Error != nil && !filter.IncludeReverted {
+			continue
 		}
 
 		log := types.Log{
@@ -219,11 +231,7 @@ func (lp *Service) Process(ctx context.Context, programEvent types.ProgramEvent)
 			EventSig:       filter.EventSig,
 			TxHash:         types.Signature(blockData.TransactionHash),
 			Error:          revertErr,
-		}
-
-		log.Data, err = base64.StdEncoding.DecodeString(programEvent.Data)
-		if err != nil {
-			return err
+			Data:           programEventData,
 		}
 
 		log.SubkeyValues = make([]types.IndexedValue, len(filter.SubkeyPaths))
@@ -499,9 +507,19 @@ func (lp *Service) processBlocksImpl(ctx context.Context, blocks []types.Block) 
 	for _, block := range blocks {
 		for _, event := range block.Events {
 			err := lp.Process(ctx, event)
-			if err != nil {
-				return fmt.Errorf("error processing event for tx %s in block %d: %w", event.TransactionHash, block.SlotNumber, err)
+			if err == nil {
+				continue
 			}
+			if errors.Is(err, errMalformedEvent) {
+				// A single malformed event must not stall ingestion for the whole chain.
+				// Skip it and keep processing; the slot is still marked as processed.
+				lp.lggr.Errorw("skipping malformed event", "tx", event.TransactionHash, "block", block.SlotNumber, "err", err)
+				lp.metrics.IncrementEventsSkipped(ctx)
+				continue
+			}
+			// Infra errors (filter loading, DB insert) are transient: propagate so the
+			// slot is retried rather than silently dropping the event.
+			return fmt.Errorf("error processing event for tx %s in block %d: %w", event.TransactionHash, block.SlotNumber, err)
 		}
 	}
 

--- a/pkg/solana/logpoller/log_poller_test.go
+++ b/pkg/solana/logpoller/log_poller_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math/rand"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1073,6 +1074,52 @@ func TestProcess_skipsBadFilterWithoutBlockingOthers(t *testing.T) {
 	}).Once()
 
 	require.NoError(t, lp.Process(ctx, ev))
+}
+
+func TestProcessBlocksImpl(t *testing.T) {
+	ctx := t.Context()
+
+	malformedEvent := types.ProgramEvent{
+		Program: newRandomPublicKey(t).ToSolana().String(),
+		BlockData: types.BlockData{
+			SlotNumber:       1,
+			TransactionIndex: -1, // out of range -> makeLogIndex fails -> malformed event
+		},
+		Data: "!!!not-base64!!!",
+	}
+
+	t.Run("skips malformed event and continues processing", func(t *testing.T) {
+		lp := newMockedLP(t)
+
+		// Return a matching filter so Process proceeds past filter matching and reaches
+		// the malformed-data checks (makeLogIndex fails on TransactionIndex=-1).
+		matching := slices.Values([]types.Filter{{ID: 1, Name: "f"}})
+		lp.Filters.EXPECT().LoadFilters(mock.Anything).Return(nil).Twice()
+		lp.Filters.EXPECT().MatchingFiltersForEncodedEvent(mock.Anything).Return(matching).Twice()
+
+		blocks := []types.Block{
+			{SlotNumber: 1, Events: []types.ProgramEvent{malformedEvent}},
+			{SlotNumber: 2, Events: []types.ProgramEvent{malformedEvent}},
+		}
+
+		err := lp.LogPoller.processBlocksImpl(ctx, blocks)
+		require.NoError(t, err, "malformed events must be skipped, not stall the chain")
+	})
+
+	t.Run("propagates infra errors for retry", func(t *testing.T) {
+		lp := newMockedLP(t)
+
+		infraErr := errors.New("failed to load filters")
+		lp.Filters.EXPECT().LoadFilters(mock.Anything).Return(infraErr).Once()
+
+		blocks := []types.Block{
+			{SlotNumber: 1, Events: []types.ProgramEvent{malformedEvent}},
+		}
+
+		err := lp.LogPoller.processBlocksImpl(ctx, blocks)
+		require.ErrorIs(t, err, infraErr, "infra errors must propagate so the slot is retried")
+		require.NotErrorIs(t, err, errMalformedEvent)
+	})
 }
 
 func Test_LogPoller_Replay(t *testing.T) {

--- a/pkg/solana/logpoller/metrics.go
+++ b/pkg/solana/logpoller/metrics.go
@@ -34,6 +34,11 @@ var promLpBlocksSkipped = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Number of blocks skipped due to max retry exhaustion",
 }, []string{"chainID"})
 
+var promLpEventsSkipped = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "solana_log_poller_events_skipped",
+	Help: "Number of events skipped due to malformed event data",
+}, []string{"chainID"})
+
 type solLpMetrics struct {
 	metrics.Labeler
 	chainID string
@@ -43,6 +48,7 @@ type solLpMetrics struct {
 	txsLogParsingError outcomeDependantMetric
 	lastProcessedSlot  metric.Int64Gauge
 	blocksSkipped      metric.Int64Counter
+	eventsSkipped      metric.Int64Counter
 }
 
 func NewSolLpMetrics(chainID string) (*solLpMetrics, error) {
@@ -68,6 +74,11 @@ func NewSolLpMetrics(chainID string) (*solLpMetrics, error) {
 		return nil, fmt.Errorf("failed to register solana_log_poller_blocks_skipped: %w", err)
 	}
 
+	eventsSkipped, err := meter.Int64Counter("solana_log_poller_events_skipped")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register solana_log_poller_events_skipped: %w", err)
+	}
+
 	return &solLpMetrics{
 		chainID: chainID,
 		Labeler: metrics.NewLabeler().With("chainID", chainID),
@@ -76,6 +87,7 @@ func NewSolLpMetrics(chainID string) (*solLpMetrics, error) {
 		txsLogParsingError: *txLogParsingError,
 		lastProcessedSlot:  lastProcessedSlot,
 		blocksSkipped:      blocksSkipped,
+		eventsSkipped:      eventsSkipped,
 	}, nil
 }
 
@@ -99,6 +111,11 @@ func (m *solLpMetrics) SetLatestProcessedSlot(ctx context.Context, slot int64) {
 func (m *solLpMetrics) IncrementBlocksSkipped(ctx context.Context) {
 	promLpBlocksSkipped.WithLabelValues(m.chainID).Inc()
 	m.blocksSkipped.Add(ctx, 1, metric.WithAttributes(m.GetOtelAttributes()...))
+}
+
+func (m *solLpMetrics) IncrementEventsSkipped(ctx context.Context) {
+	promLpEventsSkipped.WithLabelValues(m.chainID).Inc()
+	m.eventsSkipped.Add(ctx, 1, metric.WithAttributes(m.GetOtelAttributes()...))
 }
 
 func (m *solLpMetrics) incrementForOutcome(ctx context.Context, prom outcomeDependantProm, me outcomeDependantMetric, outcome txOutcome) {


### PR DESCRIPTION
- Pull out filter agnostic code from the filter loop inside `lp.Process`
   - parsing blockData err
   - makingLogIndex
   - SlotNumber verification
- Catch **bad event err** in `lp.processBlocksImpl` and continue with the rest of the events
   - One bad event should not stall the entire lp
   - Log error and increment `bad_event` counter instead of stalling
- Catch transient infra errors in `lp.processBlocksImpl` and retry slot to prevent valid event from being skipped.