### PR TITLE
skip v1 transaction from blocks for LogPoller (#1630)

### DIFF
--- a/.github/actions/build_contract_artifacts/action.yml
+++ b/.github/actions/build_contract_artifacts/action.yml
@@ -58,7 +58,9 @@ runs:
         docker run -d -v $(pwd):/repo --name build-container chainlink-solana:build tail -f /dev/null
         # generate go bindings
         docker exec build-container bash -c "/repo/scripts/build-contract-artifacts-action.sh"
-        # check go bindings
+        # check go bindings; print the full diff first so a failure shows what drifted
+        # rather than only a file/line count
+        git diff || true
         git diff --stat --exit-code
         # build with keys
         docker exec build-container bash -c "\

--- a/pkg/solana/client/client.go
+++ b/pkg/solana/client/client.go
@@ -30,6 +30,19 @@ const (
 // If the requested block contains a transaction with a higher version, an error will be returned.
 const MaxSupportTransactionVersion = uint64(0) // (legacy + v0)
 
+// MaxRequestedTransactionVersion is the max transaction version the log poller asks getBlock
+// for. It is deliberately higher than MaxSupportTransactionVersion because the RPC applies
+// the limit to the whole call: a single newer transaction makes getBlock fail with -32015
+// rather than omitting that transaction, which stalls the poller on that slot until the job
+// exhausts its retries. Requesting a higher version returns the block in full; transactions
+// this repo cannot decode are then skipped individually.
+//
+// This is a stopgap. The vendored solana-go only understands legacy and v0 messages: its
+// Message.UnmarshalWithDecoder routes anything with the version bit set to UnmarshalV0, so a
+// newer transaction would be parsed with the v0 layout rather than rejected. Until that gains
+// real support, decoding stays capped at MaxSupportTransactionVersion.
+const MaxRequestedTransactionVersion = uint64(1)
+
 // HeadMetadataGetBlockOpts returns options for getBlock that omit transaction bodies and rewards,
 // leaving only metadata (e.g. blockhash, block height, block time) for head reporting.
 func HeadMetadataGetBlockOpts(commitment rpc.CommitmentType) *rpc.GetBlockOpts {

--- a/pkg/solana/logpoller/job_get_block.go
+++ b/pkg/solana/logpoller/job_get_block.go
@@ -15,6 +15,18 @@ import (
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller/types"
 )
 
+// isDecodableTransactionVersion reports whether this client can decode a transaction of the
+// given version. rpc.TransactionVersion is -1 for legacy and the version number otherwise,
+// so anything at or below MaxSupportTransactionVersion is safe.
+//
+// The check is needed because solana-go does not reject newer versions: its
+// Message.UnmarshalWithDecoder routes any message with the version bit set to UnmarshalV0,
+// which would parse a newer transaction with the v0 layout and yield garbage rather than an
+// error. Skipping is the conservative choice until solana-go gains real support.
+func isDecodableTransactionVersion(version rpc.TransactionVersion) bool {
+	return version <= rpc.TransactionVersion(client.MaxSupportTransactionVersion)
+}
+
 // getBlockJob is a job that fetches a block with transactions, converts logs into ProgramEvents and writes them into blocks channel
 type getBlockJob struct {
 	slotNumber        uint64
@@ -74,7 +86,9 @@ func (j *getBlockJob) Run(ctx context.Context) error {
 		return ctx.Err()
 	}
 	var excludeRewards bool
-	version := client.MaxSupportTransactionVersion
+	// request above what we can decode so one newer transaction does not fail the whole
+	// block; undecodable transactions are skipped below. See MaxRequestedTransactionVersion.
+	version := client.MaxRequestedTransactionVersion
 	block, err := j.client.GetBlockWithOpts(
 		ctx,
 		j.slotNumber,
@@ -132,6 +146,16 @@ func (j *getBlockJob) Run(ctx context.Context) error {
 		blockData.TransactionIndex = idx
 		if txWithMeta.Transaction == nil {
 			return fmt.Errorf("failed to parse transaction %d in slot %d: %w", idx, j.slotNumber, errors.New("missing transaction field"))
+		}
+		// Skip transactions newer than we can decode. solana-go would parse them with the
+		// v0 layout instead of failing, so this must happen before GetTransaction.
+		// NOTE: events in skipped transactions are not indexed.
+		if !isDecodableTransactionVersion(txWithMeta.Version) {
+			j.lggr.Errorw("skipping transaction with an unsupported version; its events will not be indexed",
+				"version", int(txWithMeta.Version), "maxDecodableVersion", client.MaxSupportTransactionVersion,
+				"slot", j.slotNumber, "txIndex", idx)
+			j.metrics.IncrementTxsUnsupportedVersion(ctx)
+			continue
 		}
 		tx, err := txWithMeta.GetTransaction()
 		if err != nil {

--- a/pkg/solana/logpoller/job_get_block_version_test.go
+++ b/pkg/solana/logpoller/job_get_block_version_test.go
@@ -1,0 +1,127 @@
+package logpoller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller/mocks"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller/types"
+)
+
+func TestIsDecodableTransactionVersion(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isDecodableTransactionVersion(rpc.LegacyTransactionVersion), "legacy must be decodable")
+	require.True(t, isDecodableTransactionVersion(rpc.TransactionVersion(0)), "v0 must be decodable")
+	require.False(t, isDecodableTransactionVersion(rpc.TransactionVersion(1)), "v1 is not decodable by solana-go")
+	require.False(t, isDecodableTransactionVersion(rpc.TransactionVersion(2)))
+}
+
+// getBlock must be asked for a version above what we can decode, otherwise the RPC fails the
+// whole call with -32015 when a block contains a newer transaction.
+func TestGetBlockJob_RequestsVersionAboveDecodable(t *testing.T) {
+	require.Greater(t, client.MaxRequestedTransactionVersion, client.MaxSupportTransactionVersion,
+		"requested version must exceed the decodable one or a single newer tx stalls the whole slot")
+
+	rpcClient := mocks.NewRPCClient(t)
+	lggr := logger.Sugared(logger.Test(t))
+
+	var gotVersion *uint64
+	rpcClient.EXPECT().GetBlockWithOpts(mock.Anything, uint64(42), mock.Anything).
+		RunAndReturn(func(_ context.Context, _ uint64, opts *rpc.GetBlockOpts) (*rpc.GetBlockResult, error) {
+			gotVersion = opts.MaxSupportedTransactionVersion
+			return &rpc.GetBlockResult{
+				BlockHeight: ptr(uint64(10)),
+				BlockTime:   ptr(solana.UnixTimeSeconds(10)),
+			}, nil
+		}).Once()
+
+	metrics, err := NewSolLpMetrics(t.Name())
+	require.NoError(t, err)
+	job := newGetBlockJob(nil, rpcClient, make(chan types.Block, 1), lggr, 42, metrics, nil)
+	require.NoError(t, job.Run(t.Context()))
+
+	require.NotNil(t, gotVersion)
+	require.Equal(t, client.MaxRequestedTransactionVersion, *gotVersion)
+}
+
+// A transaction whose version we cannot decode must be skipped rather than parsed with the v0
+// layout, and must not stall the rest of the block.
+func TestGetBlockJob_SkipsUndecodableTransactionVersion(t *testing.T) {
+	const slotNumber = uint64(42)
+	promLpTxsUnsupportedVersion.DeleteLabelValues(t.Name())
+
+	rpcClient := mocks.NewRPCClient(t)
+	lggr := logger.Sugared(logger.Test(t))
+
+	txBytes := func(sig solana.Signature) *rpc.DataBytesOrJSON {
+		tx := solana.Transaction{Signatures: []solana.Signature{sig}}
+		bts, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		return rpc.DataBytesOrJSONFromBytes(bts)
+	}
+
+	legacyTx := rpc.TransactionWithMeta{
+		Version:     rpc.LegacyTransactionVersion,
+		Transaction: txBytes(solana.Signature{1}),
+		Meta:        &rpc.TransactionMeta{LogMessages: []string{"legacy-log"}},
+	}
+	// undecodable: sits between the two decodable transactions to prove it is skipped
+	// individually rather than aborting the block
+	v1Tx := rpc.TransactionWithMeta{
+		Version:     rpc.TransactionVersion(1),
+		Transaction: txBytes(solana.Signature{2}),
+		Meta:        &rpc.TransactionMeta{LogMessages: []string{"v1-log"}},
+	}
+	v0Tx := rpc.TransactionWithMeta{
+		Version:     rpc.TransactionVersion(0),
+		Transaction: txBytes(solana.Signature{3}),
+		Meta:        &rpc.TransactionMeta{LogMessages: []string{"v0-log"}},
+	}
+
+	block := rpc.GetBlockResult{
+		BlockHeight:  ptr(uint64(41)),
+		BlockTime:    ptr(solana.UnixTimeSeconds(128)),
+		Blockhash:    solana.Hash{1, 2, 3},
+		Transactions: []rpc.TransactionWithMeta{legacyTx, v1Tx, v0Tx},
+	}
+	rpcClient.EXPECT().GetBlockWithOpts(mock.Anything, slotNumber, mock.Anything).Return(&block, nil).Once()
+
+	metrics, err := NewSolLpMetrics(t.Name())
+	require.NoError(t, err)
+	job := newGetBlockJob(nil, rpcClient, make(chan types.Block, 1), lggr, slotNumber, metrics, nil)
+	job.parseProgramLogs = func(logs []string) ([]types.ProgramOutput, error) {
+		out := types.ProgramOutput{Program: "myProgram"}
+		for _, l := range logs {
+			out.Events = append(out.Events, types.ProgramEvent{Data: l, Program: "myProgram"})
+		}
+		return []types.ProgramOutput{out}, nil
+	}
+
+	require.NoError(t, job.Run(t.Context()), "an undecodable transaction must not fail the block")
+
+	result := <-job.blocks
+	data := make([]string, 0, len(result.Events))
+	txIndexes := make([]int, 0, len(result.Events))
+	for _, e := range result.Events {
+		data = append(data, e.Data)
+		txIndexes = append(txIndexes, e.TransactionIndex)
+	}
+
+	require.Equal(t, []string{"legacy-log", "v0-log"}, data, "only decodable transactions should yield events")
+	// index 1 is absent and index 2 keeps its position: skipping must not renumber
+	// transactions, which would duplicate or misattribute events
+	require.Equal(t, []int{0, 2}, txIndexes)
+
+	require.InDelta(t, 1.0, testutil.ToFloat64(promLpTxsUnsupportedVersion.WithLabelValues(t.Name())), 0.0001,
+		"skipped transaction should be counted")
+}

--- a/pkg/solana/logpoller/metrics.go
+++ b/pkg/solana/logpoller/metrics.go
@@ -34,6 +34,16 @@ var promLpBlocksSkipped = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Number of blocks skipped due to max retry exhaustion",
 }, []string{"chainID"})
 
+var promLpEventsSkipped = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "solana_log_poller_events_skipped",
+	Help: "Number of events skipped due to malformed event data",
+}, []string{"chainID"})
+
+var promLpTxsUnsupportedVersion = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "solana_log_poller_txs_unsupported_version",
+	Help: "Number of transactions skipped because their version cannot be decoded. Events in these transactions are not indexed",
+}, []string{"chainID"})
+
 type solLpMetrics struct {
 	metrics.Labeler
 	chainID string
@@ -43,6 +53,8 @@ type solLpMetrics struct {
 	txsLogParsingError outcomeDependantMetric
 	lastProcessedSlot  metric.Int64Gauge
 	blocksSkipped      metric.Int64Counter
+	eventsSkipped      metric.Int64Counter
+	txsUnsupportedVer  metric.Int64Counter
 }
 
 func NewSolLpMetrics(chainID string) (*solLpMetrics, error) {
@@ -68,6 +80,16 @@ func NewSolLpMetrics(chainID string) (*solLpMetrics, error) {
 		return nil, fmt.Errorf("failed to register solana_log_poller_blocks_skipped: %w", err)
 	}
 
+	eventsSkipped, err := meter.Int64Counter("solana_log_poller_events_skipped")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register solana_log_poller_events_skipped: %w", err)
+	}
+
+	txsUnsupportedVer, err := meter.Int64Counter("solana_log_poller_txs_unsupported_version")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register solana_log_poller_txs_unsupported_version: %w", err)
+	}
+
 	return &solLpMetrics{
 		chainID: chainID,
 		Labeler: metrics.NewLabeler().With("chainID", chainID),
@@ -76,6 +98,8 @@ func NewSolLpMetrics(chainID string) (*solLpMetrics, error) {
 		txsLogParsingError: *txLogParsingError,
 		lastProcessedSlot:  lastProcessedSlot,
 		blocksSkipped:      blocksSkipped,
+		eventsSkipped:      eventsSkipped,
+		txsUnsupportedVer:  txsUnsupportedVer,
 	}, nil
 }
 
@@ -99,6 +123,18 @@ func (m *solLpMetrics) SetLatestProcessedSlot(ctx context.Context, slot int64) {
 func (m *solLpMetrics) IncrementBlocksSkipped(ctx context.Context) {
 	promLpBlocksSkipped.WithLabelValues(m.chainID).Inc()
 	m.blocksSkipped.Add(ctx, 1, metric.WithAttributes(m.GetOtelAttributes()...))
+}
+
+func (m *solLpMetrics) IncrementEventsSkipped(ctx context.Context) {
+	promLpEventsSkipped.WithLabelValues(m.chainID).Inc()
+	m.eventsSkipped.Add(ctx, 1, metric.WithAttributes(m.GetOtelAttributes()...))
+}
+
+// IncrementTxsUnsupportedVersion counts transactions dropped because their version is
+// newer than this client can decode. Any events they contain are not indexed.
+func (m *solLpMetrics) IncrementTxsUnsupportedVersion(ctx context.Context) {
+	promLpTxsUnsupportedVersion.WithLabelValues(m.chainID).Inc()
+	m.txsUnsupportedVer.Add(ctx, 1, metric.WithAttributes(m.GetOtelAttributes()...))
 }
 
 func (m *solLpMetrics) incrementForOutcome(ctx context.Context, prom outcomeDependantProm, me outcomeDependantMetric, outcome txOutcome) {


### PR DESCRIPTION
* skip v1 transaction from blocks for LogPoller

* make linter happy

* fix CI

* fix custom build action

* fix ci output missmatch

### Description

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
