### PR TITLE
Bound Slice and array length in idl codecs

### DIFF
--- a/pkg/solana/codec/common/bounded_size.go
+++ b/pkg/solana/codec/common/bounded_size.go
@@ -48,8 +48,12 @@ func CheckElementCount(count int, element encodings.TypeCodec) error {
 		return fmt.Errorf("%w: element codec must be non-nil", types.ErrInvalidConfig)
 	}
 
-	if limit := maxElementCount(element); count < 0 || count > limit {
+	limit := maxElementCount(element)
+	if count > limit {
 		return fmt.Errorf("%w: element count %d exceeds the maximum of %d for solana data", types.ErrInvalidConfig, count, limit)
+	}
+	if count < 0 {
+		return fmt.Errorf("%w: element count %d cannot be less than zero", types.ErrInvalidConfig, count)
 	}
 
 	return nil

--- a/pkg/solana/codec/common/bounded_size.go
+++ b/pkg/solana/codec/common/bounded_size.go
@@ -99,8 +99,10 @@ func (b *boundedSize) Decode(encoded []byte) (any, []byte, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("%w: %T is not an int indicating the size", types.ErrInternal, value)
 	}
-
-	if count < 0 || count > b.maxCount {
+	if count < 0 {
+		return nil, nil, fmt.Errorf("%w: element count %d cannot be less than zero", types.ErrInvalidConfig, count)
+	}
+	if count > b.maxCount {
 		return nil, nil, fmt.Errorf("%w: element count %d exceeds the maximum of %d for solana data", types.ErrInvalidEncoding, count, b.maxCount)
 	}
 

--- a/pkg/solana/codec/common/bounded_size.go
+++ b/pkg/solana/codec/common/bounded_size.go
@@ -1,0 +1,134 @@
+package commoncodec
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+)
+
+// MaxAccountBytes is the Solana per-account data limit. No legitimate account
+// payload or program event payload can exceed it, so it doubles as an upper
+// bound on the byte footprint of any single decoded vector.
+const MaxAccountBytes = 10 * 1024 * 1024
+
+// minVariableElementBytes is the smallest on-wire footprint of an element whose
+// size is not fixed. Variable-size elements (nested vectors, strings) always
+// carry at least their own 4 byte length prefix.
+const minVariableElementBytes = 4
+
+// maxElementCount returns the largest number of elements of the given type that
+// can fit within MaxAccountBytes.
+//
+// The bound is taken over both the on-wire and the in-memory footprint of an
+// element, whichever is larger. They diverge for elements without a fixed size:
+// a nested vector occupies only a 4 byte length prefix on the wire but a 24 byte
+// slice header in memory, so sizing on the wire footprint alone would allow an
+// allocation several times over MaxAccountBytes.
+func maxElementCount(element encodings.TypeCodec) int {
+	elementBytes := minVariableElementBytes
+	if fixed, err := element.FixedSize(); err == nil && fixed > 0 {
+		elementBytes = fixed
+	}
+
+	if inMemory := int(element.GetType().Size()); inMemory > elementBytes {
+		elementBytes = inMemory
+	}
+
+	return MaxAccountBytes / elementBytes
+}
+
+// CheckElementCount reports whether count elements of the given type fit within
+// MaxAccountBytes. Use it where the count is known at construction time, such as
+// a fixed array length taken from an IDL; slices bound their wire length through
+// NewBoundedSize instead.
+func CheckElementCount(count int, element encodings.TypeCodec) error {
+	if element == nil {
+		return fmt.Errorf("%w: element codec must be non-nil", types.ErrInvalidConfig)
+	}
+
+	if limit := maxElementCount(element); count < 0 || count > limit {
+		return fmt.Errorf("%w: element count %d exceeds the maximum of %d for solana data", types.ErrInvalidConfig, count, limit)
+	}
+
+	return nil
+}
+
+// NewBoundedSize wraps the length-prefix codec of a slice so that an element
+// count whose implied byte footprint exceeds MaxAccountBytes is rejected while
+// decoding the prefix itself.
+//
+// encodings.NewSlice hands the wire length straight to reflect.MakeSlice and
+// validates only that it is non-negative, so a 4 byte prefix would otherwise
+// let a few bytes of untrusted data allocate gigabytes before the decode fails
+// for lack of input. encodings.slice.Decode returns as soon as the size codec
+// errors, which is why the bound belongs here rather than around the slice.
+//
+// The wire format is unchanged: encoding delegates to the wrapped codec.
+func NewBoundedSize(size, element encodings.TypeCodec) (encodings.TypeCodec, error) {
+	if size == nil || element == nil {
+		return nil, fmt.Errorf("%w: size and element codecs must be non-nil", types.ErrInvalidConfig)
+	}
+
+	return &boundedSize{sizeEncoder: size, maxCount: maxElementCount(element)}, nil
+}
+
+type boundedSize struct {
+	sizeEncoder encodings.TypeCodec
+	maxCount    int
+}
+
+var _ encodings.TypeCodec = &boundedSize{}
+
+func (b *boundedSize) Encode(value any, into []byte) ([]byte, error) {
+	return b.sizeEncoder.Encode(value, into)
+}
+
+func (b *boundedSize) Decode(encoded []byte) (any, []byte, error) {
+	value, bytes, err := b.sizeEncoder.Decode(encoded)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	count, ok := value.(int)
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: %T is not an int indicating the size", types.ErrInternal, value)
+	}
+
+	if count < 0 || count > b.maxCount {
+		return nil, nil, fmt.Errorf("%w: element count %d exceeds the maximum of %d for solana data", types.ErrInvalidEncoding, count, b.maxCount)
+	}
+
+	return value, bytes, nil
+}
+
+// GetType must report int, otherwise encodings.NewSlice rejects this as a size codec.
+func (b *boundedSize) GetType() reflect.Type {
+	return b.sizeEncoder.GetType()
+}
+
+func (b *boundedSize) Size(val int) (int, error) {
+	return b.sizeEncoder.Size(val)
+}
+
+// FixedSize must delegate, as encodings.slice.Encode relies on it.
+func (b *boundedSize) FixedSize() (int, error) {
+	return b.sizeEncoder.FixedSize()
+}
+
+// NewBoundedSlice builds a slice codec with a 4 byte Borsh length prefix that is
+// bounded by MaxAccountBytes.
+func NewBoundedSlice(element encodings.TypeCodec, builder encodings.Builder) (encodings.TypeCodec, error) {
+	size, err := builder.Int(4)
+	if err != nil {
+		return nil, err
+	}
+
+	bounded, err := NewBoundedSize(size, element)
+	if err != nil {
+		return nil, err
+	}
+
+	return encodings.NewSlice(element, bounded)
+}

--- a/pkg/solana/codec/common/bounded_size_test.go
+++ b/pkg/solana/codec/common/bounded_size_test.go
@@ -2,7 +2,6 @@ package commoncodec_test
 
 import (
 	"fmt"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,13 +11,6 @@ import (
 
 	commoncodec "github.com/smartcontractkit/chainlink-solana/pkg/solana/codec/common"
 )
-
-func heapAllocMB() uint64 {
-	var stats runtime.MemStats
-	runtime.ReadMemStats(&stats)
-
-	return stats.HeapAlloc >> 20
-}
 
 // oversizedLengthPrefix is a 4 byte Borsh length claiming math.MaxInt32 elements,
 // followed by a single byte of payload.
@@ -54,15 +46,17 @@ func TestNewBoundedSlice_RejectsOversizedLengthWithoutAllocating(t *testing.T) {
 			codec, err := commoncodec.NewBoundedSlice(tt.element, builder)
 			require.NoError(t, err)
 
-			before := heapAllocMB()
 			_, _, err = codec.Decode(oversizedLengthPrefix)
-			after := heapAllocMB()
 
+			// The error identifies which code path ran, so it also establishes that
+			// nothing was allocated. encodings.slice.Decode returns as soon as the
+			// size codec errors, so only the bound can produce this message; an
+			// unbounded codec reaches reflect.MakeSlice first and then fails in
+			// DecodeEach with "not enough bytes to decode type" instead.
 			require.ErrorContains(t, err, "exceeds the maximum")
 			require.ErrorContains(t, err, "2147483647")
 			require.ErrorContains(t, err, fmt.Sprintf("maximum of %d", tt.maxCount))
-			// the wire length must be rejected before reflect.MakeSlice runs
-			require.Less(t, after-before, uint64(16), "decode allocated %d MB", after-before)
+			require.NotContains(t, err.Error(), "not enough bytes")
 
 			// whatever the cap is, admitting that many elements must stay within
 			// MaxAccountBytes of memory, not just of wire bytes

--- a/pkg/solana/codec/common/bounded_size_test.go
+++ b/pkg/solana/codec/common/bounded_size_test.go
@@ -122,6 +122,6 @@ func TestCheckElementCount(t *testing.T) {
 
 	require.ErrorContains(t, commoncodec.CheckElementCount(commoncodec.MaxAccountBytes+1, builder.Uint8()), "exceeds the maximum")
 	require.ErrorContains(t, commoncodec.CheckElementCount(commoncodec.MaxAccountBytes, uint64Codec), "exceeds the maximum")
-	require.ErrorContains(t, commoncodec.CheckElementCount(-1, builder.Uint8()), "exceeds the maximum")
+	require.ErrorContains(t, commoncodec.CheckElementCount(-1, builder.Uint8()), "less than zero")
 	require.ErrorContains(t, commoncodec.CheckElementCount(1, nil), "must be non-nil")
 }

--- a/pkg/solana/codec/common/bounded_size_test.go
+++ b/pkg/solana/codec/common/bounded_size_test.go
@@ -1,0 +1,133 @@
+package commoncodec_test
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings"
+	"github.com/smartcontractkit/chainlink-common/pkg/codec/encodings/binary"
+
+	commoncodec "github.com/smartcontractkit/chainlink-solana/pkg/solana/codec/common"
+)
+
+func heapAllocMB() uint64 {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+
+	return stats.HeapAlloc >> 20
+}
+
+// oversizedLengthPrefix is a 4 byte Borsh length claiming math.MaxInt32 elements,
+// followed by a single byte of payload.
+var oversizedLengthPrefix = []byte{0xFF, 0xFF, 0xFF, 0x7F, 0x01}
+
+func TestNewBoundedSlice_RejectsOversizedLengthWithoutAllocating(t *testing.T) {
+	t.Parallel()
+
+	builder := binary.LittleEndian()
+	uint64Codec, err := builder.Uint(8)
+	require.NoError(t, err)
+	arrayCodec, err := encodings.NewArray(32, builder.Uint8())
+	require.NoError(t, err)
+
+	// a nested vector is only a 4 byte length prefix on the wire but a 24 byte
+	// slice header in memory, so it must be bounded on the in-memory footprint
+	nestedCodec, err := commoncodec.NewBoundedSlice(builder.Uint8(), builder)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name     string
+		element  encodings.TypeCodec
+		maxCount int
+	}{
+		{"vec of u8", builder.Uint8(), commoncodec.MaxAccountBytes},
+		{"vec of u64", uint64Codec, commoncodec.MaxAccountBytes / 8},
+		{"vec of [u8; 32]", arrayCodec, commoncodec.MaxAccountBytes / 32},
+		{"vec of vec of u8", nestedCodec, commoncodec.MaxAccountBytes / 24},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			codec, err := commoncodec.NewBoundedSlice(tt.element, builder)
+			require.NoError(t, err)
+
+			before := heapAllocMB()
+			_, _, err = codec.Decode(oversizedLengthPrefix)
+			after := heapAllocMB()
+
+			require.ErrorContains(t, err, "exceeds the maximum")
+			require.ErrorContains(t, err, "2147483647")
+			require.ErrorContains(t, err, fmt.Sprintf("maximum of %d", tt.maxCount))
+			// the wire length must be rejected before reflect.MakeSlice runs
+			require.Less(t, after-before, uint64(16), "decode allocated %d MB", after-before)
+
+			// whatever the cap is, admitting that many elements must stay within
+			// MaxAccountBytes of memory, not just of wire bytes
+			elementBytes := int(tt.element.GetType().Size())
+			require.LessOrEqual(t, tt.maxCount*elementBytes, commoncodec.MaxAccountBytes,
+				"cap of %d elements of %d bytes exceeds the memory budget", tt.maxCount, elementBytes)
+		})
+	}
+}
+
+func TestNewBoundedSlice_WireFormatUnchanged(t *testing.T) {
+	t.Parallel()
+
+	builder := binary.LittleEndian()
+	value := []byte{1, 2, 3, 4, 5}
+
+	bounded, err := commoncodec.NewBoundedSlice(builder.Uint8(), builder)
+	require.NoError(t, err)
+
+	size, err := builder.Int(4)
+	require.NoError(t, err)
+	unbounded, err := encodings.NewSlice(builder.Uint8(), size)
+	require.NoError(t, err)
+
+	boundedBytes, err := bounded.Encode(value, nil)
+	require.NoError(t, err)
+	unboundedBytes, err := unbounded.Encode(value, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, unboundedBytes, boundedBytes, "bounding the length prefix must not change the wire format")
+	require.Equal(t, []byte{5, 0, 0, 0, 1, 2, 3, 4, 5}, boundedBytes)
+
+	decoded, remaining, err := bounded.Decode(boundedBytes)
+	require.NoError(t, err)
+	require.Equal(t, value, decoded)
+	require.Empty(t, remaining)
+	require.Equal(t, unbounded.GetType(), bounded.GetType())
+}
+
+func TestNewBoundedSlice_AcceptsLengthAtLimit(t *testing.T) {
+	t.Parallel()
+
+	builder := binary.LittleEndian()
+	codec, err := commoncodec.NewBoundedSlice(builder.Uint8(), builder)
+	require.NoError(t, err)
+
+	// a length exactly at the cap must pass the bound and fail only on short input,
+	// proving the guard rejects on size rather than truncating valid payloads
+	atLimit := []byte{0x00, 0x00, 0xA0, 0x00, 0x01}
+	_, _, err = codec.Decode(atLimit)
+	require.ErrorContains(t, err, "not enough bytes")
+}
+
+func TestCheckElementCount(t *testing.T) {
+	t.Parallel()
+
+	builder := binary.LittleEndian()
+	uint64Codec, err := builder.Uint(8)
+	require.NoError(t, err)
+
+	require.NoError(t, commoncodec.CheckElementCount(32, builder.Uint8()))
+	require.NoError(t, commoncodec.CheckElementCount(commoncodec.MaxAccountBytes, builder.Uint8()))
+
+	require.ErrorContains(t, commoncodec.CheckElementCount(commoncodec.MaxAccountBytes+1, builder.Uint8()), "exceeds the maximum")
+	require.ErrorContains(t, commoncodec.CheckElementCount(commoncodec.MaxAccountBytes, uint64Codec), "exceeds the maximum")
+	require.ErrorContains(t, commoncodec.CheckElementCount(-1, builder.Uint8()), "exceeds the maximum")
+	require.ErrorContains(t, commoncodec.CheckElementCount(1, nil), "must be non-nil")
+}

--- a/pkg/solana/codec/v1/solana.go
+++ b/pkg/solana/codec/v1/solana.go
@@ -352,12 +352,7 @@ func asVec(parentTypeName string, idlVec *IdlTypeVec, refs *codecRefs) (commonen
 		return nil, err
 	}
 
-	b, err := refs.builder.Int(4)
-	if err != nil {
-		return nil, err
-	}
-
-	return commonencodings.NewSlice(codec, b)
+	return solcommoncodec.NewBoundedSlice(codec, refs.builder)
 }
 
 func getCodecByStringType(curType IdlTypeAsString, builder commonencodings.Builder) (commonencodings.TypeCodec, error) {
@@ -427,12 +422,7 @@ func getTimeCodecByStringType(curType IdlTypeAsString, builder commonencodings.B
 func getByteCodecByStringType(curType IdlTypeAsString, builder commonencodings.Builder) (commonencodings.TypeCodec, error) {
 	switch curType {
 	case IdlTypeBytes:
-		b, err := builder.Int(4)
-		if err != nil {
-			return nil, err
-		}
-
-		return commonencodings.NewSlice(builder.Uint8(), b)
+		return solcommoncodec.NewBoundedSlice(builder.Uint8(), builder)
 	case IdlTypePublicKey, IdlTypeHash:
 		return commonencodings.NewArray(DefaultHashBitLength, builder.Uint8())
 	default:

--- a/pkg/solana/codec/v2/solana.go
+++ b/pkg/solana/codec/v2/solana.go
@@ -278,11 +278,7 @@ func processFieldType(parentTypeName string, idlType idltype.IdlType, refs *code
 	case *idltype.U128:
 		return refs.builder.BigInt(16, false)
 	case *idltype.Bytes:
-		b, err := refs.builder.Int(4)
-		if err != nil {
-			return nil, err
-		}
-		return commonencodings.NewSlice(refs.builder.Uint8(), b)
+		return solcommoncodec.NewBoundedSlice(refs.builder.Uint8(), refs.builder)
 	case *idltype.Pubkey:
 		return commonencodings.NewArray(DefaultHashBitLength, refs.builder.Uint8())
 	case *idltype.Defined:
@@ -380,6 +376,13 @@ func asArray(parentTypeName string, idlArray *idltype.Array, refs *codecRefs) (c
 		return nil, err
 	}
 
+	// The array length comes straight from the IDL, which is caller supplied on the
+	// log poller path, and encodings.array.Decode materialises the whole array. Bound
+	// it by the Solana account limit so an oversized IDL cannot force a huge allocation.
+	if err = solcommoncodec.CheckElementCount(lenInt, codec); err != nil {
+		return nil, fmt.Errorf("array length defined in IDL type is excessively large: %w", err)
+	}
+
 	return commonencodings.NewArray(lenInt, codec)
 }
 
@@ -389,12 +392,7 @@ func asVec(parentTypeName string, idlVec *idltype.Vec, refs *codecRefs) (commone
 		return nil, err
 	}
 
-	b, err := refs.builder.Int(4)
-	if err != nil {
-		return nil, err
-	}
-
-	return commonencodings.NewSlice(codec, b)
+	return solcommoncodec.NewBoundedSlice(codec, refs.builder)
 }
 
 func validDependency(refs *codecRefs, parent, child string) bool {

--- a/pkg/solana/codec/v2/solana.go
+++ b/pkg/solana/codec/v2/solana.go
@@ -380,7 +380,7 @@ func asArray(parentTypeName string, idlArray *idltype.Array, refs *codecRefs) (c
 	// log poller path, and encodings.array.Decode materialises the whole array. Bound
 	// it by the Solana account limit so an oversized IDL cannot force a huge allocation.
 	if err = solcommoncodec.CheckElementCount(lenInt, codec); err != nil {
-		return nil, fmt.Errorf("array length defined in IDL type is excessively large: %w", err)
+		return nil, err
 	}
 
 	return commonencodings.NewArray(lenInt, codec)

--- a/pkg/solana/logpoller/filters_oversized_test.go
+++ b/pkg/solana/logpoller/filters_oversized_test.go
@@ -2,7 +2,6 @@ package logpoller
 
 import (
 	"bytes"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -61,16 +60,15 @@ func TestFilters_DecodeSubKey_RejectsOversizedVec(t *testing.T) {
 				EventName:   "TestItem",
 			}))
 
-			var before, after runtime.MemStats
-			runtime.ReadMemStats(&before)
 			_, err := fs.DecodeSubKey(t.Context(), lggr, oversizedTestItemEvent(t), tt.id, []string{"Field"})
-			runtime.ReadMemStats(&after)
 
+			// The error identifies which code path ran, so it also establishes that the
+			// 64 GiB was never allocated: the bound rejects while decoding the length
+			// prefix, whereas an unbounded codec reaches reflect.MakeSlice first and
+			// only then fails with "not enough bytes to decode type".
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "exceeds the maximum")
-
-			allocatedMB := (after.HeapAlloc - before.HeapAlloc) >> 20
-			require.Less(t, allocatedMB, uint64(16), "decode allocated %d MB", allocatedMB)
+			require.NotContains(t, err.Error(), "not enough bytes")
 		})
 	}
 }

--- a/pkg/solana/logpoller/filters_oversized_test.go
+++ b/pkg/solana/logpoller/filters_oversized_test.go
@@ -1,0 +1,76 @@
+package logpoller
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	solcommoncodec "github.com/smartcontractkit/chainlink-solana/pkg/solana/codec/common"
+	codecv1 "github.com/smartcontractkit/chainlink-solana/pkg/solana/codec/v1"
+	codecv2 "github.com/smartcontractkit/chainlink-solana/pkg/solana/codec/v2"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller/mocks"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller/types"
+)
+
+// oversizedTestItemEvent builds a TestItem payload whose Accounts field, a
+// vec of publicKey, claims math.MaxInt32 elements. Left unbounded, the 32 byte
+// element size turns those four bytes into a 64 GiB allocation.
+func oversizedTestItemEvent(t *testing.T) []byte {
+	t.Helper()
+
+	buf := new(bytes.Buffer)
+	buf.Write(solcommoncodec.NewDiscriminatorHashPrefix("TestItem", false))
+	buf.Write(make([]byte, 4))  // Field i32
+	buf.Write(make([]byte, 1))  // OracleId u8
+	buf.Write(make([]byte, 32)) // OracleIds [u8; 32]
+	buf.Write(make([]byte, 64)) // AccountStruct, two publicKeys
+	// Accounts: little endian length prefix claiming math.MaxInt32 entries
+	buf.Write([]byte{0xFF, 0xFF, 0xFF, 0x7F})
+
+	return buf.Bytes()
+}
+
+// TestFilters_DecodeSubKey_RejectsOversizedVec covers the log poller ingestion
+// path reached from solanaService.RegisterLogTracking, where the IDL is supplied
+// by the caller and event data comes straight off chain.
+func TestFilters_DecodeSubKey_RejectsOversizedVec(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		idl  string
+		id   int64
+	}{
+		{"codec v1", codecv1.FetchLogpollerTypeTestIDL(), 1},
+		{"codec v2", codecv2.FetchLogpollerTypeTestIDL(), 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			lggr := logger.Sugared(logger.Test(t))
+			orm := mocks.NewMockORM(t)
+			fs := newFilters(lggr, orm, nil)
+			orm.On("SelectFilters", mock.Anything).Return(nil, nil).Once()
+			orm.On("SelectSeqNums", mock.Anything).Return(map[int64]int64{}, nil).Once()
+			orm.On("InsertFilter", mock.Anything, mock.Anything).Return(tt.id, nil).Once()
+
+			require.NoError(t, fs.RegisterFilter(t.Context(), types.Filter{
+				Name:        tt.name,
+				ContractIdl: tt.idl,
+				EventName:   "TestItem",
+			}))
+
+			var before, after runtime.MemStats
+			runtime.ReadMemStats(&before)
+			_, err := fs.DecodeSubKey(t.Context(), lggr, oversizedTestItemEvent(t), tt.id, []string{"Field"})
+			runtime.ReadMemStats(&after)
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "exceeds the maximum")
+
+			allocatedMB := (after.HeapAlloc - before.HeapAlloc) >> 20
+			require.Less(t, allocatedMB, uint64(16), "decode allocated %d MB", allocatedMB)
+		})
+	}
+}


### PR DESCRIPTION
### Description

The IDL codecs build every vec and bytes field as encodings.NewSlice(codec, builder.Int(4)). The upstream slice decoder reads that 4-byte count and passes it straight to reflect.MakeSlice, checking only that it is non-negative — so it allocates for the declared count before discovering the data isn't there. A few bytes of untrusted input allocate 2 GB for vec<u8>, up to 64 GB for vec<publicKey>.

Adds commoncodec.NewBoundedSlice, which wraps the length-prefix codec so a count whose implied footprint exceeds the 10 MiB Solana account limit is rejected while decoding the prefix, before MakeSlice runs. The bound uses the larger of the element's on-wire and in-memory size — a nested vec is 4 bytes on the wire but a 24-byte slice header in memory.

Wire format is unchanged and asserted byte-identical against the unbounded codec. The cap equals the whole account limit, so legitimate data — which must be smaller than its containing account or log — is never rejected.


### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
